### PR TITLE
change Immer's `produce` from a default to named import

### DIFF
--- a/src/common/data-modeler-state-service/entity-state-service/EntityStateService.ts
+++ b/src/common/data-modeler-state-service/entity-state-service/EntityStateService.ts
@@ -1,53 +1,53 @@
-import { writable, get } from "svelte/store";
-import type {Writable} from "svelte/store";
-import { shallowCopy } from "$common/utils/shallowCopy";
-import produce, { applyPatches } from "immer";
-import type {Patch} from "immer";
+import { writable, get } from 'svelte/store';
+import type { Writable } from 'svelte/store';
+import { shallowCopy } from '$common/utils/shallowCopy';
+import { applyPatches, produce } from 'immer';
+import type { Patch } from 'immer';
 
 export enum EntityType {
-    Table = "Table",
-    Model = "Model",
-    Application = "Application",
+	Table = 'Table',
+	Model = 'Model',
+	Application = 'Application'
 }
 
 export enum StateType {
-    Persistent = "Persistent",
-    Derived = "Derived",
+	Persistent = 'Persistent',
+	Derived = 'Derived'
 }
 export const AllStateTypes = [StateType.Persistent, StateType.Derived];
 
 export interface EntityRecord {
-    id: string;
-    type: EntityType;
-    lastUpdated: number;
+	id: string;
+	type: EntityType;
+	lastUpdated: number;
 }
 
 export enum EntityStatus {
-    Idle,
-    Running,
+	Idle,
+	Running,
 
-    Importing,
-    Validating,
-    Profiling,
-    Exporting,
+	Importing,
+	Validating,
+	Profiling,
+	Exporting
 }
 export interface DerivedEntityRecord extends EntityRecord {
-    status: EntityStatus;
+	status: EntityStatus;
 }
 
 export interface EntityState<Entity extends EntityRecord> {
-    entities: Array<Entity>;
-    lastUpdated: number;
+	entities: Array<Entity>;
+	lastUpdated: number;
 }
 
 export type EntityStateActionArg<
-    Entity extends EntityRecord,
-    State extends EntityState<Entity> = EntityState<Entity>,
-    Service extends EntityStateService<Entity, State> = EntityStateService<Entity, State>
+	Entity extends EntityRecord,
+	State extends EntityState<Entity> = EntityState<Entity>,
+	Service extends EntityStateService<Entity, State> = EntityStateService<Entity, State>
 > = {
-    stateService: Service;
-    draftState: State;
-}
+	stateService: Service;
+	draftState: State;
+};
 
 /**
  * Each entity will have Persistent or Derived states. (Could be more, depends on {@link StateType} enum)
@@ -57,105 +57,129 @@ export type EntityStateActionArg<
  * Has CRUD methods. Can be overridden later on to fetch from a DB or an API.
  */
 export abstract class EntityStateService<
