### PR TITLE
DRAFT [incomplete]: fix table import issues

### DIFF
--- a/src/common/database-service/DatabaseDataLoaderActions.ts
+++ b/src/common/database-service/DatabaseDataLoaderActions.ts
@@ -7,16 +7,39 @@ import type {DatabaseMetadata} from "$common/database-service/DatabaseMetadata";
  * WASM version will change how the file is read.
  */
 export class DatabaseDataLoaderActions extends DatabaseActions {
+    private async importWithQuery(metadata: DatabaseMetadata, tableName: string, query: string): Promise<any> {
+        // check if table exists.
+        const tables = await this.databaseClient.execute('SHOW TABLES');
+        const tableIsPresent = tables.some(table => table.name = tableName);
+        // if table does exist, let's put it in a temporary place during import.
+        // if there is an error, we should rename the temp table back to its original one.
+        if (tableIsPresent) {
+            await this.databaseClient.execute(`ALTER TABLE ${tableName} RENAME TO ${tableName}___;`);    
+        }
+        try {
+            const outcome = await this.databaseClient.execute(query);
+            // we are finished with that temporary table, so let's drop it.
+            if (tableIsPresent) {
+                await this.databaseClient.execute(`DROP TABLE IF EXISTS ${tableName}___;`);
+            }
+            return outcome;
+        } catch (err) {
+            // let's make sure the table is renamed back to the original if there's an error.
+            if (tableIsPresent) {
+                await this.databaseClient.execute(`ALTER TABLE ${tableName}___ RENAME TO ${tableName};`);
+            }
+            throw err;
+        }
+    }
+
     public async importParquetFile(metadata: DatabaseMetadata, parquetFile: string, tableName: string): Promise<any> {
-        await this.databaseClient.execute(`DROP TABLE IF EXISTS ${tableName};`);
-        return await this.databaseClient.execute(`CREATE TABLE ${tableName} AS SELECT * FROM '${parquetFile}';`);
+        return this.importWithQuery(metadata, tableName, `CREATE TABLE ${tableName} AS SELECT * FROM '${parquetFile}';`)
     }
 
     public async importCSVFile(metadata: DatabaseMetadata, csvFile: string,
                                tableName: string, delimiter: string): Promise<void> {
-        await this.databaseClient.execute(`DROP TABLE IF EXISTS ${tableName};`);
-        return await this.databaseClient.execute(`CREATE TABLE ${tableName} AS SELECT * FROM ` +
-            `read_csv_auto('${csvFile}', header=true ${delimiter ? `,delim='${delimiter}'`: ""});`);
+        return this.importWithQuery(metadata, tableName, `CREATE TABLE ${tableName} AS SELECT * FROM 
+        read_csv_auto('${csvFile}', header=true ${delimiter ? `,delim='${delimiter}'`: ""});`);
     }
 
     public async getDestinationSize(metadata: DatabaseMetadata, path: string): Promise<number> {


### PR DESCRIPTION
some ideas about how to solve our table import issues:
- when we try to replace a table with another on import, we should not drop the existing table, but rename it. That way, if the new table import doesn't work, we can revert bak to the other table
- when a table is malformed (e.g. a bad csv), we should also not be creating a new table state object / replacing an existing one.

This PR fixes the first one