### PR TITLE
Using duckdb's summarize table instead of individual calls

### DIFF
--- a/src/common/data-modeler-service/ProfileColumnActions.ts
+++ b/src/common/data-modeler-service/ProfileColumnActions.ts
@@ -6,6 +6,8 @@ import { DataModelerActions } from "$common/data-modeler-service/DataModelerActi
 import { BOOLEANS, CATEGORICALS, TIMESTAMPS } from "$lib/duckdb-data-types";
 import type { ProfileColumn } from "$lib/types";
 import { DatabaseActionQueuePriority } from "$common/priority-action-queue/DatabaseActionQueuePriority";
+import type {DuckDBColumnSummary, DuckDBTableSummary} from "$common/duckdbTypes";
+import {parseNumber} from "$common/utils/parseNumber";
 
 const ColumnProfilePriorityMap = {
     [EntityType.Table]: DatabaseActionQueuePriority.TableProfile,
@@ -23,41 +25,51 @@ export class ProfileColumnActions extends DataModelerActions {
             console.error(`Entity not found. entityType=${entityType} entityId=${entityId}`);
             return;
         }
+        const tableSummary: DuckDBTableSummary = await this.databaseActionQueue.enqueue(
+            {id: entityId, priority: ColumnProfilePriorityMap[entityType]},
+            "getTableSummary", [persistentEntity.tableName]);
         try {
             await Promise.all(entity.profile.map(column =>
-                this.collectColumnInfo(entityType, entityId, persistentEntity.tableName, column)));
+                this.collectColumnInfo(entityType, entityId, persistentEntity.tableName, column,
+                    tableSummary.find(summary => summary.column_name === column.name))));
         } catch (err) {}
     }
 
     private async collectColumnInfo(entityType: EntityType, entityId: string,
-                                    tableName: string, column: ProfileColumn): Promise<void> {
+                                    tableName: string, column: ProfileColumn,
+                                    columnSummary: DuckDBColumnSummary): Promise<void> {
         const promises = [];
         if (CATEGORICALS.has(column.type) || BOOLEANS.has(column.type)) {
-            promises.push(this.collectTopKAndCardinality(entityType, entityId, tableName, column));
+            promises.push(this.collectTopKAndCardinality(entityType, entityId, tableName, column, columnSummary));
         } else {
-            promises.push(this.collectNumericHistogram(entityType, entityId, tableName, column));
+            promises.push(this.collectNumericHistogram(entityType, entityId, tableName, column, columnSummary));
             if (TIMESTAMPS.has(column.type)) {
                 promises.push(this.collectTimeRange(entityType, entityId, tableName, column));
             } else {
-                promises.push(this.collectDescriptiveStatistics(entityType, entityId, tableName, column));
+                promises.push(this.collectDescriptiveStatistics(entityType, entityId, tableName, column, columnSummary));
             }
         }
-        promises.push(this.collectNullCount(entityType, entityId, tableName, column));
+        promises.push(this.collectNullCount(entityType, entityId, tableName, column, columnSummary));
         await Promise.all(promises);
     }
 
     private async collectTopKAndCardinality(entityType: EntityType, entityId: string,
-                                            tableName: string, column: ProfileColumn): Promise<void> {
+                                            tableName: string, column: ProfileColumn,
+                                            columnSummary: DuckDBColumnSummary): Promise<void> {
         this.dataModelerStateService.dispatch("updateColumnSummary",[
             entityType, entityId, column.name,
-            await this.databaseActionQueue.enqueue(
-                {id: entityId, priority: ColumnProfilePriorityMap[entityType]},
-                "getTopKAndCardinality", [tableName, column.name]),
+            {
+                topK: await this.databaseActionQueue.enqueue(
+                    {id: entityId, priority: ColumnProfilePriorityMap[entityType]},
+                    "getTopKOfColumn", [tableName, column.name]),
+                cardinality: parseNumber(columnSummary.approx_unique),
+            }
         ]);
     }
 
     private async collectNumericHistogram(entityType: EntityType, entityId: string,
-                                          tableName: string, column: ProfileColumn): Promise<void> {
+                                          tableName: string, column: ProfileColumn,
+                                          columnSummary: DuckDBColumnSummary): Promise<void> {
         this.dataModelerStateService.dispatch("updateColumnSummary", [
             entityType, entityId, column.name,
             await this.databaseActionQueue.enqueue(
@@ -77,22 +89,32 @@ export class ProfileColumnActions extends DataModelerActions {
     }
 
     private async collectDescriptiveStatistics(entityType: EntityType, entityId: string,
-                                               tableName: string, column: ProfileColumn): Promise<void> {
+                                               tableName: string, column: ProfileColumn,
+                                               columnSummary: DuckDBColumnSummary): Promise<void> {
         this.dataModelerStateService.dispatch("updateColumnSummary", [
             entityType, entityId, column.name,
-            await this.databaseActionQueue.enqueue(
-                {id: entityId, priority: ColumnProfilePriorityMap[entityType]},
-                "getDescriptiveStatistics", [tableName, column.name]),
+            {
+                statistics: {
+                    max: parseNumber(columnSummary.max),
+                    min: parseNumber(columnSummary.min),
+                    mean: parseNumber(columnSummary.avg),
+                    q25: parseNumber(columnSummary.q25),
+                    q50: parseNumber(columnSummary.q50),
+                    q75: parseNumber(columnSummary.q75),
+                    sd: parseNumber(columnSummary.std),
+                }
+            },
         ]);
     }
 
     private async collectNullCount(entityType: EntityType, entityId: string,
-                                   tableName: string, column: ProfileColumn): Promise<void> {
+                                   tableName: string, column: ProfileColumn,
+                                   columnSummary: DuckDBColumnSummary): Promise<void> {
+        const nullPercent = columnSummary.null_percentage ?
+            Number(columnSummary.null_percentage.replace("%", "")) : 0;
         this.dataModelerStateService.dispatch("updateNullCount", [
             entityType, entityId, column.name,
-            await this.databaseActionQueue.enqueue(
-                {id: entityId, priority: ColumnProfilePriorityMap[entityType]},
-                "getNullCount", [tableName, column.name]),
+            Math.round(nullPercent * columnSummary.count / 100),
         ]);
     }
 }

--- a/src/common/database-service/DatabaseColumnActions.ts
+++ b/src/common/database-service/DatabaseColumnActions.ts
@@ -108,7 +108,7 @@ export class DatabaseColumnActions extends DatabaseActions {
         return ranges;
     }
 
-    private async getTopKOfColumn(metadata: DatabaseMetadata,
+    public async getTopKOfColumn(metadata: DatabaseMetadata,
                           tableName: string, columnName: string, func = "count(*)"): Promise<any> {
         const sanitizedColumnName = sanitizeColumn(columnName);
         return this.databaseClient.execute(`
@@ -119,7 +119,7 @@ export class DatabaseColumnActions extends DatabaseActions {
         `);
     }
 
-    private async getCardinalityOfColumn(metadata: DatabaseMetadata,
+    public async getCardinalityOfColumn(metadata: DatabaseMetadata,
                                  tableName: string, columnName: string): Promise<number> {
         const sanitizedColumnName = sanitizeColumn(columnName);
         const [results] = await this.databaseClient.execute(

--- a/src/common/database-service/DatabaseTableActions.ts
+++ b/src/common/database-service/DatabaseTableActions.ts
@@ -1,6 +1,7 @@
 import {DatabaseActions} from "./DatabaseActions";
 import {guidGenerator} from "$lib/util/guid";
 import type {DatabaseMetadata} from "$common/database-service/DatabaseMetadata";
+import type {DuckDBTableSummary} from "$common/duckdbTypes";
 
 export class DatabaseTableActions extends DatabaseActions {
     public async createViewOfQuery(metadata: DatabaseMetadata, tableName: string, query: string): Promise<any> {
@@ -41,5 +42,9 @@ export class DatabaseTableActions extends DatabaseActions {
 
     public async dropTable(metadata: DatabaseMetadata, tableName: string): Promise<any> {
         await this.databaseClient.execute(`DROP TABLE ${tableName}`);
+    }
+
+    public async getTableSummary(metadata: DatabaseMetadata, tableName: string): Promise<DuckDBTableSummary> {
+        return await this.databaseClient.execute(`SUMMARIZE ${tableName}`);
     }
 }

--- a/src/common/duckdbTypes.ts
+++ b/src/common/duckdbTypes.ts
@@ -1,0 +1,15 @@
+export interface DuckDBColumnSummary {
+    column_name: string;
+    column_type: string;
+    min: string;
+    max: string;
+    approx_unique: string;
+    avg: string;
+    std: string;
+    q25: string;
+    q50: string;
+    q75: string;
+    count: number;
+    null_percentage: string;
+}
+export type DuckDBTableSummary = Array<DuckDBColumnSummary>;

--- a/src/common/utils/parseNumber.ts
+++ b/src/common/utils/parseNumber.ts
@@ -1,0 +1,3 @@
+export function parseNumber(str: string, defaultValue = null) {
+    return str ? Number(str) : defaultValue;
+}


### PR DESCRIPTION
Replacing multiple duckdb queries with `SUMMARIZE` query