-    Entity extends EntityRecord,
-    State extends EntityState<Entity> = EntityState<Entity>,
+	Entity extends EntityRecord,
+	State extends EntityState<Entity> = EntityState<Entity>
 > {
-    public store: Writable<State>;
+	public store: Writable<State>;
 
-    public readonly entityType: EntityType;
-    public readonly stateType: StateType;
+	public readonly entityType: EntityType;
+	public readonly stateType: StateType;
 
-    public constructor() {
-        // need an empty state for UI where state init is async but component init is not
-        this.init({entities: [], lastUpdated: 0} as State);
-    }
+	public constructor() {
+		// need an empty state for UI where state init is async but component init is not
+		this.init({ entities: [], lastUpdated: 0 } as State);
+	}
 
-    public init(initialState: State): void {
-        this.store = writable(initialState);
-    }
+	public init(initialState: State): void {
+		this.store = writable(initialState);
+	}
 
-    public getCurrentState(): State {
-        return get(this.store);
-    }
+	public getCurrentState(): State {
+		return get(this.store);
+	}
 
-    public getEmptyState(): State {
-        return {lastUpdated: 0, entities: []} as State;
-    }
+	public getEmptyState(): State {
+		return { lastUpdated: 0, entities: [] } as State;
+	}
 
-    public updateState(draftModCallback: (draft: State) => void,
-                       pathCallback: (patches: Array<Patch>) => void): void {
-        this.store.set(produce(this.getCurrentState(), (draft) => {
-            draftModCallback(draft as any);
-        }, pathCallback));
-    }
+	public updateState(
+		draftModCallback: (draft: State) => void,
+		pathCallback: (patches: Array<Patch>) => void
+	): void {
+		this.store.set(
+			produce(
+				this.getCurrentState(),
+				(draft) => {
+					draftModCallback(draft as any);
+				},
+				pathCallback
+			)
+		);
+	}
 
-    public applyPatches(patches: Array<Patch>): void {
-        this.store.set(applyPatches(this.getCurrentState(), patches));
-    }
+	public applyPatches(patches: Array<Patch>): void {
+		this.store.set(applyPatches(this.getCurrentState(), patches));
+	}
 
-    public getById(id: string, state: State = this.getCurrentState()): Entity {
-        return state.entities.find(entity => entity.id === id);
-    }
+	public getById(id: string, state: State = this.getCurrentState()): Entity {
+		return state.entities.find((entity) => entity.id === id);
+	}
 
-    public getByField<Field extends keyof Entity>(field: Field, value: Entity[Field],
-                                                  state: State = this.getCurrentState()): Entity {
-        return state.entities.find(entity => entity[field] === value);
-    }
+	public getByField<Field extends keyof Entity>(
+		field: Field,
+		value: Entity[Field],
+		state: State = this.getCurrentState()
+	): Entity {
+		return state.entities.find((entity) => entity[field] === value);
+	}
 
-    public addEntity(draftState: State, newEntity: Entity, atIndex?: number): void {
-        // TODO: validate id conflicts
-        if (atIndex) {
-            draftState.entities.splice(atIndex, 0, newEntity);
-        }
-        else {
-            draftState.entities.push(newEntity);
-        }
-    }
+	public addEntity(draftState: State, newEntity: Entity, atIndex?: number): void {
+		// TODO: validate id conflicts
+		if (atIndex) {
+			draftState.entities.splice(atIndex, 0, newEntity);
+		} else {
+			draftState.entities.push(newEntity);
+		}
+	}
 
-    public updateEntity(draftState: State, id: string, newEntity: Entity): void {
-        const entity = this.getById(id, draftState);
-        if (!entity) {
-            console.error(`Record not found. entityType=${this.entityType} stateType=${this.stateType} id=${id}`);
-        }
-        shallowCopy(newEntity, entity);
-        entity.lastUpdated = Date.now();
-    }
+	public updateEntity(draftState: State, id: string, newEntity: Entity): void {
+		const entity = this.getById(id, draftState);
+		if (!entity) {
+			console.error(
+				`Record not found. entityType=${this.entityType} stateType=${this.stateType} id=${id}`
+			);
+		}
+		shallowCopy(newEntity, entity);
+		entity.lastUpdated = Date.now();
+	}
 
-    public updateEntityField<Field extends keyof Entity>(draftState: State,
-                                                         id: string, field: Field, value: Entity[Field]): void {
-        const entity = this.getById(id, draftState);
-        if (!entity) {
-            console.error(`Record not found. entityType=${this.entityType} stateType=${this.stateType} id=${id}`);
-        }
-        entity[field] = value;
-        entity.lastUpdated = Date.now();
-    }
+	public updateEntityField<Field extends keyof Entity>(
+		draftState: State,
+		id: string,
+		field: Field,
+		value: Entity[Field]
+	): void {
+		const entity = this.getById(id, draftState);
+		if (!entity) {
+			console.error(
+				`Record not found. entityType=${this.entityType} stateType=${this.stateType} id=${id}`
+			);
+		}
+		entity[field] = value;
+		entity.lastUpdated = Date.now();
+	}
 
-    public deleteEntity(draftState: State, id: string): void {
-        const index = draftState.entities.findIndex(entity => entity.id === id);
-        if (index === -1) {
-            console.error(`Record not found. entityType=${this.entityType} stateType=${this.stateType} id=${id}`);
-        }
-        draftState.entities.splice(index, 1);
-    }
+	public deleteEntity(draftState: State, id: string): void {
+		const index = draftState.entities.findIndex((entity) => entity.id === id);
+		if (index === -1) {
+			console.error(
+				`Record not found. entityType=${this.entityType} stateType=${this.stateType} id=${id}`
+			);
+		}
+		draftState.entities.splice(index, 1);
+	}
 
-    public moveEntityDown(draftState: State, id: string): void {
-        const index = draftState.entities.findIndex(entity => entity.id === id);
-        if (index === -1 || index === draftState.entities.length - 1) return;
+	public moveEntityDown(draftState: State, id: string): void {
+		const index = draftState.entities.findIndex((entity) => entity.id === id);
+		if (index === -1 || index === draftState.entities.length - 1) return;
 
-        draftState.entities[index].lastUpdated = Date.now();
-        draftState.entities[index + 1].lastUpdated = Date.now();
-        [draftState.entities[index], draftState.entities[index + 1]] =
-            [draftState.entities[index + 1], draftState.entities[index]];
-    }
+		draftState.entities[index].lastUpdated = Date.now();
+		draftState.entities[index + 1].lastUpdated = Date.now();
+		[draftState.entities[index], draftState.entities[index + 1]] = [
+			draftState.entities[index + 1],
+			draftState.entities[index]
+		];
+	}
 
-    public moveEntityUp(draftState: State, id: string): void {
-        const index = draftState.entities.findIndex(entity => entity.id === id);
-        if (index === -1 || index === 0) return;
+	public moveEntityUp(draftState: State, id: string): void {
+		const index = draftState.entities.findIndex((entity) => entity.id === id);
+		if (index === -1 || index === 0) return;
 
-        draftState.entities[index].lastUpdated = Date.now();
-        draftState.entities[index - 1].lastUpdated = Date.now();
-        [draftState.entities[index], draftState.entities[index - 1]] =
-            [draftState.entities[index - 1], draftState.entities[index]];
-    }
+		draftState.entities[index].lastUpdated = Date.now();
+		draftState.entities[index - 1].lastUpdated = Date.now();
+		[draftState.entities[index], draftState.entities[index - 1]] = [
+			draftState.entities[index - 1],
+			draftState.entities[index]
+		];
+	}
 }

