### PR TITLE
add time grain estimates to column profiling & interface

### DIFF
--- a/src/common/data-modeler-service/ProfileColumnActions.ts
+++ b/src/common/data-modeler-service/ProfileColumnActions.ts
@@ -56,6 +56,16 @@ export class ProfileColumnActions extends DataModelerActions {
         ]);
     }
 
+    private async estimateTimeGrain(entityType: EntityType, entityId: string,
+                                            tableName: string, column: ProfileColumn): Promise<void> {
+            this.dataModelerStateService.dispatch("updateColumnSummary",[
+            entityType, entityId, column.name,
+            await this.databaseActionQueue.enqueue(
+            {id: entityId, priority: ColumnProfilePriorityMap[entityType]},
+            "estimateTimeGrain", [tableName, column.name]),
+        ]);
+    }
+
     private async collectNumericHistogram(entityType: EntityType, entityId: string,
                                           tableName: string, column: ProfileColumn): Promise<void> {
         this.dataModelerStateService.dispatch("updateColumnSummary", [

--- a/src/common/data-modeler-service/ProfileColumnActions.ts
+++ b/src/common/data-modeler-service/ProfileColumnActions.ts
@@ -56,13 +56,13 @@ export class ProfileColumnActions extends DataModelerActions {
         ]);
     }
 
-    private async estimateTimeGrain(entityType: EntityType, entityId: string,
+    private async estimateSmallesTimeGrain(entityType: EntityType, entityId: string,
                                             tableName: string, column: ProfileColumn): Promise<void> {
             this.dataModelerStateService.dispatch("updateColumnSummary",[
             entityType, entityId, column.name,
             await this.databaseActionQueue.enqueue(
             {id: entityId, priority: ColumnProfilePriorityMap[entityType]},
-            "estimateTimeGrain", [tableName, column.name]),
+            "estimateSmallestTimeGrain", [tableName, column.name]),
         ]);
     }
 

--- a/src/common/data-modeler-service/ProfileColumnActions.ts
+++ b/src/common/data-modeler-service/ProfileColumnActions.ts
@@ -38,6 +38,7 @@ export class ProfileColumnActions extends DataModelerActions {
             promises.push(this.collectNumericHistogram(entityType, entityId, tableName, column));
             if (TIMESTAMPS.has(column.type)) {
                 promises.push(this.collectTimeRange(entityType, entityId, tableName, column));
+                promises.push(this.collectSmallestTimegrainEstimate(entityType, entityId, tableName, column));
             } else {
                 promises.push(this.collectDescriptiveStatistics(entityType, entityId, tableName, column));
             }
@@ -56,7 +57,7 @@ export class ProfileColumnActions extends DataModelerActions {
         ]);
     }
 
