### PR TITLE
remove invalid props from <TableHeader> invocation

### DIFF
--- a/src/lib/components/table/PreviewTableHeader.svelte
+++ b/src/lib/components/table/PreviewTableHeader.svelte
@@ -21,7 +21,7 @@ const dispatch = createEventDispatcher();
 const { shiftClickAction } = createShiftClickAction();
 </script>
 
-<TableHeader {name} {type}>
+<TableHeader>
     <div 
        style:grid-template-columns="210px max-content"
        use:shiftClickAction


### PR DESCRIPTION
Fixes console warnings:
<TableHeader> was created with unknown prop 'name'
<TableHeader> was created with unknown prop 'type'