--- a/src/common/data-modeler-state-service/entity-state-service/EntityStateService.ts
+++ b/src/common/data-modeler-state-service/entity-state-service/EntityStateService.ts
@@ -1,53 +1,53 @@
-import { writable, get } from 'svelte/store';
-import type { Writable } from 'svelte/store';
-import { shallowCopy } from '$common/utils/shallowCopy';
-import { applyPatches, produce } from 'immer';
-import type { Patch } from 'immer';
+import { writable, get } from "svelte/store";
+import type {Writable} from "svelte/store";
+import { shallowCopy } from "$common/utils/shallowCopy";
+import { applyPatches, produce } from "immer";
+import type {Patch} from "immer";
 
 export enum EntityType {
-	Table = 'Table',
-	Model = 'Model',
-	Application = 'Application'
+    Table = "Table",
+    Model = "Model",
+    Application = "Application",
 }
 
 export enum StateType {
-	Persistent = 'Persistent',
-	Derived = 'Derived'
+    Persistent = "Persistent",
+    Derived = "Derived",
 }
 export const AllStateTypes = [StateType.Persistent, StateType.Derived];
 
 export interface EntityRecord {
-	id: string;
-	type: EntityType;
-	lastUpdated: number;
+    id: string;
+    type: EntityType;
+    lastUpdated: number;
 }
 
 export enum EntityStatus {
-	Idle,
-	Running,
+    Idle,
+    Running,
 
-	Importing,
-	Validating,
-	Profiling,
-	Exporting
+    Importing,
+    Validating,
+    Profiling,
+    Exporting,
 }
 export interface DerivedEntityRecord extends EntityRecord {
-	status: EntityStatus;
+    status: EntityStatus;
 }
 
 export interface EntityState<Entity extends EntityRecord> {
-	entities: Array<Entity>;
-	lastUpdated: number;
+    entities: Array<Entity>;
+    lastUpdated: number;
 }
 
 export type EntityStateActionArg<
-	Entity extends EntityRecord,
-	State extends EntityState<Entity> = EntityState<Entity>,
-	Service extends EntityStateService<Entity, State> = EntityStateService<Entity, State>
+    Entity extends EntityRecord,
+    State extends EntityState<Entity> = EntityState<Entity>,
+    Service extends EntityStateService<Entity, State> = EntityStateService<Entity, State>
 > = {
-	stateService: Service;
-	draftState: State;
-};
+    stateService: Service;
+    draftState: State;
+}
 
 /**
  * Each entity will have Persistent or Derived states. (Could be more, depends on {@link StateType} enum)
@@ -57,129 +57,105 @@ export type EntityStateActionArg<
  * Has CRUD methods. Can be overridden later on to fetch from a DB or an API.
  */
 export abstract class EntityStateService<
