### PR TITLE
remove typo that was breaking prettier

### DIFF
--- a/src/lib/components/column-profile/ColumnProfile.svelte
+++ b/src/lib/components/column-profile/ColumnProfile.svelte
@@ -119,8 +119,7 @@ let titleTooltip;
                         column name to clipboard
                     </div>
                     <Shortcut>
-                        <span style='font-family: var(--system);";
-                        '>⇧</span> + Click
+                        <span style='font-family: var(--system);'>⇧</span> + Click
                     </Shortcut>
                 </TooltipShortcutContainer>
             {:else}

--- a/src/lib/components/table/PreviewTableHeader.svelte
+++ b/src/lib/components/table/PreviewTableHeader.svelte
@@ -62,8 +62,7 @@ const { shiftClickAction } = createShiftClickAction();
                     column name to clipboard
                 </div>
                 <Shortcut>
-                    <span style='font-family: var(--system);";
-                    '>⇧</span> + Click
+                    <span style='font-family: var(--system);'>⇧</span> + Click
                 </Shortcut>
             </TooltipShortcutContainer>
            </TooltipContent>

--- a/src/lib/components/table/TableCell.svelte
+++ b/src/lib/components/table/TableCell.svelte
@@ -108,8 +108,7 @@ let activeCell = false;
             <StackingWord>copy</StackingWord> this value to clipboard
         </div>
         <Shortcut>
-            <span style='font-family: var(--system);";
-            '>⇧</span> + Click
+            <span style='font-family: var(--system);'>⇧</span> + Click
         </Shortcut>
     </TooltipShortcutContainer>
 </TooltipContent>

--- a/src/lib/components/viz/TopKSummary.svelte
+++ b/src/lib/components/viz/TopKSummary.svelte
@@ -59,8 +59,7 @@ $: formatCount = format(',');
                             <StackingWord>copy</StackingWord> column value to clipboard
                         </div>
                         <Shortcut>
-                            <span style='font-family: var(--system);";
-                            '>⇧</span> + Click
+                            <span style='font-family: var(--system);'>⇧</span> + Click
                         </Shortcut>
                     </TooltipShortcutContainer>
                 </TooltipContent>
@@ -93,8 +92,7 @@ $: formatCount = format(',');
                                 <StackingWord>copy</StackingWord> {count} to clipboard
                             </div>
                             <Shortcut>
-                                <span style='font-family: var(--system);";
-                                '>⇧</span> + Click
+                                <span style='font-family: var(--system);'>⇧</span> + Click
                             </Shortcut>
                         </TooltipShortcutContainer>
                     </TooltipContent>


### PR DESCRIPTION
this removes an extra linebreak + quote + semicolon in a few places that looks like a small typo that was copy/pasted a few places. Making this change doesn't appear to affect rendering or functionality locally.