### PR TITLE
add default value for prop

### DIFF
--- a/src/lib/components/surface/SurfaceControlButton.svelte
+++ b/src/lib/components/surface/SurfaceControlButton.svelte
@@ -6,7 +6,7 @@ import Tooltip from "$lib/components/tooltip/Tooltip.svelte";
 import TooltipContent from "$lib/components/tooltip/TooltipContent.svelte";
 export let show = false;
 export let left;
-export let right;
+export let right = undefined;
 export let top = "calc(var(--header-height) / 2 - 24px / 2)";
 </script>
 


### PR DESCRIPTION
fixes console warning about missing prop in `index.svelte`