### PR TITLE
Using sveltkit hooks to start the socket server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "@rilldata/rill-developer",
+	"name": "@rilldata/rill",
 	"version": "0.1.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "@rilldata/rill-developer",
+			"name": "@rilldata/rill",
 			"version": "0.1.0",
 			"hasInstallScript": true,
 			"dependencies": {
@@ -35,7 +35,7 @@
 				"svelte": "^3.46.4"
 			},
 			"bin": {
-				"rill-developer": "dist/cli/data-modeler-cli.js"
+				"rill": "dist/cli/data-modeler-cli.js"
 			},
 			"devDependencies": {
 				"@adityahegde/typescript-test-utils": "^1.3.2",

--- a/src/common/serverFactory.ts
+++ b/src/common/serverFactory.ts
@@ -38,6 +38,13 @@ import { RillIntakeClient } from "$common/metrics-service/RillIntakeClient";
 import { existsSync, readFileSync } from "fs";
 import { LocalConfigFile } from "$common/config/ConfigFolders";
 
+let PACKAGE_JSON = "";
+try {
+    PACKAGE_JSON = __dirname + "/../../package.json";
+} catch (err) {
+    PACKAGE_JSON = "package.json";
+}
+
 export function databaseServiceFactory(config: RootConfig) {
     const duckDbClient = new DuckDBClient(config.database);
     const databaseDataLoaderActions = new DatabaseDataLoaderActions(config.database, duckDbClient);
@@ -74,7 +81,7 @@ export function dataModelerServiceFactory(config: RootConfig) {
         config.local = JSON.parse(readFileSync(LocalConfigFile).toString());
     }
     try {
-        config.local.version = JSON.parse(readFileSync(__dirname + "/../../package.json").toString()).version;
+        config.local.version = JSON.parse(readFileSync(PACKAGE_JSON).toString()).version;
     } catch (err) {
         console.error(err);
     }

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,0 +1,28 @@
+import {RootConfig} from "$common/config/RootConfig";
+import {RillDeveloper} from "$common/RillDeveloper";
+import {SocketServer} from "$common/socket/SocketServer";
+
+/**
+ * Sveltekit hook to start the dev UI + server at the same time
+ */
+
+const config = new RootConfig({});
+const rillDeveloper = RillDeveloper.getRillDeveloper(config);
+const socketServer =  new SocketServer(config, rillDeveloper.dataModelerService,
+    rillDeveloper.dataModelerStateService, rillDeveloper.metricsService);
+let socketStarted = false;
+
+async function startSocket() {
+    if (socketStarted) return;
+    socketStarted = true;
+
+    await rillDeveloper.init();
+    await socketServer.init();
+    socketServer.getSocketServer().listen(config.server.socketPort);
+}
+
+/** @type {import('@sveltejs/kit').Handle} */
+export async function handle({ resolve, request }) {
+    await startSocket()
+    return resolve(request);
+}

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,4 +1,3 @@
-//import adapter from '@sveltejs/adapter-auto';
 import adapter from '@sveltejs/adapter-static';
 import preprocess from 'svelte-preprocess';
 import { resolve } from "path";


### PR DESCRIPTION
Using sveltekit's handleEvent hook to handle any request to start the backend server if it has not already started. 