### PR TITLE
remove unusable prop for NavEntry in CollapsibleTableSummary

### DIFF
--- a/src/lib/components/column-profile/CollapsibleTableSummary.svelte
+++ b/src/lib/components/column-profile/CollapsibleTableSummary.svelte
@@ -152,7 +152,7 @@ let titleElementHovered = false;
             // pass up expand
             dispatch('expand');
         }}
-        {icon} >
+        >
         <svelte:fragment slot='tooltip-content'>
             <TooltipTitle>
                 <svelte:fragment slot="name">


### PR DESCRIPTION
Fix console.warn "<NavEntry> was created with unknown prop 'icon'"