-    private async estimateSmallesTimeGrain(entityType: EntityType, entityId: string,
+    private async collectSmallestTimegrainEstimate(entityType: EntityType, entityId: string,
                                             tableName: string, column: ProfileColumn): Promise<void> {
             this.dataModelerStateService.dispatch("updateColumnSummary",[
             entityType, entityId, column.name,

--- a/src/common/database-service/DatabaseColumnActions.ts
+++ b/src/common/database-service/DatabaseColumnActions.ts
@@ -7,14 +7,14 @@ import {TIMESTAMPS} from "$lib/duckdb-data-types";
 const TOP_K_COUNT = 50;
 
 export enum TimeGrain {
-  ms = "ms",
-  second = "second",
-  minute = "minute",
-  hour = "hour",
-  day = "day",
-  week = "week",
-  month = "month",
-  year = "year"
+  milliseconds = "milliseconds",
+  seconds = "seconds",
+  minutes = "minutes",
+  hours = "hours",
+  days = "days",
+  weeks = "weeks",
+  months = "months",
+  years = "years"
 }
 
 /**
@@ -113,17 +113,17 @@ export class DatabaseColumnActions extends DatabaseActions {
       )
       SELECT 
         COALESCE(
-            case WHEN ms > 1 THEN 'ms' else NULL END,
-            CASE WHEN second > 1 THEN 'second' else NULL END,
-            CASE WHEN minute > 1 THEN 'minute' else null END,
-            CASE WHEN hour > 1 THEN 'hour' else null END,
+            case WHEN ms > 1 THEN 'milliseconds' else NULL END,
+            CASE WHEN second > 1 THEN 'seconds' else NULL END,
+            CASE WHEN minute > 1 THEN 'minutes' else null END,
+            CASE WHEN hour > 1 THEN 'hours' else null END,
             -- cases above, if equal to 1, then we have some candidates for
             -- bigger time grains. We need to reverse from here
             -- years, months, weeks, days.
-            CASE WHEN dayofyear = 1 and year > 1 THEN 'year' else null END,
-            CASE WHEN (dayofmonth = 1 OR lastdayofmonth) and month > 1 THEN 'month' else null END,
-            CASE WHEN dayofweek = 1 and weekofyear > 1 THEN 'week' else null END,
-            CASE WHEN hour = 1 THEN 'day' else null END
+            CASE WHEN dayofyear = 1 and year > 1 THEN 'years' else null END,
+            CASE WHEN (dayofmonth = 1 OR lastdayofmonth) and month > 1 THEN 'months' else null END,
+            CASE WHEN dayofweek = 1 and weekofyear > 1 THEN 'weeks' else null END,
+            CASE WHEN hour = 1 THEN 'days' else null END
         ) as estimatedSmallestTimeGrain
       FROM time_grains
       `);

--- a/src/common/database-service/DatabaseService.ts
+++ b/src/common/database-service/DatabaseService.ts
@@ -32,7 +32,7 @@ export class DatabaseService implements ActionServiceBase<DatabaseActionsDefinit
         [Action in keyof DatabaseActionsDefinition]?: DatabaseActionsClasses
     } = {};
 
-    public constructor(private readonly databaseClient: DuckDBClient,
+    public constructor(public readonly databaseClient: DuckDBClient,
                        private readonly databaseActions: Array<DatabaseActions>) {
         databaseActions.forEach((actions) => {
             getActionMethods(actions).forEach(action => {

--- a/src/common/database-service/DatabaseService.ts
+++ b/src/common/database-service/DatabaseService.ts
@@ -32,7 +32,7 @@ export class DatabaseService implements ActionServiceBase<DatabaseActionsDefinit
         [Action in keyof DatabaseActionsDefinition]?: DatabaseActionsClasses
     } = {};
 
-    public constructor(public readonly databaseClient: DuckDBClient,
+    public constructor(private readonly databaseClient: DuckDBClient,
                        private readonly databaseActions: Array<DatabaseActions>) {
         databaseActions.forEach((actions) => {
             getActionMethods(actions).forEach(action => {
@@ -43,6 +43,10 @@ export class DatabaseService implements ActionServiceBase<DatabaseActionsDefinit
 
     public async init(): Promise<void> {
         await this.databaseClient?.init();
+    }
+
+    public getDatabaseClient(): DuckDBClient {
+        return this.databaseClient;
     }
 
     /**

--- a/src/lib/components/column-profile/ColumnProfile.svelte
+++ b/src/lib/components/column-profile/ColumnProfile.svelte
@@ -256,6 +256,7 @@ let titleTooltip;
                         width={containerWidth - (indentLevel === 1 ? (20 + 24 + 54 ): 32 + 20)}
                         data={summary.histogram}
                         interval={summary.interval}
+                        estimatedSmallestTimeGrain={summary?.estimatedSmallestTimeGrain}
                     />
                 </div>
             {/if}

--- a/src/lib/components/viz/histogram/TimestampHistogram.svelte
+++ b/src/lib/components/viz/histogram/TimestampHistogram.svelte
@@ -1,4 +1,6 @@
-<script>
+<script lang="ts">
+import Tooltip from "$lib/components/tooltip/Tooltip.svelte";
+import TooltipContent from "$lib/components/tooltip/TooltipContent.svelte";
 import HistogramBase from "./HistogramBase.svelte";
 import { datePortion, timePortion, intervalToTimestring, removeTimezoneOffset } from "$lib/util/formatters";
 import { TIMESTAMP_TOKENS } from "$lib/duckdb-data-types";
@@ -7,14 +9,40 @@ export let type;
 export let interval;
 export let width;
 export let height = 100;
+export let estimatedSmallestTimeGrain:string;
 
 $: effectiveWidth = Math.max(width - 8, 120);
 
 let fontSize = 12;
+
+$: timeLength = interval ? intervalToTimestring(type === "DATE" ? {days: interval, months: 0, micros: 0 } : interval) : undefined;
 </script>
 
 {#if interval}
-<div class="italic pt-1 pb-2">{intervalToTimestring(type === "DATE" ? {days: interval, months: 0, micros: 0 } : interval)}</div>
+<div class="grid space-between grid-cols-2 items-baseline pr-6">
+    <Tooltip location="top" distance={16}>
+    <div class="italic pt-1 pb-2">
+        {timeLength}
+    </div>
+    <TooltipContent slot="tooltip-content">
+        <div style:width="240px">
+            This column represents {timeLength} of data.
+        </div>
+    </TooltipContent>
+    </Tooltip>
+    {#if estimatedSmallestTimeGrain}
+    <Tooltip location="top" distance={16}>
+        <div class="justify-self-end">
+            min grain: {estimatedSmallestTimeGrain}
+        </div>
+    <TooltipContent slot='tooltip-content'>
+        <div style:width="240px">
+            The smallest estimated time granularity of this column is at the <b>{estimatedSmallestTimeGrain}</b> level.
+        </div>
+    </TooltipContent>
+    </Tooltip>
+    {/if}
+</div>
 {/if}
 <HistogramBase separate={width > 300} fillColor={TIMESTAMP_TOKENS.vizFillClass} baselineStrokeColor={TIMESTAMP_TOKENS.vizStrokeClass} {data} left={0} right={0} width={effectiveWidth} {height} bottom={40}>
     <svelte:fragment let:x let:y let:buffer>

--- a/src/lib/components/viz/histogram/TimestampHistogram.svelte
+++ b/src/lib/components/viz/histogram/TimestampHistogram.svelte
@@ -26,18 +26,18 @@ $: timeLength = interval ? intervalToTimestring(type === "DATE" ? {days: interva
     </div>
     <TooltipContent slot="tooltip-content">
         <div style:width="240px">
-            This column represents {timeLength} of data.
+            This column represents <span class='italic'>{timeLength}</span> of data.
         </div>
     </TooltipContent>
     </Tooltip>
     {#if estimatedSmallestTimeGrain}
     <Tooltip location="top" distance={16}>
-        <div class="justify-self-end">
-            min grain: {estimatedSmallestTimeGrain}
+        <div class="justify-self-end text-gray-500 text-right">
+            smallest time grain – <span class='italic'>{estimatedSmallestTimeGrain}</span>
         </div>
     <TooltipContent slot='tooltip-content'>
         <div style:width="240px">
-            The smallest estimated time granularity of this column is at the <b>{estimatedSmallestTimeGrain}</b> level.
+            The smallest estimated time granularity of this column is at the <span class='italic'>{estimatedSmallestTimeGrain}</span> level.
         </div>
     </TooltipContent>
     </Tooltip>

--- a/src/lib/components/viz/histogram/TimestampHistogram.svelte
+++ b/src/lib/components/viz/histogram/TimestampHistogram.svelte
@@ -32,12 +32,12 @@ $: timeLength = interval ? intervalToTimestring(type === "DATE" ? {days: interva
     </Tooltip>
     {#if estimatedSmallestTimeGrain}
     <Tooltip location="top" distance={16}>
-        <div class="justify-self-end text-gray-500 text-right">
-            smallest time grain – <span class='italic'>{estimatedSmallestTimeGrain}</span>
+        <div class="justify-self-end text-gray-500 text-right leading-4">
+            time grain in <span class='italic'>{estimatedSmallestTimeGrain}</span>
         </div>
     <TooltipContent slot='tooltip-content'>
         <div style:width="240px">
-            The smallest estimated time granularity of this column is at the <span class='italic'>{estimatedSmallestTimeGrain}</span> level.
+            The smallest estimated time grain of this column is at the <span class='italic'>{estimatedSmallestTimeGrain}</span> level.
         </div>
     </TooltipContent>
     </Tooltip>
@@ -47,7 +47,7 @@ $: timeLength = interval ? intervalToTimestring(type === "DATE" ? {days: interva
 <HistogramBase separate={width > 300} fillColor={TIMESTAMP_TOKENS.vizFillClass} baselineStrokeColor={TIMESTAMP_TOKENS.vizStrokeClass} {data} left={0} right={0} width={effectiveWidth} {height} bottom={40}>
     <svelte:fragment let:x let:y let:buffer>
         {@const yStart = y.range()[0] + fontSize + buffer * 1.5}
-        {@const yEnd = y.range()[0] + fontSize *2 + buffer * 1.75}
+        {@const yEnd = y.range()[0] + fontSize * 2 + buffer * 1.75}
         {@const xStart = x.range()[0]}
         {@const xEnd = x.range()[1]}
         {@const start = removeTimezoneOffset(new Date(x.domain()[0] * 1000))}

--- a/test/data/TimeGrain.data.ts
+++ b/test/data/TimeGrain.data.ts
@@ -1,0 +1,114 @@
+import type { DataProviderData } from "@adityahegde/typescript-test-utils";=
+import { TimeGrain } from "$common/database-service/DatabaseColumnActions";
+
+export interface GeneratedTimeseriesTestCase {
+    start: string,
+    end: string,
+    interval: string,
+    table: string,
+    expectedTimeGrain: string
+}
+
+export const timeGrainSeriesData:DataProviderData<[GeneratedTimeseriesTestCase]> = { subData: [
+    {
+        title: 'different ms, same day',
+        subData: [{ args: [{
+                table:'ts_ms_01',
+                start: '2021-01-01 01:30:00',
+                end: '2021-01-01 02:00:00',
+                interval: '4 millisecond',
+                expectedTimeGrain: TimeGrain.ms
+            }]}
+        ]
+    },
+    {
+        title: 'ms but over the date border',
+        subData: [{ args: [{
+                table:'ts_ms_03',
+                start: '2021-01-01 23:30:00',
+                end: '2021-01-02 23:30:00',
+                interval: '4 millisecond',
+                expectedTimeGrain: TimeGrain.ms
+            }]}]
+    },
+    {
+        title: 'ts_seconds_01',
+        subData: [{ args: [{
+            table:'ts_seconds_01',
+            start: '2021-01-01 12:30:00',
+            end: '2021-01-01 13:30:00',
+            interval: '2 seconds',
+            expectedTimeGrain: TimeGrain.second
+        }]}]
+    },
+    {
+        title: "ts_minutes_01",
+        subData: [{ args: [{
+            table:'ts_minutes_01',
+            start: '2021-01-01 01:04:04',
+            end: '2021-01-01 09:04:04',
+            interval: '47 minutes',
+            expectedTimeGrain: TimeGrain.minute
+        }]}]
+    },
+    {
+        title: 'ts_hours_01',
+        subData: [{ args: [{
+            table:'ts_hours_01',
+            start: '2021-01-01',
+            end: '2022-01-01',
+            interval: '2 hours',
+            expectedTimeGrain: TimeGrain.hour
+        }]}]
+    },
+    {
+        title: 'ts_days_01',
+        subData: [{ args: [{
+            table:'ts_days_01',
+            start: '2021-01-01',
+            end: '2025-01-01',
+            interval: '3 days',
+            expectedTimeGrain: TimeGrain.day
+        }]}]
+    },
+    {
+        title: 'ts_weeks_01',
+        subData: [{ args: [{
+            table:'ts_weeks_01',
+            start: '1900-01-01',
+            end: '2000-01-01',
+            interval: '7 day',
+            expectedTimeGrain: TimeGrain.week
+        }]}]
+    },
+    {
+        title: 'ts_weeks_02',
+        subData: [{ args: [{
+            table:'ts_weeks_02',
+            start: '1900-01-01',
+            end: '1900-03-01',
+            interval: '7 day',
+            expectedTimeGrain: TimeGrain.week
+        }]}]
+    },
+    {
+        title: "weekly, 100 years",
+        subData: [{ args: [{
+            table:'ts_weeks_03',
+            start: '1900-01-01',
+            end: '2000-01-01',
+            interval: '7 day',
+            expectedTimeGrain: TimeGrain.week
+        }]}]
+    },
+    {
+        title: 'ts_years_01',
+        subData: [{ args: [{
+            table:'ts_years_01',
+            start: '1900-01-01',
+            end: '2000-01-01',
+            interval: '1 year',
+            expectedTimeGrain: TimeGrain.year
+        }]}]
+    },
+]}

--- a/test/data/TimeGrain.data.ts
+++ b/test/data/TimeGrain.data.ts
@@ -1,4 +1,4 @@
-import type { DataProviderData } from "@adityahegde/typescript-test-utils";=
+import type { DataProviderData } from "@adityahegde/typescript-test-utils";
 import { TimeGrain } from "$common/database-service/DatabaseColumnActions";
 
 export interface GeneratedTimeseriesTestCase {

--- a/test/data/TimeGrain.data.ts
+++ b/test/data/TimeGrain.data.ts
@@ -17,7 +17,7 @@ export const timeGrainSeriesData:DataProviderData<[GeneratedTimeseriesTestCase]>
                 start: '2021-01-01 01:30:00',
                 end: '2021-01-01 02:00:00',
                 interval: '4 millisecond',
-                expectedTimeGrain: TimeGrain.ms
+                expectedTimeGrain: TimeGrain.milliseconds
             }]}
         ]
     },
@@ -28,7 +28,7 @@ export const timeGrainSeriesData:DataProviderData<[GeneratedTimeseriesTestCase]>
                 start: '2021-01-01 23:30:00',
                 end: '2021-01-02 23:30:00',
                 interval: '4 millisecond',
-                expectedTimeGrain: TimeGrain.ms
+                expectedTimeGrain: TimeGrain.milliseconds
             }]}]
     },
     {
@@ -38,7 +38,7 @@ export const timeGrainSeriesData:DataProviderData<[GeneratedTimeseriesTestCase]>
             start: '2021-01-01 12:30:00',
             end: '2021-01-01 13:30:00',
             interval: '2 seconds',
-            expectedTimeGrain: TimeGrain.second
+            expectedTimeGrain: TimeGrain.seconds
         }]}]
     },
     {
@@ -48,7 +48,7 @@ export const timeGrainSeriesData:DataProviderData<[GeneratedTimeseriesTestCase]>
             start: '2021-01-01 01:04:04',
             end: '2021-01-01 09:04:04',
             interval: '47 minutes',
-            expectedTimeGrain: TimeGrain.minute
+            expectedTimeGrain: TimeGrain.minutes
         }]}]
     },
     {
@@ -58,7 +58,7 @@ export const timeGrainSeriesData:DataProviderData<[GeneratedTimeseriesTestCase]>
             start: '2021-01-01',
             end: '2022-01-01',
             interval: '2 hours',
-            expectedTimeGrain: TimeGrain.hour
+            expectedTimeGrain: TimeGrain.hours
         }]}]
     },
     {
@@ -68,7 +68,7 @@ export const timeGrainSeriesData:DataProviderData<[GeneratedTimeseriesTestCase]>
             start: '2021-01-01',
             end: '2025-01-01',
             interval: '3 days',
-            expectedTimeGrain: TimeGrain.day
+            expectedTimeGrain: TimeGrain.days
         }]}]
     },
     {
@@ -78,7 +78,7 @@ export const timeGrainSeriesData:DataProviderData<[GeneratedTimeseriesTestCase]>
             start: '1900-01-01',
             end: '2000-01-01',
             interval: '7 day',
-            expectedTimeGrain: TimeGrain.week
+            expectedTimeGrain: TimeGrain.weeks
         }]}]
     },
     {
@@ -88,7 +88,7 @@ export const timeGrainSeriesData:DataProviderData<[GeneratedTimeseriesTestCase]>
             start: '1900-01-01',
             end: '1900-03-01',
             interval: '7 day',
-            expectedTimeGrain: TimeGrain.week
+            expectedTimeGrain: TimeGrain.weeks
         }]}]
     },
     {
@@ -98,7 +98,17 @@ export const timeGrainSeriesData:DataProviderData<[GeneratedTimeseriesTestCase]>
             start: '1900-01-01',
             end: '2000-01-01',
             interval: '7 day',
-            expectedTimeGrain: TimeGrain.week
+            expectedTimeGrain: TimeGrain.weeks
+        }]}]
+    },
+    {
+        title: "once every two months, 100 years",
+        subData: [{ args: [{
+            table:'ts_months_01',
+            start: '1900-01-01',
+            end: '2000-01-01',
+            interval: '2 month',
+            expectedTimeGrain: TimeGrain.months
         }]}]
     },
     {
@@ -108,7 +118,7 @@ export const timeGrainSeriesData:DataProviderData<[GeneratedTimeseriesTestCase]>
             start: '1900-01-01',
             end: '2000-01-01',
             interval: '1 year',
-            expectedTimeGrain: TimeGrain.year
+            expectedTimeGrain: TimeGrain.years
         }]}]
     },
 ]}

--- a/test/functional/EstimateSmallestTimeGrain.spec.ts
+++ b/test/functional/EstimateSmallestTimeGrain.spec.ts
@@ -32,7 +32,6 @@ export class EstimateSmallestTimeGrainSpec extends FunctionalTestBase  {
             state: new StateConfig({ autoSync: true, syncInterval: 50 }),
             projectFolder: SYNC_TEST_FOLDER, profileWithUpdate: false,
         });
-        await super.setup(config);
         const secondServerInstances = dataModelerServiceFactory(config);
         this.databaseService = secondServerInstances.dataModelerService.getDatabaseService();
         await this.databaseService.init();

--- a/test/functional/EstimateSmallestTimeGrain.spec.ts
+++ b/test/functional/EstimateSmallestTimeGrain.spec.ts
@@ -41,7 +41,6 @@ export class EstimateSmallestTimeGrainSpec extends FunctionalTestBase  {
 
     @TestBase.Test("seriesGeneratedTimegrainData")
     public async shouldIdentifyTimegrain(args:GeneratedTimeseriesTestCase) {
-        // @ts-ignore
         await this.databaseService.databaseClient.execute(generateSeries(args.table, args.start, args.end, args.interval));
         const result = await this.databaseService.dispatch("estimateSmallestTimeGrain", [args.table, "ts"]) as { estimatedSmallestTimeGrain: TimeGrain };
         expect(args.expectedTimeGrain).toBe(result.estimatedSmallestTimeGrain);

--- a/test/functional/EstimateSmallestTimeGrain.spec.ts
+++ b/test/functional/EstimateSmallestTimeGrain.spec.ts
@@ -1,4 +1,4 @@
-import { DataProviderData, TestBase } from "@adityahegde/typescript-test-utils";=
+import { DataProviderData, TestBase } from "@adityahegde/typescript-test-utils";
 import { FunctionalTestBase } from "./FunctionalTestBase";
 import type { DatabaseService } from "$common/database-service/DatabaseService";
 import type { TimeGrain } from "$common/database-service/DatabaseColumnActions";
@@ -41,10 +41,9 @@ export class StateSyncServiceSpec extends FunctionalTestBase  {
 
     @TestBase.Test("seriesGeneratedTimegrainData")
     public async shouldIdentifyTimegrain(args:GeneratedTimeseriesTestCase) {
-        // generate the temporary table.
         // @ts-ignore
         await this.databaseService.databaseClient.execute(generateSeries(args.table, args.start, args.end, args.interval));
-        const timeGrain = await this.databaseService.dispatch("estimateTimeGrain", [args.table, "ts"]) as TimeGrain;
-        expect(args.expectedTimeGrain).toBe(timeGrain);
+        const result = await this.databaseService.dispatch("estimateSmallestTimeGrain", [args.table, "ts"]) as { estimatedSmallestTimeGrain: TimeGrain };
+        expect(args.expectedTimeGrain).toBe(result.estimatedSmallestTimeGrain);
     }
 }

--- a/test/functional/EstimateSmallestTimeGrain.spec.ts
+++ b/test/functional/EstimateSmallestTimeGrain.spec.ts
@@ -21,7 +21,7 @@ function generateSeries(table:string, start:string, end:string, interval:string)
 }
 
 @FunctionalTestBase.Suite
-export class StateSyncServiceSpec extends FunctionalTestBase  {
+export class EstimateSmallestTimeGrainSpec extends FunctionalTestBase  {
     protected databaseService: DatabaseService;
 
     public async setup(): Promise<void> {

--- a/test/functional/EstimateTimeGrain.spec.ts
+++ b/test/functional/EstimateTimeGrain.spec.ts
@@ -1,0 +1,161 @@
+import { DataProviderData, TestBase } from "@adityahegde/typescript-test-utils";
+import { JestTestLibrary } from "@adityahegde/typescript-test-utils/dist/jest/JestTestLibrary";
+import { FunctionalTestBase } from "./FunctionalTestBase";
+import type { DatabaseActionsDefinition, DatabaseService } from "$common/database-service/DatabaseService";
+import { RootConfig } from "$common/config/RootConfig";
+import { DatabaseConfig } from "$common/config/DatabaseConfig";
+import { StateConfig } from "$common/config/StateConfig";
+import { dataModelerServiceFactory } from "$common/serverFactory";
+
+interface GeneratedTimeseriesTestCase {
+    start: string,
+    end: string,
+    interval: string,
+    table: string,
+    expectedTimeGrain: string
+}
+
+const SYNC_TEST_FOLDER = "temp/sync-test";
+
+function ctas(table, select_statement, temp = true) {
+    return `CREATE ${temp ? 'TEMPORARY' : ''} VIEW ${table} AS (${select_statement})`
+}
+
+function generateSeries(table:string, start:string, end:string, interval:string) {
+    return ctas(table, `SELECT generate_series as ts from generate_series(TIMESTAMP '${start}', TIMESTAMP '${end}', interval ${interval})`)
+}
+
+const subData = { subData: [
+    {
+        title: 'different ms, same day',
+        subData: [{ args: [{
+                table:'ts_ms_01',
+                start: '2021-01-01 01:30:00',
+                end: '2021-01-01 02:00:00',
+                interval: '4 millisecond',
+                expectedTimeGrain: 'ms'
+            }]}
+        ]
+    },
+    {
+        title: 'ms but over the date border',
+        subData: [{ args: [{
+                table:'ts_ms_03',
+                start: '2021-01-01 23:30:00',
+                end: '2021-01-02 23:30:00',
+                interval: '4 millisecond',
+                expectedTimeGrain: 'ms'
+            }]}]
+    },
+    {
+        title: '',
+        subData: [{ args: [{
+            table:'ts_seconds_01',
+            start: '2021-01-01 12:30:00',
+            end: '2021-01-01 13:30:00',
+            interval: '2 seconds',
+            expectedTimeGrain: 'second'
+        }]}]
+    },
+    {
+        title: '',
+        subData: [{ args: [{
+            table:'ts_minutes_01',
+            start: '2021-01-01 01:04:04',
+            end: '2021-01-01 09:04:04',
+            interval: '47 minutes',
+            expectedTimeGrain: 'minute'
+        }]}]
+    },
+    {
+        title: '',
+        subData: [{ args: [{
+            table:'ts_hours_01',
+            start: '2021-01-01',
+            end: '2022-01-01',
+            interval: '2 hours',
+            expectedTimeGrain: 'hour'
+        }]}]
+    },
+    {
+        title: '',
+        subData: [{ args: [{
+            table:'ts_days_01',
+            start: '2021-01-01',
+            end: '2025-01-01',
+            interval: '3 days',
+            expectedTimeGrain: 'day'
+        }]}]
+    },
+    {
+        title: '',
+        subData: [{ args: [{
+            table:'ts_weeks_01',
+            start: '1900-01-01',
+            end: '2000-01-01',
+            interval: '7 day',
+            expectedTimeGrain: 'week'
+        }]}]
+    },
+    {
+        title: '',
+        subData: [{ args: [{
+            table:'ts_weeks_02',
+            start: '1900-01-01',
+            end: '1900-03-01',
+            interval: '7 day',
+            expectedTimeGrain: 'week'
+        }]}]
+    },
+    {
+        title: '',
+        subData: [{ args: [{
+            title: "weekly, 100 years",
+            table:'ts_weeks_03',
+            start: '1900-01-01',
+            end: '2000-01-01',
+            interval: '7 day',
+            expectedTimeGrain: 'week'
+        }]}]
+    },
+    {
+        title: '',
+        subData: [{ args: [{
+            table:'ts_years_01',
+            start: '1900-01-01',
+            end: '2000-01-01',
+            interval: '1 year',
+            expectedTimeGrain: 'year'
+        }]}]
+    },
+]} as DataProviderData<[GeneratedTimeseriesTestCase]>
+
+@FunctionalTestBase.Suite
+export class StateSyncServiceSpec extends FunctionalTestBase  {
+    protected databaseService: DatabaseService;
+
+    public async setup(): Promise<void> {
+        const config = new RootConfig({
+            database: new DatabaseConfig({ databaseName: ":memory:" }),
+            state: new StateConfig({ autoSync: true, syncInterval: 50 }),
+            projectFolder: SYNC_TEST_FOLDER, profileWithUpdate: false,
+        });
+        await super.setup(config);
+        const secondServerInstances = dataModelerServiceFactory(config);
+        this.databaseService = secondServerInstances.dataModelerService.getDatabaseService();
+        await this.databaseService.init();
+    }
+    public seriesGeneratedTimegrainData(): DataProviderData<[GeneratedTimeseriesTestCase]> {
+        return subData;
+    }
+
+    @TestBase.Test("seriesGeneratedTimegrainData")
+    public async shouldIdentifyTimegrain(args:GeneratedTimeseriesTestCase) {
+        console.log(args.table)
+        // generate the temporary table.
+        // @ts-ignore
+        await this.databaseService.databaseClient.execute(generateSeries(args.table, args.start, args.end, args.interval));
+        const {timeGrain} = await this.databaseService.dispatch("estimateTimeGrain", [args.table, "ts"]);
+        expect(args.expectedTimeGrain).toBe(timeGrain);
+    }
+}

--- a/test/functional/EstimateTimeGrain.spec.ts
+++ b/test/functional/EstimateTimeGrain.spec.ts
@@ -1,19 +1,14 @@
-import { DataProviderData, TestBase } from "@adityahegde/typescript-test-utils";
-import { JestTestLibrary } from "@adityahegde/typescript-test-utils/dist/jest/JestTestLibrary";
+import { DataProviderData, TestBase } from "@adityahegde/typescript-test-utils";=
 import { FunctionalTestBase } from "./FunctionalTestBase";
-import type { DatabaseActionsDefinition, DatabaseService } from "$common/database-service/DatabaseService";
+import type { DatabaseService } from "$common/database-service/DatabaseService";
+import type { TimeGrain } from "$common/database-service/DatabaseColumnActions";
 import { RootConfig } from "$common/config/RootConfig";
 import { DatabaseConfig } from "$common/config/DatabaseConfig";
 import { StateConfig } from "$common/config/StateConfig";
 import { dataModelerServiceFactory } from "$common/serverFactory";
 
-interface GeneratedTimeseriesTestCase {
-    start: string,
-    end: string,
-    interval: string,
-    table: string,
-    expectedTimeGrain: string
-}
+import { timeGrainSeriesData } from "../data/TimeGrain.data"
+import type { GeneratedTimeseriesTestCase } from "../data/TimeGrain.data"
 
 const SYNC_TEST_FOLDER = "temp/sync-test";
 
@@ -24,111 +19,6 @@ function ctas(table, select_statement, temp = true) {
 function generateSeries(table:string, start:string, end:string, interval:string) {
     return ctas(table, `SELECT generate_series as ts from generate_series(TIMESTAMP '${start}', TIMESTAMP '${end}', interval ${interval})`)
 }
-
-const subData = { subData: [
-    {
-        title: 'different ms, same day',
-        subData: [{ args: [{
-                table:'ts_ms_01',
-                start: '2021-01-01 01:30:00',
-                end: '2021-01-01 02:00:00',
-                interval: '4 millisecond',
-                expectedTimeGrain: 'ms'
-            }]}
-        ]
-    },
-    {
-        title: 'ms but over the date border',
-        subData: [{ args: [{
-                table:'ts_ms_03',
-                start: '2021-01-01 23:30:00',
-                end: '2021-01-02 23:30:00',
-                interval: '4 millisecond',
-                expectedTimeGrain: 'ms'
-            }]}]
-    },
-    {
-        title: '',
-        subData: [{ args: [{
-            table:'ts_seconds_01',
-            start: '2021-01-01 12:30:00',
-            end: '2021-01-01 13:30:00',
-            interval: '2 seconds',
-            expectedTimeGrain: 'second'
-        }]}]
-    },
-    {
-        title: '',
-        subData: [{ args: [{
-            table:'ts_minutes_01',
-            start: '2021-01-01 01:04:04',
-            end: '2021-01-01 09:04:04',
-            interval: '47 minutes',
-            expectedTimeGrain: 'minute'
-        }]}]
-    },
-    {
-        title: '',
-        subData: [{ args: [{
-            table:'ts_hours_01',
-            start: '2021-01-01',
-            end: '2022-01-01',
-            interval: '2 hours',
-            expectedTimeGrain: 'hour'
-        }]}]
-    },
-    {
-        title: '',
-        subData: [{ args: [{
-            table:'ts_days_01',
-            start: '2021-01-01',
-            end: '2025-01-01',
-            interval: '3 days',
-            expectedTimeGrain: 'day'
-        }]}]
-    },
-    {
-        title: '',
-        subData: [{ args: [{
-            table:'ts_weeks_01',
-            start: '1900-01-01',
-            end: '2000-01-01',
-            interval: '7 day',
-            expectedTimeGrain: 'week'
-        }]}]
-    },
-    {
-        title: '',
-        subData: [{ args: [{
-            table:'ts_weeks_02',
-            start: '1900-01-01',
-            end: '1900-03-01',
-            interval: '7 day',
-            expectedTimeGrain: 'week'
-        }]}]
-    },
-    {
-        title: '',
-        subData: [{ args: [{
-            title: "weekly, 100 years",
-            table:'ts_weeks_03',
-            start: '1900-01-01',
-            end: '2000-01-01',
-            interval: '7 day',
-            expectedTimeGrain: 'week'
-        }]}]
-    },
-    {
-        title: '',
-        subData: [{ args: [{
-            table:'ts_years_01',
-            start: '1900-01-01',
-            end: '2000-01-01',
-            interval: '1 year',
-            expectedTimeGrain: 'year'
-        }]}]
-    },
-]} as DataProviderData<[GeneratedTimeseriesTestCase]>
 
 @FunctionalTestBase.Suite
 export class StateSyncServiceSpec extends FunctionalTestBase  {
@@ -146,16 +36,15 @@ export class StateSyncServiceSpec extends FunctionalTestBase  {
         await this.databaseService.init();
     }
     public seriesGeneratedTimegrainData(): DataProviderData<[GeneratedTimeseriesTestCase]> {
-        return subData;
+        return timeGrainSeriesData;
     }
 
     @TestBase.Test("seriesGeneratedTimegrainData")
     public async shouldIdentifyTimegrain(args:GeneratedTimeseriesTestCase) {
-        console.log(args.table)
         // generate the temporary table.
         // @ts-ignore
         await this.databaseService.databaseClient.execute(generateSeries(args.table, args.start, args.end, args.interval));
-        const {timeGrain} = await this.databaseService.dispatch("estimateTimeGrain", [args.table, "ts"]);
+        const timeGrain = await this.databaseService.dispatch("estimateTimeGrain", [args.table, "ts"]) as TimeGrain;
         expect(args.expectedTimeGrain).toBe(timeGrain);
     }
 }


### PR DESCRIPTION
<img width="601" alt="Screen Shot 2022-04-04 at 7 11 07 PM" src="https://user-images.githubusercontent.com/95735/161665466-8c41cf99-7a57-4604-a633-76b824be6e37.png">

We've come up with a pretty simple heuristic for estimating the smallest time grain of a `TIMESTAMP` column in duckdb. This is part of our general improvements to profiling time columns which will include an M4-like reduction of the line series. This PR implements the estimation heuristic into our services layer.

- [x] write new `EstimateTimeGrain` database column action
- [x] integrate the column action into the profiling flow
- [x] add estimated time grain into the interface
- [x] add tests for new database column action
- [x] verify test structure before merge