### PR TITLE
DM-415 remove build script in favor of `svelte-kit build`

### DIFF
--- a/build-tools/build.sh
+++ b/build-tools/build.sh
@@ -1,5 +1,0 @@
-if ! output=$(svelte-kit build  2>&1); then 
-    echo "$output"
-    exit 2
-fi
-echo "Built Rill Developer!"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"scripts": {
 		"dev": "svelte-kit dev",
-		"build": "./build-tools/build.sh && tsc --project tsconfig.node.json",
+		"build": "svelte-kit build && tsc --project tsconfig.node.json",
 		"prepack": "./build-tools/replace_package_type.sh module commonjs",
 		"postpack": "./build-tools/replace_package_type.sh commonjs module",
 		"postinstall": "ts-node-dev --quiet --project tsconfig.node.json src/cli/post-install.ts",


### PR DESCRIPTION
Running `npm run build` now shows output of `svelte-kit build`. See:

<img width="1061" alt="image" src="https://user-images.githubusercontent.com/14206386/166289929-cb9ab50b-68ab-4515-b127-1731ad99b6e3.png">