### PR TITLE
DM-84 - produce prototype of more efficient compression calculation

### DIFF
--- a/src/common/data-modeler-service/ModelActions.ts
+++ b/src/common/data-modeler-service/ModelActions.ts
@@ -50,8 +50,6 @@ export class ModelActions extends DataModelerActions {
     public async exportToParquet(currentState: DataModelerState, modelId: string, exportFile: string): Promise<void> {
         const model = currentState.models.find(findModel => findModel.id === modelId);
         const exportPath = await this.databaseService.dispatch("exportToParquet", [model.sanitizedQuery, exportFile]);
-        await this.dataModelerStateService.dispatch("updateModelDestinationSize",
-          [modelId, await this.databaseService.dispatch("getDestinationSize", [exportPath])]);
         this.notificationService.notify({ message: `exported ${exportPath}`, type: "info"})
     }
 
@@ -111,7 +109,7 @@ export class ModelActions extends DataModelerActions {
             async () => this.dataModelerStateService.dispatch("updateModelCardinality", [model.id,
                 await this.databaseService.dispatch("getCardinalityOfTable", [model.tableName])]),
             async () => this.dataModelerStateService.dispatch("updateModelDestinationSize", [model.id,
-                await this.databaseService.dispatch("getDestinationSize", [model.tableName])]),
+                await this.databaseService.dispatch("getDestinationSize", [model, profileColumns])]),
         ].map(asyncFunc => asyncFunc()));
     }
 }

--- a/src/common/data-modeler-service/TableActions.ts
+++ b/src/common/data-modeler-service/TableActions.ts
@@ -141,7 +141,7 @@ export class TableActions extends DataModelerActions {
                     .filter(row => row.name !== "duckdb_schema" && row.name !== "schema" && row.name !== "root");
             },
             async () => newTable.sizeInBytes =
-                await this.databaseService.dispatch("getDestinationSize", [table.path]),
+                await this.databaseService.dispatch("getDestinationSize", [table, newTable.profile]),
             async () => newTable.cardinality =
                 await this.databaseService.dispatch("getCardinalityOfTable", [table.tableName]),
             async () => newTable.head =

--- a/src/common/database-service/DatabaseDataLoaderActions.ts
+++ b/src/common/database-service/DatabaseDataLoaderActions.ts
@@ -1,6 +1,6 @@
-import {DatabaseActions} from "./DatabaseActions";
+import { DatabaseActions } from "./DatabaseActions";
 import { existsSync, mkdirSync } from "fs";
-import type {DatabaseMetadata} from "$common/database-service/DatabaseMetadata";
+import type { DatabaseMetadata } from "$common/database-service/DatabaseMetadata";
 
 /**
  * Abstraction around loading data into duck db.
@@ -16,16 +16,7 @@ export class DatabaseDataLoaderActions extends DatabaseActions {
                                tableName: string, delimiter: string): Promise<void> {
         await this.databaseClient.execute(`DROP TABLE IF EXISTS ${tableName};`);
         return await this.databaseClient.execute(`CREATE TABLE ${tableName} AS SELECT * FROM ` +
-            `read_csv_auto('${csvFile}', header=true ${delimiter ? `,delim='${delimiter}'`: ""});`);
-    }
-
-    public async getDestinationSize(metadata: DatabaseMetadata, path: string): Promise<number> {
-        // Being worked on to handle this in a better way.
-        // if (existsSync(path)) {
-        //     const size = await this.databaseClient.all(`SELECT total_compressed_size from parquet_metadata('${path}')`) as any[];
-        //     return size.reduce((acc: number, v: Record<string, any>) => acc + v.total_compressed_size, 0);
-        // }
-        return undefined;
+            `read_csv_auto('${csvFile}', header=true ${delimiter ? `,delim='${delimiter}'` : ""});`);
     }
 
     public async exportToParquet(metadata: DatabaseMetadata, query: string, exportFile: string): Promise<any> {

--- a/src/common/database-service/DatabaseTableActions.ts
+++ b/src/common/database-service/DatabaseTableActions.ts
@@ -1,6 +1,9 @@
-import {DatabaseActions} from "./DatabaseActions";
-import {guidGenerator} from "$lib/util/guid";
-import type {DatabaseMetadata} from "$common/database-service/DatabaseMetadata";
+import { DatabaseActions } from "./DatabaseActions";
+import { guidGenerator } from "$lib/util/guid";
+import type { DatabaseMetadata } from "$common/database-service/DatabaseMetadata";
+import type { ProfileColumn } from "$lib/types";
+import { CATEGORICALS } from "$lib/duckdb-data-types"
+import type { Table } from "$lib/components/table";
 
 export class DatabaseTableActions extends DatabaseActions {
     public async createViewOfQuery(metadata: DatabaseMetadata, tableName: string, query: string): Promise<any> {
@@ -20,6 +23,52 @@ export class DatabaseTableActions extends DatabaseActions {
     public async getCardinalityOfTable(metadata: DatabaseMetadata, tableName: string): Promise<number> {
         const [cardinality] = await this.databaseClient.execute(`select count(*) as count FROM '${tableName}';`);
         return cardinality.count;
+    }
+
+    /**
+     * Estimate size (in bytes) of output table.
+     *
+     * @param {DatabaseMetadata} metadata - DB metadata.
+     * @param {Table} table - Table metadata.
+     * @param {Array<ProfileColumn>} - Column metadata from profiler.
+     * @returns Estimated size of output table, in bytes.
+     */
+    public async getDestinationSize(metadata: DatabaseMetadata, table: Table, profileColumns: Array<ProfileColumn>): Promise<number> {
+        const args = [];
+        const sizes = [];
+
+        for (const column of profileColumns) {
+            if (CATEGORICALS.has(column.type)) {
+                // If this is a categorical type such as VARCHAR, we will need to query to get a good estimate.
+                args.push(`sum(bit_length(${column.name}))`);
+            } else {
+                // Otherwise, use the column type and row count (removing any nulls).
+
+                // FIXME provide sizes for various types e.g. https://duckdb.org/docs/sql/data_types/numeric
+                // FIXME this could probably go into `duckdb-data-types`
+                enum SIZES {
+                    TINYINT = 1, SMALLINT = 1, INTEGER = 1, BIGINT = 1, HUGEINT = 1, UTINYINT = 1,
+                    USMALLINT = 1, UINTEGER = 1, UBIGINT = 1, INT16 = 2, INT32 = 4, INT64 = 8, INT128 = 16,
+                    REAL = 4, DOUBLE = 8,
+                    TIMESTAMP = 32
+                };
+                const profile = table.profile.find((a: { name: string; }) => a.name === column.name);
+                let nullCount = 0;
+                if (profile && profile.nullCount) {
+                    nullCount = profile.nullCount;
+                }
+                sizes.push(SIZES[column.type] * (table.cardinality - nullCount));
+            }
+        }
+
+        if (args.length > 0) {
+            const [result] = await this.databaseClient.execute(`SELECT ${args} from ${table.tableName} USING SAMPLE 10000`);
+            sizes.push(...Object.values(result));
+        }
+        const sum = sizes.reduce((a, b) => a + b, 0);
+
+        // Return size in bytes.
+        return sum / 8;
     }
 
     public async getProfileColumns(metadata: DatabaseMetadata, tableName: string): Promise<any[]> {


### PR DESCRIPTION
This aligns with the proposal in DM-86.

NOTE: if we go this direction, then we need to make sure we have access to all of the sizes for the various data types provided by DuckDB, as noted by FIXME comments in the source.

This prototype only has a handful, so we can test with the `nyc311` dataset.