### PR TITLE
DM-345 add support for `INTERVAL` data type representations

### DIFF
--- a/src/lib/components/column-profile/ColumnProfile.svelte
+++ b/src/lib/components/column-profile/ColumnProfile.svelte
@@ -210,28 +210,10 @@ let titleTooltip;
         class="
             pl-8 text-ellipsis overflow-hidden whitespace-nowrap text-right" style:max-width="{exampleWidth}px"
         >
-                <FormattedDataType {type} isNull={example === null || example === ''}>
-                    {#if TIMESTAMPS.has(type)}
-                        {standardTimestampFormat(new Date(example))}
-                    {:else if CATEGORICALS.has(type) && example === ''}
-                        <span class="text-gray-400 italic">{"<"}empty string{">"}</span>
-                    {:else}
-                        {example}
-                    {/if}
-                    <!-- {TIMESTAMPS.has(type) ? standardTimestampFormat(new Date(example)) : example} -->
-                </FormattedDataType>
+                <FormattedDataType {type} isNull={example === null || example === ''} value={example} />
         </div>
         <TooltipContent slot="tooltip-content" >
-                <FormattedDataType {type} isNull={example === null || example === ''} dark>
-                    {#if TIMESTAMPS.has(type)}
-                        {standardTimestampFormat(new Date(example))}
-                    {:else if CATEGORICALS.has(type) && example === ''}
-                        <span class="text-gray-400 italic">{"<"}empty string{">"}</span>
-                    {:else}
-                        {example}
-                    {/if}
-                    <!-- {TIMESTAMPS.has(type) ? standardTimestampFormat(new Date(example)) : example} -->
-                </FormattedDataType>
+                <FormattedDataType value={example} {type} isNull={example === null || example === ''} dark />
         </TooltipContent>
         </Tooltip>
     </svelte:fragment>

--- a/src/lib/components/data-types/DataTypeIcon.svelte
+++ b/src/lib/components/data-types/DataTypeIcon.svelte
@@ -3,6 +3,7 @@ import {
     CATEGORICALS, 
     TIMESTAMPS,
     INTEGERS,
+    INTERVALS,
     FLOATS, 
     BOOLEANS } from "$lib/duckdb-data-types";
 import Tooltip from "$lib/components/tooltip/Tooltip.svelte";
@@ -25,7 +26,7 @@ function typeToSymbol(fieldType:string) {
         return FloatType;
     } else if (CATEGORICALS.has(fieldType)) {
         return CategoricalType;
-    } else if (TIMESTAMPS.has(fieldType)) {
+    } else if (TIMESTAMPS.has(fieldType) ||  INTERVALS.has(type)) {
         return TimestampType;
     } else if (BOOLEANS.has(fieldType)) {
         return BooleanType;

--- a/src/lib/components/data-types/FormattedDataType.svelte
+++ b/src/lib/components/data-types/FormattedDataType.svelte
@@ -1,13 +1,17 @@
 <script>
-import { NUMERICS, TIMESTAMPS } from "$lib/duckdb-data-types"
+/** provides the formatting for data types */
+import { INTERVALS, NUMERICS, TIMESTAMPS } from "$lib/duckdb-data-types"
 import Varchar from "./Varchar.svelte";
 import Number from "./Number.svelte";
 import Timestamp from "./Timestamp.svelte";
+import Interval from "./Interval.svelte";
+import { formatDataType } from "$lib/util/formatters";
 
 export let type = 'VARCHAR';
 export let isNull = false;
 export let inTable = false;
 export let dark = false;
+export let value = undefined;
 
 let dataType = Varchar;
 $: {
@@ -15,6 +19,8 @@ $: {
         dataType = Number;
     } else if (TIMESTAMPS.has(type)) {
         dataType = Timestamp;
+    } else if (INTERVALS.has(type)) {
+        dataType = Interval;
     } else {
         // default to the varchar style
         dataType = Varchar;
@@ -23,5 +29,9 @@ $: {
 </script>
 
 <svelte:component this={dataType} {isNull} {inTable} {dark}>
-    <slot />
+    {#if value === undefined}
+        <slot />
+    {:else}
+        {formatDataType(value, type)}
+    {/if}
 </svelte:component>

--- a/src/lib/components/data-types/FormattedDataType.svelte
+++ b/src/lib/components/data-types/FormattedDataType.svelte
@@ -28,7 +28,7 @@ $: {
 }
 </script>
 
-<svelte:component this={dataType} {isNull} {inTable} {dark}>
+<svelte:component this={dataType} isNull={isNull || (value === null)} {inTable} {dark}>
     {#if value === undefined}
         <slot />
     {:else}

--- a/src/lib/components/data-types/Interval.svelte
+++ b/src/lib/components/data-types/Interval.svelte
@@ -1,0 +1,9 @@
+<script>
+    import Base from "./Base.svelte";
+    export let isNull = false;
+    export let inTable = false;
+    export let dark  = false;
+</script>
+<Base {isNull} classes="font-semibold {inTable && 'block text-right'}" {dark}>
+    <slot />
+</Base>

--- a/src/lib/components/table/PreviewTable.svelte
+++ b/src/lib/components/table/PreviewTable.svelte
@@ -127,8 +127,6 @@ function togglePin(name, type, selectedCols) {
         style:box-shadow="0 -4px 2px 0 rgb(0 0 0 / 0.05)"
     >
         <span class='font-bold pr-5'>{visualCellField}</span>
-        <FormattedDataType type={visualCellType} isNull={visualCellValue === null}>
-            {TIMESTAMPS.has(visualCellType) ? standardTimestampFormat(new Date(visualCellValue), visualCellType) : visualCellValue}
-        </FormattedDataType>
+        <FormattedDataType value={visualCellValue} type={visualCellType} isNull={visualCellValue === null} />
 </div>
 {/if}

--- a/src/lib/components/table/TableCell.svelte
+++ b/src/lib/components/table/TableCell.svelte
@@ -8,7 +8,7 @@ import { createEventDispatcher } from "svelte";
 import { fade } from "svelte/transition"
 import { FormattedDataType } from "$lib/components/data-types/";
 import { INTERVALS, TIMESTAMPS } from "$lib/duckdb-data-types";
-import { standardTimestampFormat } from "$lib/util/formatters";
+import { formatDataType, standardTimestampFormat } from "$lib/util/formatters";
 import Tooltip from "../tooltip/Tooltip.svelte";
 import TooltipContent from "../tooltip/TooltipContent.svelte";
 import notificationStore from "../notifications";
@@ -80,7 +80,8 @@ let activeCell = false;
         on:shift-click={async (event) => {
             let exportedValue = value;
             if (INTERVALS.has(type)) {
-                exportedValue = `INTERVAL ${value.days} DAY ${value.micros ? `INTERVAL ${value.micros} MICRO` : ''}`
+                exportedValue = formatDataType(value, type);
+
             } else if (TIMESTAMPS.has(type)) {
                 exportedValue =  `TIMESTAMP '${value}'`;
             }

--- a/src/lib/duckdb-data-types.ts
+++ b/src/lib/duckdb-data-types.ts
@@ -15,6 +15,7 @@ export const FLOATS = new Set([
 export const NUMERICS = new Set([...INTEGERS, ...FLOATS]);
 export const BOOLEANS = new Set([ "BOOLEAN", "BOOL", "LOGICAL" ]);
 export const TIMESTAMPS = new Set(['TIMESTAMP', 'TIME', 'DATETIME', 'DATE']);
+export const INTERVALS = new Set(['INTERVAL'])
 export const CATEGORICALS = new Set(['BYTE_ARRAY', 'VARCHAR', "CHAR", "BPCHAR", "TEXT", "STRING"]);
 
 interface ColorTokens {
@@ -45,6 +46,8 @@ export const TIMESTAMP_TOKENS: ColorTokens = {
     vizStrokeClass: "stroke-teal-500"
 }
 
+export const INTERVAL_TOKENS: ColorTokens = TIMESTAMP_TOKENS;
+
 function setTypeTailwindStyles(
         list:string[], 
         // a tailwind class, for now.
@@ -60,5 +63,6 @@ export const DATA_TYPE_COLORS = {
     ...setTypeTailwindStyles(Array.from(CATEGORICALS), CATEGORICAL_TOKENS),
     ...setTypeTailwindStyles(Array.from(NUMERICS), NUMERIC_TOKENS),
     ...setTypeTailwindStyles(Array.from(TIMESTAMPS), TIMESTAMP_TOKENS),
+    ...setTypeTailwindStyles(Array.from(INTERVALS), INTERVAL_TOKENS),
     ...setTypeTailwindStyles(Array.from(BOOLEANS), CATEGORICAL_TOKENS),
 }

--- a/src/lib/util/formatters.ts
+++ b/src/lib/util/formatters.ts
@@ -1,6 +1,6 @@
+import { INTERVALS, INTEGERS, FLOATS, CATEGORICALS, TIMESTAMPS, BOOLEANS } from "$lib/duckdb-data-types";
 import { format } from "d3-format";
 import { timeFormat } from "d3-time-format";
-
 
 const zeroPad = format('02d');
 export const formatInteger = format(',');
@@ -71,5 +71,21 @@ export function formatCompactInteger(n:number) {
     } else {
         fmt = format('.3s');
         return fmt(n);
+    }
+}
+
+export function formatDataType(value:any, type:string) {
+    if (INTEGERS.has(type)) {
+        return value;
+    } else if (FLOATS.has(type)) {
+        return value;
+    } else if (CATEGORICALS.has(type)) {
+        return value;
+    } else if (TIMESTAMPS.has(type)) {
+        return standardTimestampFormat(value);
+    } else if (INTERVALS.has(type)) {
+        return intervalToTimestring(value);
+    } else if (BOOLEANS.has(type)) {
+        return value;
     }
 }

--- a/src/lib/util/formatters.ts
+++ b/src/lib/util/formatters.ts
@@ -3,6 +3,7 @@ import { format } from "d3-format";
 import { timeFormat } from "d3-time-format";
 
 const zeroPad = format('02d');
+const msPad = format('03d')
 export const formatInteger = format(',');
 const formatRate = format('.1f');
 
@@ -38,14 +39,23 @@ export const standardTimestampFormat = (v, type = 'TIMESTAMP') => {
 export const datePortion = timeFormat('%b %d, %Y');
 export const timePortion = timeFormat("%I:%M:%S");
 
-export function microsToTimestring(micros:number) {
+export function microsToTimestring(microseconds:number) {
     // to format micros, we need to translate this to hh:mm:ss.
     // start with hours/
+    let sign = Math.sign(microseconds);
+    let micros = Math.abs(microseconds);
     const hours = ~~(micros / 1000 / 1000 / 60 / 60);
     let remaining = micros - (hours * 1000 * 1000 * 60 * 60);
     const minutes = ~~(remaining / 1000/ 1000 / 60);
-    const seconds = (remaining - (minutes * 1000 * 1000 * 60)) / 1000 / 1000;
-    return `${zeroPad(hours)}:${zeroPad(minutes)}:${zeroPad(seconds)}`
+    //const seconds = (remaining - (minutes * 1000 * 1000 * 60)) / 1000 / 1000;
+    remaining -= (minutes * 1000 * 1000 * 60);
+    const seconds = ~~(remaining / 1000 / 1000);
+    remaining -= (seconds * 1000 * 1000);
+    const ms = ~~(remaining / 1000);
+    if (hours === 0 && minutes === 0 && seconds === 0 && ms > 0) {
+        return `${sign == 1 ? '' : '-'}${ms}ms`
+    }
+    return `${sign == 1 ? '' : '-'}${zeroPad(hours)}:${zeroPad(minutes)}:${zeroPad(seconds)}.${msPad(ms)}`
 }
 
 interface Interval {
@@ -82,7 +92,7 @@ export function formatDataType(value:any, type:string) {
     } else if (CATEGORICALS.has(type)) {
         return value;
     } else if (TIMESTAMPS.has(type)) {
-        return standardTimestampFormat(value);
+        return standardTimestampFormat(value, type);
     } else if (INTERVALS.has(type)) {
         return intervalToTimestring(value);
     } else if (BOOLEANS.has(type)) {

--- a/src/routes/dev/__layout.svelte
+++ b/src/routes/dev/__layout.svelte
@@ -1,0 +1,3 @@
+<div class='bg-white p-8' style:min-width="100vw" style:min-height="100vh">
+    <slot />
+</div>

--- a/src/routes/dev/data-types.svelte
+++ b/src/routes/dev/data-types.svelte
@@ -1,0 +1,37 @@
+<script>
+import DataTypeIcon from "$lib/components/data-types/DataTypeIcon.svelte"
+import FormattedDataType from "$lib/components/data-types/FormattedDataType.svelte";
+
+const examples = [
+    {value: 10.534234, type:'FLOAT', label: 'float', comment: ''},
+    {value: 53243, type:'INTEGER', label: 'integer'},
+    {value: 'test text', type:'VARCHAR', label: 'varchar'},
+    {value: new Date(), type:'TIMESTAMP', label: 'timestamp'},
+    {value: '1985-12-04', type:'DATE', label: 'date'},
+    {value: {months:0, days:0, micros: 599300}, type:'INTERVAL', label: 'interval (ms)'},
+    {value: {months:0, days:0, micros: 10503020202}, type:'INTERVAL', label: 'interval (inner-day)'},
+    {value: {months:0, days:1, micros: 12345679039}, type:'INTERVAL', label: 'interval (about a day)'},
+    {value: {months:0, days:3, micros: 10503020202}, type:'INTERVAL', label: 'interval (a few days)'},
+    {value: {months:0, days:4*7 + 1, micros: 0}, type:'INTERVAL', label: 'interval (a few weeks)'},
+    {value: {months:0, days:364, micros: 34939439}, type:'INTERVAL', label: 'interval (almost a year)'},
+    {value: {months:0, days:364 * 2.43, micros: 34939439}, type:'INTERVAL', label: 'interval (a few years)'},
+    {value: {months:0, days:364 * 54.43, micros: 34939439}, type:'INTERVAL', label: 'interval (many years)'},
+    {value: null, type:'', label: 'nulls'},
+]
+
+</script>
+<h1 class="pb-4">Data Type Value Representations</h1>
+
+<div class="grid grid-cols-3 w-max gap-x-4">
+    {#each examples as {value, type, label}}
+        <div class="flex items-center gap-x-2 pl-2 pr-2">
+            <DataTypeIcon {type} /> {label}
+        </div>
+        <div class="text-right pl-2 pr-2">
+            <FormattedDataType {value} {type} />
+        </div>
+        <div class="text-right bg-gray-800 pl-2 pr-2">
+            <FormattedDataType {value} {type} dark />
+        </div>
+    {/each}
+</div>


### PR DESCRIPTION
We had a bug report that intervals cause a rendering issue. This PR will:
- create an `INTERVAL` representation in the table + in the profilers
- re-organize and clean up the other formatted datatypes