### PR TITLE
fix console warning for CollapsibleTableSummary

### DIFF
--- a/src/lib/components/column-profile/CollapsibleTableSummary.svelte
+++ b/src/lib/components/column-profile/CollapsibleTableSummary.svelte
@@ -34,13 +34,13 @@ import notificationStore from "$lib/components/notifications/";
 import { onClickOutside } from "$lib/util/on-click-outside";
 import { config } from "./utils";
 
-export let icon:SvelteComponent;
+export let icon:SvelteComponent = undefined;
 export let name:string;
-export let path:string;
+export let path:string = undefined;
 export let cardinality:number;
 export let profile:any;
 export let head:any; // FIXME
-export let sizeInBytes:number;
+export let sizeInBytes:number = undefined;
 export let emphasizeTitle:boolean = false;
 export let draggable = true;
 export let show = false;

--- a/src/routes/_surfaces/assets/index.svelte
+++ b/src/routes/_surfaces/assets/index.svelte
@@ -151,8 +151,9 @@ let view = 'assets';
                   cardinality={derivedModel?.cardinality ?? 0}
                   profile={derivedModel?.profile ?? []}
                   head={derivedModel?.preview ?? []}
-                  sizeInByptes={derivedModel?.sizeInBytes ?? 0}
-                  emphasizeTitle ={query?.id === $store?.activeEntity?.id}
+                  sizeInBytes={derivedModel?.sizeInBytes ?? 0}
+                  emphasizeTitle ={
+                  query?.id === $store?.activeEntity?.id}
                 />
               {/each}
               </div>


### PR DESCRIPTION
Add default `undefined` props to clear console warnings:
<CollapsibleTableSummary> was created without expected prop 'icon'
<CollapsibleTableSummary> was created without expected prop 'path'
<CollapsibleTableSummary> was created without expected prop 'sizeInBytes'

Fix typo resulting in warning
<CollapsibleTableSummary> was created with unknown prop 'sizeInByptes'