### PR TITLE
DM-257 adds shift+click functionality to tables

### DIFF
--- a/src/lib/components/column-profile/CollapsibleTableSummary.svelte
+++ b/src/lib/components/column-profile/CollapsibleTableSummary.svelte
@@ -29,7 +29,7 @@ import TooltipTitle from "$lib/components/tooltip/TooltipTitle.svelte";
 
 import { dropStore } from '$lib/drop-store';
 
-import { defaultSort, sortByNullity, sortByCardinality, sortByName } from "$lib/components/column-profile/sort-utils"
+import { defaultSort, sortByNullity, sortByName } from "$lib/components/column-profile/sort-utils"
 import notificationStore from "$lib/components/notifications/";
 
 import { onClickOutside } from "$lib/util/on-click-outside";
@@ -184,7 +184,6 @@ let titleElementHovered = false;
         <!-- note: the classes in this span are also used for UI tests. -->
         <span
             class='collapsible-table-summary-title w-full'
-            style:outline="1px solid black"
             class:is-active={emphasizeTitle}
             class:font-bold={emphasizeTitle} 
             class:italic={selectingColumns}

--- a/src/lib/components/column-profile/CollapsibleTableSummary.svelte
+++ b/src/lib/components/column-profile/CollapsibleTableSummary.svelte
@@ -22,7 +22,6 @@ import NavEntry from "$lib/components/column-profile/NavEntry.svelte";
 import MoreIcon from "$lib/components/icons/MoreHorizontal.svelte";
 
 import Shortcut from "$lib/components/tooltip/Shortcut.svelte";
-import transientBooleanStore from "$lib/util/transient-boolean-store";
 import StackingWord from "$lib/components/tooltip/StackingWord.svelte";
 import TooltipShortcutContainer from "$lib/components/tooltip/TooltipShortcutContainer.svelte";
 import TooltipTitle from "$lib/components/tooltip/TooltipTitle.svelte";
@@ -58,7 +57,6 @@ let contextMenu;
 let contextMenuOpen = false;
 let container;
 
