### PR TITLE
DM-337 DM-336 DM-297 fixes the rollup factor and NaN issues at the top of the inspector

### DIFF
--- a/src/lib/util/model-structure.test.ts
+++ b/src/lib/util/model-structure.test.ts
@@ -134,7 +134,6 @@ select something, count(*) from       table
             output: [{ name: 'table', start: 39, end: 44}]
         },
 
-                // check wraps for ?
                 {
                     input: `
         select something, count(*) from       table    abc    

--- a/src/lib/util/model-structure.test.ts
+++ b/src/lib/util/model-structure.test.ts
@@ -133,6 +133,14 @@ select something, count(*) from       table
     LEFT JOIN cruds ON cruds.id = table.id;`,
             output: [{ name: 'table', start: 39, end: 44}]
         },
+
+                // check wraps for ?
+                {
+                    input: `
+        select something, count(*) from       table    abc    
+            LEFT JOIN cruds ON cruds.id = table.id;`,
+                    output: [{ name: 'table', start: 39, end: 44}]
+                },
 ]
 
 describe('extractFromStatements', () => {
@@ -147,6 +155,7 @@ describe('extractFromStatements', () => {
         expect(extractFromStatements(selectQueries[7].input)).toEqual(selectQueries[7].output);
 
         expect(extractFromStatements(selectQueries[8].input)).toEqual(selectQueries[8].output);
+        expect(extractFromStatements(selectQueries[8].input)).toEqual(selectQueries[9].output);
 
     })
 })

--- a/src/lib/util/model-structure.ts
+++ b/src/lib/util/model-structure.ts
@@ -309,11 +309,12 @@ export function extractFromStatements(query:string) {
                 }
                 
                 const finalSeq = restOfQuery.slice(ei + leftCorrection, ri - rightCorrection);
-                
+                const [name, ...remainder] = finalSeq.split(' ');
+                let remainingChars = remainder.join(' ');
                 sourceTables.push({
-                    name: finalSeq,
+                    name: name.trim(),
                     start: ei  + latest + leftCorrection,
-                    end: ri - rightCorrection + latest
+                    end: ri - rightCorrection + latest - (remainingChars.length ? (remainingChars.length + 1): 0)
                 });
 
                 break;

--- a/src/routes/_surfaces/inspector/Model.svelte
+++ b/src/routes/_surfaces/inspector/Model.svelte
@@ -135,7 +135,7 @@ onMount(() => {
       class:text-gray-300={currentDerivedModel?.error} 
       class='cost pl-4 pr-4 flex flex-row items-center gap-x-2'
       >
-      {#if  !currentDerivedModel?.error}
+      {#if !currentDerivedModel?.error && (rollup && rollup !== Infinity && rollup !== -Infinity)}
     <Tooltip location="left" alignment="middle" distance={16} suppress={contextMenuOpen}>
       <button
       bind:this={contextMenu}

--- a/src/routes/_surfaces/inspector/Model.svelte
+++ b/src/routes/_surfaces/inspector/Model.svelte
@@ -135,7 +135,7 @@ onMount(() => {
       class:text-gray-300={currentDerivedModel?.error} 
       class='cost pl-4 pr-4 flex flex-row items-center gap-x-2'
       >
-
+      {#if  !currentDerivedModel?.error}
     <Tooltip location="left" alignment="middle" distance={16} suppress={contextMenuOpen}>
       <button
       bind:this={contextMenu}
@@ -192,13 +192,13 @@ onMount(() => {
                   {:else if rollup === 0 }
                     no rows selected
                   {:else if rollup !== 1}
-                                  {formatBigNumberPercentage($bigRollupNumber)}
+                                  {formatBigNumberPercentage(rollup < .0005 ? rollup :( $bigRollupNumber || 0))}
                               of source rows
                   {:else}no change in row {#if containerWidth > config.hideRight}count{:else}ct.{/if}
 
                   {/if}  
               {:else if rollup === Infinity}
-                &nbsp; {outputRowCardinalityValue} row{#if outputRowCardinalityValue !== 1}s{/if} selected
+                &nbsp; {formatInteger(outputRowCardinalityValue)} row{#if outputRowCardinalityValue !== 1}s{/if} selected
             {/if}
         </div>
       <TooltipContent slot='tooltip-content'>
@@ -212,6 +212,7 @@ onMount(() => {
       </TooltipContent>
       </Tooltip>
     </div>
+    {/if}
     </div>
   {/if}
 
@@ -226,8 +227,9 @@ onMount(() => {
           </CollapsibleSectionTitle>
         </div>
         {#if showSourceTables}
-          {#if sourceTableReferences?.length && tables}
           <div transition:slide|local={{duration: 200}} class="mt-1">
+            {#if sourceTableReferences?.length && tables}
+
             {#each sourceTableReferences as reference, index (reference.name)}
             {@const correspondingTableCardinality = tables[index]?.cardinality}
               <div
@@ -257,12 +259,12 @@ onMount(() => {
               </div>
             </div>
             {/each}
-          </div>
-          {:else}
+            {:else}
             <div class='pl-4 pr-5 p-1 italic text-gray-400'>
             none selected
             </div>
           {/if}
+          </div>
         {/if}
       </div>
       

--- a/test/ui/DataModeler.spec.ts
+++ b/test/ui/DataModeler.spec.ts
@@ -87,10 +87,10 @@ export class DataModelerTest extends TestBase {
   public queryDataProvider(): DataProviderData<[string, CostOutput]> {
     type Args = [string, CostOutput];
 
-    const LimitZeroQuery = 'SELECT * FROM AdBids LIMIT 0';
+    const LimitZeroQuery = 'SELECT * FROM AdBids LIMIT 1';
     // FIXME the first query loaded doesn't seem to show the cost correctly, this could be a bug in the
     // UI.
-    const LimitZeroQueryResult: CostOutput = encodeURI('0 rows, 5 columns');
+    const LimitZeroQueryResult: CostOutput = encodeURI('1 row, 5 columns');
     const LimitZeroQueryTestData: Args = [LimitZeroQuery, LimitZeroQueryResult];
 
     const LimitTenQuery = 'SELECT * FROM AdBids LIMIT 10';


### PR DESCRIPTION
fixes the top right estimates when the query is broken and also when there is a very small row cardinality

this also fixes the issue with source table aliases not working when you don't include `AS`