-	Entity extends EntityRecord,
-	State extends EntityState<Entity> = EntityState<Entity>
+    Entity extends EntityRecord,
+    State extends EntityState<Entity> = EntityState<Entity>,
 > {
-	public store: Writable<State>;
+    public store: Writable<State>;
 
-	public readonly entityType: EntityType;
-	public readonly stateType: StateType;
+    public readonly entityType: EntityType;
+    public readonly stateType: StateType;
 
-	public constructor() {
-		// need an empty state for UI where state init is async but component init is not
-		this.init({ entities: [], lastUpdated: 0 } as State);
-	}
+    public constructor() {
+        // need an empty state for UI where state init is async but component init is not
+        this.init({entities: [], lastUpdated: 0} as State);
+    }
 
-	public init(initialState: State): void {
-		this.store = writable(initialState);
-	}
+    public init(initialState: State): void {
+        this.store = writable(initialState);
+    }
 
-	public getCurrentState(): State {
-		return get(this.store);
-	}
+    public getCurrentState(): State {
+        return get(this.store);
+    }
 
-	public getEmptyState(): State {
-		return { lastUpdated: 0, entities: [] } as State;
-	}
+    public getEmptyState(): State {
+        return {lastUpdated: 0, entities: []} as State;
+    }
 
-	public updateState(
-		draftModCallback: (draft: State) => void,
-		pathCallback: (patches: Array<Patch>) => void
-	): void {
-		this.store.set(
-			produce(
-				this.getCurrentState(),
-				(draft) => {
-					draftModCallback(draft as any);
-				},
-				pathCallback
-			)
-		);
-	}
+    public updateState(draftModCallback: (draft: State) => void,
+                       pathCallback: (patches: Array<Patch>) => void): void {
+        this.store.set(produce(this.getCurrentState(), (draft) => {
+            draftModCallback(draft as any);
+        }, pathCallback));
+    }
 
-	public applyPatches(patches: Array<Patch>): void {
-		this.store.set(applyPatches(this.getCurrentState(), patches));
-	}
+    public applyPatches(patches: Array<Patch>): void {
+        this.store.set(applyPatches(this.getCurrentState(), patches));
+    }
 
-	public getById(id: string, state: State = this.getCurrentState()): Entity {
-		return state.entities.find((entity) => entity.id === id);
-	}
+    public getById(id: string, state: State = this.getCurrentState()): Entity {
+        return state.entities.find(entity => entity.id === id);
+    }
 
-	public getByField<Field extends keyof Entity>(
-		field: Field,
-		value: Entity[Field],
-		state: State = this.getCurrentState()
-	): Entity {
-		return state.entities.find((entity) => entity[field] === value);
-	}
+    public getByField<Field extends keyof Entity>(field: Field, value: Entity[Field],
+                                                  state: State = this.getCurrentState()): Entity {
+        return state.entities.find(entity => entity[field] === value);
+    }
 
-	public addEntity(draftState: State, newEntity: Entity, atIndex?: number): void {
-		// TODO: validate id conflicts
-		if (atIndex) {
-			draftState.entities.splice(atIndex, 0, newEntity);
-		} else {
-			draftState.entities.push(newEntity);
-		}
-	}
+    public addEntity(draftState: State, newEntity: Entity, atIndex?: number): void {
+        // TODO: validate id conflicts
+        if (atIndex) {
+            draftState.entities.splice(atIndex, 0, newEntity);
+        }
+        else {
+            draftState.entities.push(newEntity);
+        }
+    }
 
-	public updateEntity(draftState: State, id: string, newEntity: Entity): void {
-		const entity = this.getById(id, draftState);
-		if (!entity) {
-			console.error(
-				`Record not found. entityType=${this.entityType} stateType=${this.stateType} id=${id}`
-			);
-		}
-		shallowCopy(newEntity, entity);
-		entity.lastUpdated = Date.now();
-	}
+    public updateEntity(draftState: State, id: string, newEntity: Entity): void {
+        const entity = this.getById(id, draftState);
+        if (!entity) {
+            console.error(`Record not found. entityType=${this.entityType} stateType=${this.stateType} id=${id}`);
+        }
+        shallowCopy(newEntity, entity);
+        entity.lastUpdated = Date.now();
+    }
 
-	public updateEntityField<Field extends keyof Entity>(
-		draftState: State,
-		id: string,
-		field: Field,
-		value: Entity[Field]
-	): void {
-		const entity = this.getById(id, draftState);
-		if (!entity) {
-			console.error(
-				`Record not found. entityType=${this.entityType} stateType=${this.stateType} id=${id}`
-			);
-		}
-		entity[field] = value;
-		entity.lastUpdated = Date.now();
-	}
+    public updateEntityField<Field extends keyof Entity>(draftState: State,
+                                                         id: string, field: Field, value: Entity[Field]): void {
+        const entity = this.getById(id, draftState);
+        if (!entity) {
+            console.error(`Record not found. entityType=${this.entityType} stateType=${this.stateType} id=${id}`);
+        }
+        entity[field] = value;
+        entity.lastUpdated = Date.now();
+    }
 
-	public deleteEntity(draftState: State, id: string): void {
-		const index = draftState.entities.findIndex((entity) => entity.id === id);
-		if (index === -1) {
-			console.error(
-				`Record not found. entityType=${this.entityType} stateType=${this.stateType} id=${id}`
-			);
-		}
-		draftState.entities.splice(index, 1);
-	}
+    public deleteEntity(draftState: State, id: string): void {
+        const index = draftState.entities.findIndex(entity => entity.id === id);
+        if (index === -1) {
+            console.error(`Record not found. entityType=${this.entityType} stateType=${this.stateType} id=${id}`);
+        }
+        draftState.entities.splice(index, 1);
+    }
 
-	public moveEntityDown(draftState: State, id: string): void {
-		const index = draftState.entities.findIndex((entity) => entity.id === id);
-		if (index === -1 || index === draftState.entities.length - 1) return;
+    public moveEntityDown(draftState: State, id: string): void {
+        const index = draftState.entities.findIndex(entity => entity.id === id);
+        if (index === -1 || index === draftState.entities.length - 1) return;
 
-		draftState.entities[index].lastUpdated = Date.now();
-		draftState.entities[index + 1].lastUpdated = Date.now();
-		[draftState.entities[index], draftState.entities[index + 1]] = [
-			draftState.entities[index + 1],
-			draftState.entities[index]
-		];
-	}
+        draftState.entities[index].lastUpdated = Date.now();
+        draftState.entities[index + 1].lastUpdated = Date.now();
+        [draftState.entities[index], draftState.entities[index + 1]] =
+            [draftState.entities[index + 1], draftState.entities[index]];
+    }
 
-	public moveEntityUp(draftState: State, id: string): void {
-		const index = draftState.entities.findIndex((entity) => entity.id === id);
-		if (index === -1 || index === 0) return;
+    public moveEntityUp(draftState: State, id: string): void {
+        const index = draftState.entities.findIndex(entity => entity.id === id);
+        if (index === -1 || index === 0) return;
 
-		draftState.entities[index].lastUpdated = Date.now();
-		draftState.entities[index - 1].lastUpdated = Date.now();
-		[draftState.entities[index], draftState.entities[index - 1]] = [
-			draftState.entities[index - 1],
-			draftState.entities[index]
-		];
-	}
+        draftState.entities[index].lastUpdated = Date.now();
+        draftState.entities[index - 1].lastUpdated = Date.now();
+        [draftState.entities[index], draftState.entities[index - 1]] =
+            [draftState.entities[index - 1], draftState.entities[index]];
+    }
 }


### PR DESCRIPTION
Motivation:
PR #188 breaks `npm run build` on my machine, due to a problem with importing Immer's `produce` function. It's a bit weird since the PR passed the CI/CD tests. One guess for the discrepancy is that the CI/CD tests ran on Linux, and my machine is a Mac. This Github discussion references Immer function imports working differently in different build environments: https://github.com/immerjs/immer/issues/136

Here's the error message of my broken build:
![image](https://user-images.githubusercontent.com/14206386/166871083-e2ff6e97-93da-4d93-ba24-8052ffef21d8.png)

I fixed it by importing the `produce` function as a "named" import not as a "default" one.

@AdityaHegde, would you mind reviewing this? I see you were the one who originally imported `produce`, so would like your eyes to double check this.