-let clicked = transientBooleanStore();
 
 onMount(() => {
     const observer = new ResizeObserver(entries => {
@@ -142,14 +140,12 @@ let titleElementHovered = false;
         expanded={show}
         selected={emphasizeTitle}
         bind:hovered={titleElementHovered}
+        on:shift-click={async () => {
+            await navigator.clipboard.writeText(name);
+            notificationStore.send({ message: `copied "${name}" to clipboard`});
+        }}
         on:select-body={async (event) => { 
-                if (event.detail) {
-                    await navigator.clipboard.writeText(name);
-                    notificationStore.send({ message: `copied "${name}" to clipboard`});
-                    clicked.flip();
-                } else {
-                    dispatch('select');
-                }
+            dispatch('select');
         }}
         on:expand={() => {
             show = !show;
@@ -174,7 +170,7 @@ let titleElementHovered = false;
                     click
                 </Shortcut>
                 <div>
-                    <StackingWord active={$clicked}>copy</StackingWord> to clipboard
+                    <StackingWord>copy</StackingWord> to clipboard
                 </div>
                 <Shortcut>
                     shift + click

--- a/src/lib/components/column-profile/ColumnEntry.svelte
+++ b/src/lib/components/column-profile/ColumnEntry.svelte
@@ -1,7 +1,9 @@
 <script>
 import { createEventDispatcher } from "svelte";
+import { createShiftClickAction } from "$lib/util/shift-click-action"
 
 const dispatch = createEventDispatcher();
+const { shiftClickAction } = createShiftClickAction();
 
 export let active = false;
 export let emphasize = false;
@@ -26,9 +28,9 @@ export let right = 4 // pr-2";
         focus:outline-gray-300 flex-1
         justify-between w-full"
     class:bg-gray-50={active}
-    on:click={(event) => {
-        dispatch('select', event.shiftKey);
-    }}
+    use:shiftClickAction
+    on:shift-click
+    on:click={(event) => { dispatch('select'); }}
 >
     <div class="flex gap-2 grow items-baseline flex-1" style:min-width="0px">
         <div class="self-center flex items-center">

--- a/src/lib/components/column-profile/ColumnProfile.svelte
+++ b/src/lib/components/column-profile/ColumnProfile.svelte
@@ -22,7 +22,7 @@ import TimestampHistogram from "$lib/components/viz/histogram/TimestampHistogram
 import NumericHistogram from "$lib/components/viz/histogram/NumericHistogram.svelte";
 import notificationStore from "$lib/components/notifications/";
 import transientBooleanStore from "$lib/util/transient-boolean-store";
-import DataTypeTitle from "../tooltip/DataTypeTitle.svelte";
+import TooltipTitle from "$lib/components/tooltip/TooltipTitle.svelte";
 
 export let name;
 export let type;
@@ -92,7 +92,15 @@ let shiftClicked = transientBooleanStore();
             </div>
         <TooltipContent slot="tooltip-content">
 
-            <DataTypeTitle {name} {type} />
+            <TooltipTitle>
+                <svelte:fragment slot="name">
+                    {name}
+                </svelte:fragment>
+                <svelte:fragment slot="description">
+                        {type}
+                </svelte:fragment>
+            </TooltipTitle>
+
 
             {#if totalRows}
                 <TooltipShortcutContainer>

--- a/src/lib/components/column-profile/ColumnProfile.svelte
+++ b/src/lib/components/column-profile/ColumnProfile.svelte
@@ -21,7 +21,6 @@ import Histogram from "$lib/components/viz/histogram/SmallHistogram.svelte";
 import TimestampHistogram from "$lib/components/viz/histogram/TimestampHistogram.svelte";
 import NumericHistogram from "$lib/components/viz/histogram/NumericHistogram.svelte";
 import notificationStore from "$lib/components/notifications/";
-import transientBooleanStore from "$lib/util/transient-boolean-store";
 import TooltipTitle from "$lib/components/tooltip/TooltipTitle.svelte";
 
 export let name;
@@ -51,7 +50,6 @@ $: cardinalityFormatter = containerWidth > config.compactBreakpoint ? formatInte
 
 let titleTooltip;
 
-let shiftClicked = transientBooleanStore();
 </script>
 
     <!-- pl-10 -->
@@ -60,17 +58,13 @@ let shiftClicked = transientBooleanStore();
     {hideRight}
     {active}
     emphasize={active}
+    on:shift-click={async () => {
+        await navigator.clipboard.writeText(name);
+        notificationStore.send({ message: `copied column name "${name}" to clipboard`});
+    }}
     on:select={async (event) => {
         // we should only allow activation when there are rows present.
-        if (event.detail) {
-            await navigator.clipboard.writeText(name);
-
-            notificationStore.send({ message: `copied column name "${name}" to clipboard`});
-            
-            // update this to set the active animation in the tooltip text
-            shiftClicked.flip();
-
-        } else if (totalRows) {
+        if (totalRows) {
             active = !active;
         }
     }}
@@ -119,7 +113,7 @@ let shiftClicked = transientBooleanStore();
                     </Shortcut>
 
                     <div>
-                        <StackingWord active={$shiftClicked}>
+                        <StackingWord>
                             copy
                         </StackingWord>
                         column name to clipboard

--- a/src/lib/components/column-profile/NavEntry.svelte
+++ b/src/lib/components/column-profile/NavEntry.svelte
@@ -3,7 +3,12 @@
 import { createEventDispatcher } from "svelte";
 import CaretDownIcon from "$lib/components/icons/CaretDownIcon.svelte";
 import ExpanderButton from "$lib/components/column-profile/ExpanderButton.svelte";
-import type { SvelteComponent } from "svelte";
+import Tooltip from "$lib/components/tooltip/Tooltip.svelte";
+import TooltipContent from "$lib/components/tooltip/TooltipContent.svelte";
+import TooltipShortcutContainer from "$lib/components/tooltip/TooltipShortcutContainer.svelte";
+import Shortcut from "$lib/components/tooltip/Shortcut.svelte";
+import transientBooleanStore from "$lib/util/transient-boolean-store";
+import StackingWord from "$lib/components/tooltip/StackingWord.svelte";
 
 const dispatch = createEventDispatcher();
 
@@ -11,13 +16,16 @@ export let expanded = true;
 export let expandable = true;
 export let selected = false;
 export let hovered = false;
+
+let clicked = transientBooleanStore();
+
 </script>
 
 <div
     on:mouseenter={() => { hovered = true; }}
     on:mouseleave={() => { hovered = false; }}
     style:height="24px"
-    style:grid-template-columns="[left-control] max-content [body] auto"
+    style:grid-template-columns="[left-control] max-content [body] auto [contextual-information] max-content"
     class="
         {selected ? 'bg-gray-100' : 'bg-transparent'}
         grid
@@ -33,35 +41,44 @@ export let hovered = false;
         <CaretDownIcon size="14px" />
     </ExpanderButton>
     {/if}
-    <button 
-        on:click={() => { dispatch('select-body')}}
-        on:focus={() => { hovered = true; }}
-        on:blur={() => { hovered = false; }}
-        style:grid-column="body"
-        style:grid-template-columns="[icon] max-content [text] 1fr [contextual-information] max-content"
-        class="
-            w-full 
-            justify-start
-            text-left 
-            grid 
-            items-center
-            p-0"
-        >
-        <div
-            style:grid-column="text"
+    <Tooltip location="right">
+        <button 
+            on:click={(evt) => { 
+                dispatch('select-body', evt.shiftKey);
+                clicked.flip();
+         }}
+            on:focus={() => { hovered = true; }}
+            on:blur={() => { hovered = false; }}
+            style:grid-column="body"
+            style:grid-template-columns="[icon] max-content [text] 1fr"
             class="
-                justify-self-auto
-                text-ellipsis 
-                overflow-hidden 
-                whitespace-nowrap">
-            <slot />
-        </div>
+                w-full 
+                justify-start
+                text-left 
+                grid 
+                items-center
+                p-0"
+            >
+            <div
+                style:grid-column="text"
+                class="
+                    w-full
+                    justify-self-auto
+                    text-ellipsis 
+                    overflow-hidden 
+                    whitespace-nowrap">
+                <slot />
+            </div>
+        </button>
+    <TooltipContent slot='tooltip-content'>
 
-        <div 
-            style:grid-column="contextual-information"
-            class="justify-self-end"
-        >
-            <slot name="contextual-information" />
-        </div>
-    </button>
+        <slot name="tooltip-content" />
+    </TooltipContent>
+    </Tooltip>
+    <div 
+    style:grid-column="contextual-information"
+    class="justify-self-end"
+>
+    <slot name="contextual-information" />
+</div>
 </div>

--- a/src/lib/components/column-profile/NavEntry.svelte
+++ b/src/lib/components/column-profile/NavEntry.svelte
@@ -5,11 +5,10 @@ import CaretDownIcon from "$lib/components/icons/CaretDownIcon.svelte";
 import ExpanderButton from "$lib/components/column-profile/ExpanderButton.svelte";
 import Tooltip from "$lib/components/tooltip/Tooltip.svelte";
 import TooltipContent from "$lib/components/tooltip/TooltipContent.svelte";
-import TooltipShortcutContainer from "$lib/components/tooltip/TooltipShortcutContainer.svelte";
-import Shortcut from "$lib/components/tooltip/Shortcut.svelte";
-import transientBooleanStore from "$lib/util/transient-boolean-store";
-import StackingWord from "$lib/components/tooltip/StackingWord.svelte";
 
+import { createShiftClickAction } from "$lib/util/shift-click-action";
+
+const { shiftClickAction } = createShiftClickAction();
 const dispatch = createEventDispatcher();
 
 export let expanded = true;
@@ -17,7 +16,6 @@ export let expandable = true;
 export let selected = false;
 export let hovered = false;
 
-let clicked = transientBooleanStore();
 
 </script>
 
@@ -43,10 +41,11 @@ let clicked = transientBooleanStore();
     {/if}
     <Tooltip location="right">
         <button 
+            use:shiftClickAction
+            on:shift-click
             on:click={(evt) => { 
-                dispatch('select-body', evt.shiftKey);
-                clicked.flip();
-         }}
+                dispatch('select-body');
+            }}
             on:focus={() => { hovered = true; }}
             on:blur={() => { hovered = false; }}
             style:grid-column="body"

--- a/src/lib/components/table/PreviewTable.svelte
+++ b/src/lib/components/table/PreviewTable.svelte
@@ -6,12 +6,8 @@
  * and provide the interactions needed to do things with the table.
 */
 import { slide } from "svelte/transition";
-import { Table, TableRow, TableHeader, TableCell } from "$lib/components/table/";
-import { FormattedDataType, DataTypeIcon } from "$lib/components/data-types/";
-import Pin from "$lib/components/icons/Pin.svelte";
-import Tooltip from "$lib/components/tooltip/Tooltip.svelte";
-import TooltipContent from "$lib/components/tooltip/TooltipContent.svelte";
-import DataTypeTitle from "$lib/components/tooltip/DataTypeTitle.svelte";
+import { Table, TableRow, TableCell } from "$lib/components/table/";
+import { FormattedDataType } from "$lib/components/data-types/";
 import PreviewTableHeader from "./PreviewTableHeader.svelte";
 import { TIMESTAMPS } from "$lib/duckdb-data-types";
 import { standardTimestampFormat } from "$lib/util/formatters"

--- a/src/lib/components/table/PreviewTableHeader.svelte
+++ b/src/lib/components/table/PreviewTableHeader.svelte
@@ -7,30 +7,27 @@ import TooltipContent from "$lib/components/tooltip/TooltipContent.svelte";
 import TooltipTitle from "$lib/components/tooltip/TooltipTitle.svelte"
 import Pin from "$lib/components/icons/Pin.svelte";
 
-import transientBooleanStore from "$lib/util/transient-boolean-store";
 import notificationStore from "$lib/components/notifications/";
 import TooltipShortcutContainer from "../tooltip/TooltipShortcutContainer.svelte";
 import Shortcut from "../tooltip/Shortcut.svelte";
 import StackingWord from "../tooltip/StackingWord.svelte";
+import { createShiftClickAction } from "$lib/util/shift-click-action";
 
 export let name:string;
 export let type:string;
 export let pinned = false;
 
-let shiftClicked = transientBooleanStore();
 const dispatch = createEventDispatcher();
+const { shiftClickAction } = createShiftClickAction();
 </script>
 
 <TableHeader {name} {type}>
     <div 
        style:grid-template-columns="210px max-content"
-       on:click={async (event) => {
-           if (event.shiftKey) {
+       use:shiftClickAction
+       on:shift-click={async () => {
             await navigator.clipboard.writeText(name);
             notificationStore.send({ message: `copied column name "${name}" to clipboard`});
-            // update this to set the active animation in the tooltip text
-            shiftClicked.flip();
-           }
        }}
        class="
            grid
@@ -59,7 +56,7 @@ const dispatch = createEventDispatcher();
                <TooltipShortcutContainer>
 
                 <div>
-                    <StackingWord active={$shiftClicked}>
+                    <StackingWord>
                         copy
                     </StackingWord>
                     column name to clipboard

--- a/src/lib/components/table/PreviewTableHeader.svelte
+++ b/src/lib/components/table/PreviewTableHeader.svelte
@@ -4,7 +4,7 @@ import DataTypeIcon from "$lib/components/data-types/DataTypeIcon.svelte";
 import TableHeader from "./TableHeader.svelte";
 import Tooltip from "$lib/components/tooltip/Tooltip.svelte";
 import TooltipContent from "$lib/components/tooltip/TooltipContent.svelte";
-import DataTypeTitle from "$lib/components/tooltip/DataTypeTitle.svelte"
+import TooltipTitle from "$lib/components/tooltip/TooltipTitle.svelte"
 import Pin from "$lib/components/icons/Pin.svelte";
 
 import transientBooleanStore from "$lib/util/transient-boolean-store";
@@ -48,7 +48,14 @@ const dispatch = createEventDispatcher();
                </span>
            </div>
            <TooltipContent slot='tooltip-content'>
-               <DataTypeTitle {name} {type} />
+            <TooltipTitle>
+                <svelte:fragment slot="name">
+                    {name}
+                </svelte:fragment>
+                <svelte:fragment slot="description">
+                        {type}
+                </svelte:fragment>
+            </TooltipTitle>
                <TooltipShortcutContainer>
 
                 <div>

--- a/src/lib/components/table/TableCell.svelte
+++ b/src/lib/components/table/TableCell.svelte
@@ -9,6 +9,18 @@ import { fade } from "svelte/transition"
 import { FormattedDataType } from "$lib/components/data-types/";
 import { TIMESTAMPS } from "$lib/duckdb-data-types";
 import { standardTimestampFormat } from "$lib/util/formatters";
+import Tooltip from "../tooltip/Tooltip.svelte";
+import TooltipContent from "../tooltip/TooltipContent.svelte";
+import notificationStore from "../notifications";
+import TooltipShortcutContainer from "../tooltip/TooltipShortcutContainer.svelte";
+import StackingWord from "../tooltip/StackingWord.svelte";
+import Shortcut from "../tooltip/Shortcut.svelte";
+import TooltipTitle from "../tooltip/TooltipTitle.svelte";
+
+import { createShiftClickAction } from "$lib/util/shift-click-action";
+
+const { shiftClickAction } = createShiftClickAction();
+
 export let type;
 export let value;
 export let name;
@@ -37,11 +49,10 @@ $: {
     }
 }
 
-
 let activeCell = false;
 
 </script>
-
+<Tooltip location='top' distance={16}>
 <td
     on:mouseover={() => { dispatch('inspect', index); activeCell = true; }}
     on:mouseout={() => { activeCell = false; }}
@@ -49,7 +60,6 @@ let activeCell = false;
     on:blur={() => {activeCell = false;} }
     title={value}
     class="
-        text-ellipsis overflow-hidden whitespace-nowrap
         p-2
         pl-4
         pr-4
@@ -60,6 +70,16 @@ let activeCell = false;
     style:width="var(--table-column-width-{name}, 210px)"
     style:max-width="var(--table-column-width-{name}, 210px)"
 >
+    <button 
+        class="text-left w-full text-ellipsis overflow-hidden whitespace-nowrap"
+        use:shiftClickAction
+        on:shift-click={async (event) => {
+            await navigator.clipboard.writeText(name);
+            let rep = name.toString().slice(0,10)
+            notificationStore.send({ message: `copied value to clipboard`});
+            // update this to set the active animation in the tooltip text
+        }}
+    >
     {#if value !== undefined}
     <span transition:fade|local={{duration: 75}}>
         <FormattedDataType {type} {isNull} inTable>
@@ -67,4 +87,22 @@ let activeCell = false;
         </FormattedDataType>
     </span>
     {/if}
+    </button>
 </td>
+<TooltipContent slot='tooltip-content'>
+    <TooltipTitle>
+        <svelte:fragment slot='name'>
+            {value}
+        </svelte:fragment>
+    </TooltipTitle>
+    <TooltipShortcutContainer>
+        <div>
+            <StackingWord>copy</StackingWord> this value to clipboard
+        </div>
+        <Shortcut>
+            <span style='font-family: var(--system);";
+            '>⇧</span> + Click
+        </Shortcut>
+    </TooltipShortcutContainer>
+</TooltipContent>
+</Tooltip>

--- a/src/lib/components/tooltip/StackingWord.svelte
+++ b/src/lib/components/tooltip/StackingWord.svelte
@@ -1,8 +1,11 @@
 <script>
-export let active = false;
+import { getContext } from "svelte";
+import { writable } from "svelte/store";
+const transientBoolean = getContext("rill:app:ui:shift-click") || writable(false);
+
 </script>
 
-<span class="inline-block shiftable" class:shiftClicked={active}><slot /></span>
+<span class="inline-block shiftable" class:shiftClicked={$transientBoolean}><slot /></span>
 
 <style>
 

--- a/src/lib/components/tooltip/StackingWord.svelte
+++ b/src/lib/components/tooltip/StackingWord.svelte
@@ -1,11 +1,18 @@
 <script>
 import { getContext } from "svelte";
-import { writable } from "svelte/store";
-const transientBoolean = getContext("rill:app:ui:shift-click") || writable(false);
+import transientBooleanStore from "$lib/util/transient-boolean-store";
+const callbacks = getContext('rill:app:ui:shift-click-action-callbacks');
+let shiftClicked = transientBooleanStore();
+
+// if a parent component upstream triggers the shift-click action,
+// let's flip our transientBooleanStore to create the animation.
+callbacks.addCallback(() => {
+    shiftClicked.flip();
+})
 
 </script>
 
-<span class="inline-block shiftable" class:shiftClicked={$transientBoolean}><slot /></span>
+<span class="inline-block shiftable" class:shiftClicked={$shiftClicked}><slot /></span>
 
 <style>
 

--- a/src/lib/components/tooltip/TooltipTitle.svelte
+++ b/src/lib/components/tooltip/TooltipTitle.svelte
@@ -1,13 +1,8 @@
-<script lang="ts">
-export let name:string;
-export let type:string;
-</script>
-
 <div class="grid gap-x-2 items-center pt-1 pb-1" style="grid-template-columns: auto max-content" style:min-width="200px">
     <div class="font-bold">
-        {name}
+        <slot name="name" />
     </div>
     <div class="text-gray-300 justify-self-end pl-3">
-        {type}
+        <slot name="description" />
     </div>
 </div>

--- a/src/lib/util/shift-click-action.ts
+++ b/src/lib/util/shift-click-action.ts
@@ -1,0 +1,40 @@
+import { setContext } from "svelte";
+import transientBooleanStore from "$lib/util/transient-boolean-store"
+
+interface CreateShiftClick {
+    stopImmediatePropagation: boolean
+}
+
+export function createShiftClickAction(params : CreateShiftClick = { stopImmediatePropagation: true}) {
+    let _stopImmediatePropagation = params?.stopImmediatePropagation || false;
+	const clickSwitch = transientBooleanStore();
+	// set a context for children to consume transient state.
+	setContext("rill:app:ui:shift-click", clickSwitch);
+	
+	return {
+		// export the click switch store if needed in the attached component
+		clickSwitch,
+		// put this in a use:shiftClickAction
+		shiftClickAction(node:Element) {
+			function shiftClick(event:MouseEvent) {
+				if (event.shiftKey) {
+						// dispatch our custom event. accessible via on:shift-click
+						node.dispatchEvent(new CustomEvent("shift-click"));
+						// update our shared store.
+						clickSwitch.flip();
+						// prevent the regular on:click event here.
+						if (_stopImmediatePropagation) {
+							event.stopImmediatePropagation();
+						}
+				}
+			}
+			node.addEventListener('click', shiftClick);
+			return {
+				destroy() {
+					// remove the shiftClick listener if the DOM element
+					node.addEventListener('click', shiftClick);
+				}
+			}
+		}
+	}
+}

--- a/src/routes/_surfaces/assets/index.svelte
+++ b/src/routes/_surfaces/assets/index.svelte
@@ -93,7 +93,6 @@ let view = 'assets';
                   <div animate:flip>
                     <CollapsibleTableSummary
                       indentLevel={1}
-
                       icon={ParquetIcon}
                       name={tableName}
                       cardinality={derivedTable?.cardinality ?? 0}


### PR DESCRIPTION
We had a request come in to add more shift+click functionality. This PR adds it to the assets on the left hand side and to tables.

- [x] add shift+click to assets
- [x] add shift+click to preview table values
- [x] generalize action for shift+click