### PR TITLE
Simplify-assets-sidebar

### DIFF
--- a/src/lib/util/file-upload.ts
+++ b/src/lib/util/file-upload.ts
@@ -55,6 +55,7 @@ function reportFileErrors(invalidFiles: File[]) {
  * through reportFileErrors.
  */
 export function handleFileUploads(filesArray: File[]) {
+  console.log(filesArray.length, filesArray);
   let invalidFiles = [];
   if (filesArray) {
     invalidFiles = uploadTableFiles(
@@ -77,8 +78,17 @@ export function onSourceDrop(e: DragEvent) {
 
 /** an event callback when a source table file is chosen manually */
 export function onManualSourceUpload(e: Event) {
+  console.log(e);
   const files = (<HTMLInputElement>e.target)?.files as FileList;
   if (files) {
     handleFileUploads(Array.from(files));
   }
+}
+
+export async function uploadFilesWithDialog() {
+  const input = document.createElement("input");
+  input.multiple = true;
+  input.type = "file";
+  input.onchange = onManualSourceUpload;
+  input.click();
 }

--- a/src/lib/util/file-upload.ts
+++ b/src/lib/util/file-upload.ts
@@ -55,7 +55,6 @@ function reportFileErrors(invalidFiles: File[]) {
  * through reportFileErrors.
  */
 export function handleFileUploads(filesArray: File[]) {
-  console.log(filesArray.length, filesArray);
   let invalidFiles = [];
   if (filesArray) {
     invalidFiles = uploadTableFiles(
@@ -78,7 +77,6 @@ export function onSourceDrop(e: DragEvent) {
 
 /** an event callback when a source table file is chosen manually */
 export function onManualSourceUpload(e: Event) {
-  console.log(e);
   const files = (<HTMLInputElement>e.target)?.files as FileList;
   if (files) {
     handleFileUploads(Array.from(files));

--- a/src/routes/_surfaces/assets/ModelAssets.svelte
+++ b/src/routes/_surfaces/assets/ModelAssets.svelte
@@ -1,0 +1,106 @@
+<script lang="ts">
+  import { getContext } from "svelte";
+  import { slide } from "svelte/transition";
+
+  import type { ApplicationStore } from "$lib/application-state-stores/application-store";
+
+  import ModelIcon from "$lib/components/icons/Code.svelte";
+  import AddIcon from "$lib/components/icons/Add.svelte";
+  import CollapsibleTableSummary from "$lib/components/column-profile/CollapsibleTableSummary.svelte";
+  import ContextButton from "$lib/components/column-profile/ContextButton.svelte";
+  import CollapsibleSectionTitle from "$lib/components/CollapsibleSectionTitle.svelte";
+
+  import { dataModelerService } from "$lib/application-state-stores/application-store";
+  import type {
+    DerivedModelStore,
+    PersistentModelStore,
+  } from "$lib/application-state-stores/model-stores";
+  import type { PersistentModelEntity } from "$common/data-modeler-state-service/entity-state-service/PersistentModelEntityService";
+  import { EntityType } from "$common/data-modeler-state-service/entity-state-service/EntityStateService";
+
+  const store = getContext("rill:app:store") as ApplicationStore;
+  const persistentModelStore = getContext(
+    "rill:app:persistent-model-store"
+  ) as PersistentModelStore;
+  const derivedModelStore = getContext(
+    "rill:app:derived-model-store"
+  ) as DerivedModelStore;
+
+  let activeModel: PersistentModelEntity;
+  $: activeModel =
+    $store &&
+    $persistentModelStore &&
+    $store?.activeEntity &&
+    $persistentModelStore?.entities
+      ? $persistentModelStore.entities.find(
+          (q) => q.id === $store.activeEntity.id
+        )
+      : undefined;
+  let showModels = true;
+</script>
+
+{#if $persistentModelStore && $persistentModelStore.entities}
+  <div
+    class="pl-4 pb-3 pr-4 grid justify-between"
+    style="grid-template-columns: auto max-content;"
+    out:slide={{ duration: 200 }}
+  >
+    <CollapsibleSectionTitle tooltipText={"models"} bind:active={showModels}>
+      <h4 class="flex flex-row items-center gap-x-2">
+        <ModelIcon size="16px" /> Models
+      </h4>
+    </CollapsibleSectionTitle>
+    <ContextButton
+      id={"create-model-button"}
+      tooltipText="create a new model"
+      on:click={async () => {
+        // create the new model.
+        let response = await dataModelerService.dispatch("addModel", [{}]);
+        // change the active asset to the new model.
+        dataModelerService.dispatch("setActiveAsset", [
+          EntityType.Model,
+          response.id,
+        ]);
+        // if the models are not visible in the assets list, show them.
+        if (!showModels) {
+          showModels = true;
+        }
+      }}
+    >
+      <AddIcon />
+    </ContextButton>
+  </div>
+  {#if showModels}
+    <div
+      class="pb-6 justify-self-end"
+      transition:slide={{ duration: 200 }}
+      id="assets-model-list"
+    >
+      <!-- TODO: fix the object property access back to m.id from m["id"] once svelte fixes it -->
+      {#each $persistentModelStore.entities as query, i (query.id)}
+        {@const derivedModel = $derivedModelStore.entities.find(
+          (m) => m["id"] === query["id"]
+        )}
+        <CollapsibleTableSummary
+          on:select={() => {
+            dataModelerService.dispatch("setActiveAsset", [
+              EntityType.Model,
+              query.id,
+            ]);
+          }}
+          on:delete={() => {
+            dataModelerService.dispatch("deleteModel", [query.id]);
+          }}
+          indentLevel={1}
+          icon={ModelIcon}
+          name={query.name}
+          cardinality={derivedModel?.cardinality ?? 0}
+          profile={derivedModel?.profile ?? []}
+          head={derivedModel?.preview ?? []}
+          sizeInBytes={derivedModel?.sizeInBytes ?? 0}
+          emphasizeTitle={query?.id === $store?.activeEntity?.id}
+        />
+      {/each}
+    </div>
+  {/if}
+{/if}

--- a/src/routes/_surfaces/assets/TableAssets.svelte
+++ b/src/routes/_surfaces/assets/TableAssets.svelte
@@ -3,52 +3,29 @@
   import { slide } from "svelte/transition";
   import { flip } from "svelte/animate";
 
-  import type { ApplicationStore } from "$lib/application-state-stores/application-store";
-
-  import Portal from "$lib/components/Portal.svelte";
+  import { uploadFilesWithDialog } from "$lib/util/file-upload";
 
   import ParquetIcon from "$lib/components/icons/Parquet.svelte";
-  import ModelIcon from "$lib/components/icons/Code.svelte";
   import AddIcon from "$lib/components/icons/Add.svelte";
   import CollapsibleTableSummary from "$lib/components/column-profile/CollapsibleTableSummary.svelte";
   import ContextButton from "$lib/components/column-profile/ContextButton.svelte";
   import CollapsibleSectionTitle from "$lib/components/CollapsibleSectionTitle.svelte";
 
-  import { drag } from "$lib/drag";
   import { dataModelerService } from "$lib/application-state-stores/application-store";
   import type {
     DerivedTableStore,
     PersistentTableStore,
   } from "$lib/application-state-stores/table-stores";
-  import type {
-    DerivedModelStore,
-    PersistentModelStore,
-  } from "$lib/application-state-stores/model-stores";
-  import type { PersistentModelEntity } from "$common/data-modeler-state-service/entity-state-service/PersistentModelEntityService";
-  import { EntityType } from "$common/data-modeler-state-service/entity-state-service/EntityStateService";
 
-  import {
-    assetVisibilityTween,
-    assetsVisible,
-    layout,
-  } from "$lib/application-state-stores/layout-store";
-  import { onManualSourceUpload, onSourceDrop } from "$lib/util/file-upload";
+  import { onSourceDrop } from "$lib/util/file-upload";
 
-  export let fileUploadElement: HTMLElement;
-
-  const store = getContext("rill:app:store") as ApplicationStore;
   const persistentTableStore = getContext(
     "rill:app:persistent-table-store"
   ) as PersistentTableStore;
+
   const derivedTableStore = getContext(
     "rill:app:derived-table-store"
   ) as DerivedTableStore;
-  const persistentModelStore = getContext(
-    "rill:app:persistent-model-store"
-  ) as PersistentModelStore;
-  const derivedModelStore = getContext(
-    "rill:app:derived-model-store"
-  ) as DerivedModelStore;
 
   let showTables = true;
 </script>
@@ -71,15 +48,7 @@
   <ContextButton
     id={"create-table-button"}
     tooltipText="import csv or parquet file into a table"
-    on:click={/**
-     * Manual file upload
-     * ------------------
-     * clicks on the fileUploadElement above, which is hidden from the user.
-     *
-     */
-    async () => {
-      fileUploadElement.click();
-    }}
+    on:click={uploadFilesWithDialog}
   >
     <AddIcon />
   </ContextButton>

--- a/src/routes/_surfaces/assets/TableAssets.svelte
+++ b/src/routes/_surfaces/assets/TableAssets.svelte
@@ -1,0 +1,121 @@
+<script lang="ts">
+  import { getContext } from "svelte";
+  import { slide } from "svelte/transition";
+  import { flip } from "svelte/animate";
+
+  import type { ApplicationStore } from "$lib/application-state-stores/application-store";
+
+  import Portal from "$lib/components/Portal.svelte";
+
+  import ParquetIcon from "$lib/components/icons/Parquet.svelte";
+  import ModelIcon from "$lib/components/icons/Code.svelte";
+  import AddIcon from "$lib/components/icons/Add.svelte";
+  import CollapsibleTableSummary from "$lib/components/column-profile/CollapsibleTableSummary.svelte";
+  import ContextButton from "$lib/components/column-profile/ContextButton.svelte";
+  import CollapsibleSectionTitle from "$lib/components/CollapsibleSectionTitle.svelte";
+
+  import { drag } from "$lib/drag";
+  import { dataModelerService } from "$lib/application-state-stores/application-store";
+  import type {
+    DerivedTableStore,
+    PersistentTableStore,
+  } from "$lib/application-state-stores/table-stores";
+  import type {
+    DerivedModelStore,
+    PersistentModelStore,
+  } from "$lib/application-state-stores/model-stores";
+  import type { PersistentModelEntity } from "$common/data-modeler-state-service/entity-state-service/PersistentModelEntityService";
+  import { EntityType } from "$common/data-modeler-state-service/entity-state-service/EntityStateService";
+
+  import {
+    assetVisibilityTween,
+    assetsVisible,
+    layout,
+  } from "$lib/application-state-stores/layout-store";
+  import { onManualSourceUpload, onSourceDrop } from "$lib/util/file-upload";
+
+  export let fileUploadElement: HTMLElement;
+
+  const store = getContext("rill:app:store") as ApplicationStore;
+  const persistentTableStore = getContext(
+    "rill:app:persistent-table-store"
+  ) as PersistentTableStore;
+  const derivedTableStore = getContext(
+    "rill:app:derived-table-store"
+  ) as DerivedTableStore;
+  const persistentModelStore = getContext(
+    "rill:app:persistent-model-store"
+  ) as PersistentModelStore;
+  const derivedModelStore = getContext(
+    "rill:app:derived-model-store"
+  ) as DerivedModelStore;
+
+  let showTables = true;
+</script>
+
+<div
+  class="pl-4 pb-3 pr-4 pt-5 grid justify-between"
+  style="grid-template-columns: auto max-content;"
+  on:drop|preventDefault|stopPropagation={onSourceDrop}
+  on:drag|preventDefault|stopPropagation
+  on:dragenter|preventDefault|stopPropagation
+  on:dragover|preventDefault|stopPropagation
+  on:dragleave|preventDefault|stopPropagation
+>
+  <CollapsibleSectionTitle tooltipText={"tables"} bind:active={showTables}>
+    <h4 class="flex flex-row items-center gap-x-2">
+      <ParquetIcon size="16px" /> Tables
+    </h4>
+  </CollapsibleSectionTitle>
+
+  <ContextButton
+    id={"create-table-button"}
+    tooltipText="import csv or parquet file into a table"
+    on:click={/**
+     * Manual file upload
+     * ------------------
+     * clicks on the fileUploadElement above, which is hidden from the user.
+     *
+     */
+    async () => {
+      fileUploadElement.click();
+    }}
+  >
+    <AddIcon />
+  </ContextButton>
+</div>
+{#if showTables}
+  <div
+    class="pb-6"
+    transition:slide|local={{ duration: 200 }}
+    on:drop={onSourceDrop}
+    on:drag|preventDefault|stopPropagation
+    on:dragenter|preventDefault|stopPropagation
+    on:dragover|preventDefault|stopPropagation
+    on:dragleave|preventDefault|stopPropagation
+  >
+    {#if $persistentTableStore?.entities && $derivedTableStore?.entities}
+      <!-- TODO: fix the object property access back to t.id from t["id"] once svelte fixes it -->
+      {#each $persistentTableStore.entities as { path, tableName, id } (id)}
+        {@const derivedTable = $derivedTableStore.entities.find(
+          (t) => t["id"] === id
+        )}
+        <div animate:flip={{ duration: 200 }} out:slide={{ duration: 200 }}>
+          <CollapsibleTableSummary
+            indentLevel={1}
+            icon={ParquetIcon}
+            name={tableName}
+            cardinality={derivedTable?.cardinality ?? 0}
+            profile={derivedTable?.profile ?? []}
+            head={derivedTable?.preview ?? []}
+            {path}
+            sizeInBytes={derivedTable?.sizeInBytes ?? 0}
+            on:delete={() => {
+              dataModelerService.dispatch("dropTable", [tableName]);
+            }}
+          />
+        </div>
+      {/each}
+    {/if}
+  </div>
+{/if}

--- a/src/routes/_surfaces/assets/index.svelte
+++ b/src/routes/_surfaces/assets/index.svelte
@@ -1,23 +1,14 @@
 <script lang="ts">
-  // import { getContext } from "svelte";
-
-  // import type { ApplicationStore } from "$lib/application-state-stores/application-store";
-
   import Portal from "$lib/components/Portal.svelte";
-
   import { drag } from "$lib/drag";
-  // import type { PersistentModelStore } from "$lib/application-state-stores/model-stores";
   import {
     assetVisibilityTween,
     assetsVisible,
     layout,
   } from "$lib/application-state-stores/layout-store";
-  import { onManualSourceUpload } from "$lib/util/file-upload";
 
   import TableAssets from "./TableAssets.svelte";
   import ModelAssets from "./ModelAssets.svelte";
-
-  let fileUploadElement: HTMLElement;
 </script>
 
 <div
@@ -47,15 +38,6 @@
     </Portal>
   {/if}
 
-  <!-- This input element will be used for all file uploads-->
-  <input
-    class="hidden"
-    type="file"
-    multiple
-    bind:this={fileUploadElement}
-    on:change={onManualSourceUpload}
-  />
-
   <div class="w-full flex flex-col h-full">
     <div class="grow" style:outline="1px solid black">
       <header
@@ -73,9 +55,7 @@
           <div class="font-bold">Rill Developer</div>
         </h1>
       </header>
-
-      <!-- <div style:height="80px"></div> -->
-      <TableAssets {fileUploadElement} />
+      <TableAssets />
       <ModelAssets />
     </div>
     <!-- assets pane footer. -->

--- a/src/routes/_surfaces/assets/index.svelte
+++ b/src/routes/_surfaces/assets/index.svelte
@@ -1,65 +1,21 @@
 <script lang="ts">
-  import { getContext } from "svelte";
-  import { slide } from "svelte/transition";
-  import { flip } from "svelte/animate";
+  // import { getContext } from "svelte";
 
-  import type { ApplicationStore } from "$lib/application-state-stores/application-store";
+  // import type { ApplicationStore } from "$lib/application-state-stores/application-store";
 
   import Portal from "$lib/components/Portal.svelte";
 
-  import ParquetIcon from "$lib/components/icons/Parquet.svelte";
-  import ModelIcon from "$lib/components/icons/Code.svelte";
-  import AddIcon from "$lib/components/icons/Add.svelte";
-  import CollapsibleTableSummary from "$lib/components/column-profile/CollapsibleTableSummary.svelte";
-  import ContextButton from "$lib/components/column-profile/ContextButton.svelte";
-  import CollapsibleSectionTitle from "$lib/components/CollapsibleSectionTitle.svelte";
-
   import { drag } from "$lib/drag";
-  import { dataModelerService } from "$lib/application-state-stores/application-store";
-  import type {
-    DerivedTableStore,
-    PersistentTableStore,
-  } from "$lib/application-state-stores/table-stores";
-  import type {
-    DerivedModelStore,
-    PersistentModelStore,
-  } from "$lib/application-state-stores/model-stores";
-  import type { PersistentModelEntity } from "$common/data-modeler-state-service/entity-state-service/PersistentModelEntityService";
-  import { EntityType } from "$common/data-modeler-state-service/entity-state-service/EntityStateService";
-
+  // import type { PersistentModelStore } from "$lib/application-state-stores/model-stores";
   import {
     assetVisibilityTween,
     assetsVisible,
     layout,
   } from "$lib/application-state-stores/layout-store";
-  import { onManualSourceUpload, onSourceDrop } from "$lib/util/file-upload";
+  import { onManualSourceUpload } from "$lib/util/file-upload";
 
-  const store = getContext("rill:app:store") as ApplicationStore;
-  const persistentTableStore = getContext(
-    "rill:app:persistent-table-store"
-  ) as PersistentTableStore;
-  const derivedTableStore = getContext(
-    "rill:app:derived-table-store"
-  ) as DerivedTableStore;
-  const persistentModelStore = getContext(
-    "rill:app:persistent-model-store"
-  ) as PersistentModelStore;
-  const derivedModelStore = getContext(
-    "rill:app:derived-model-store"
-  ) as DerivedModelStore;
-
-  let activeModel: PersistentModelEntity;
-  $: activeModel =
-    $store &&
-    $persistentModelStore &&
-    $store?.activeEntity &&
-    $persistentModelStore?.entities
-      ? $persistentModelStore.entities.find(
-          (q) => q.id === $store.activeEntity.id
-        )
-      : undefined;
-  let showTables = true;
-  let showModels = true;
+  import TableAssets from "./TableAssets.svelte";
+  import ModelAssets from "./ModelAssets.svelte";
 
   let fileUploadElement: HTMLElement;
 </script>
@@ -119,150 +75,8 @@
       </header>
 
       <!-- <div style:height="80px"></div> -->
-
-      <div
-        class="pl-4 pb-3 pr-4 pt-5 grid justify-between"
-        style="grid-template-columns: auto max-content;"
-        on:drop|preventDefault|stopPropagation={onSourceDrop}
-        on:drag|preventDefault|stopPropagation
-        on:dragenter|preventDefault|stopPropagation
-        on:dragover|preventDefault|stopPropagation
-        on:dragleave|preventDefault|stopPropagation
-      >
-        <CollapsibleSectionTitle
-          tooltipText={"tables"}
-          bind:active={showTables}
-        >
-          <h4 class="flex flex-row items-center gap-x-2">
-            <ParquetIcon size="16px" /> Tables
-          </h4>
-        </CollapsibleSectionTitle>
-
-        <ContextButton
-          id={"create-table-button"}
-          tooltipText="import csv or parquet file into a table"
-          on:click={/**
-           * Manual file upload
-           * ------------------
-           * clicks on the fileUploadElement above, which is hidden from the user.
-           *
-           */
-          async () => {
-            fileUploadElement.click();
-          }}
-        >
-          <AddIcon />
-        </ContextButton>
-      </div>
-      {#if showTables}
-        <div
-          class="pb-6"
-          transition:slide|local={{ duration: 200 }}
-          on:drop={onSourceDrop}
-          on:drag|preventDefault|stopPropagation
-          on:dragenter|preventDefault|stopPropagation
-          on:dragover|preventDefault|stopPropagation
-          on:dragleave|preventDefault|stopPropagation
-        >
-          {#if $persistentTableStore?.entities && $derivedTableStore?.entities}
-            <!-- TODO: fix the object property access back to t.id from t["id"] once svelte fixes it -->
-            {#each $persistentTableStore.entities as { path, tableName, id } (id)}
-              {@const derivedTable = $derivedTableStore.entities.find(
-                (t) => t["id"] === id
-              )}
-              <div
-                animate:flip={{ duration: 200 }}
-                out:slide={{ duration: 200 }}
-              >
-                <CollapsibleTableSummary
-                  indentLevel={1}
-                  icon={ParquetIcon}
-                  name={tableName}
-                  cardinality={derivedTable?.cardinality ?? 0}
-                  profile={derivedTable?.profile ?? []}
-                  head={derivedTable?.preview ?? []}
-                  {path}
-                  sizeInBytes={derivedTable?.sizeInBytes ?? 0}
-                  on:delete={() => {
-                    dataModelerService.dispatch("dropTable", [tableName]);
-                  }}
-                />
-              </div>
-            {/each}
-          {/if}
-        </div>
-      {/if}
-
-      {#if $persistentModelStore && $persistentModelStore.entities}
-        <div
-          class="pl-4 pb-3 pr-4 grid justify-between"
-          style="grid-template-columns: auto max-content;"
-          out:slide={{ duration: 200 }}
-        >
-          <CollapsibleSectionTitle
-            tooltipText={"tables"}
-            bind:active={showModels}
-          >
-            <h4 class="flex flex-row items-center gap-x-2">
-              <ModelIcon size="16px" /> Models
-            </h4>
-          </CollapsibleSectionTitle>
-          <ContextButton
-            id={"create-model-button"}
-            tooltipText="create a new model"
-            on:click={async () => {
-              // create the new model.
-              let response = await dataModelerService.dispatch("addModel", [
-                {},
-              ]);
-              // change the active asset to the new model.
-              dataModelerService.dispatch("setActiveAsset", [
-                EntityType.Model,
-                response.id,
-              ]);
-              // if the models are not visible in the assets list, show them.
-              if (!showModels) {
-                showModels = true;
-              }
-            }}
-          >
-            <AddIcon />
-          </ContextButton>
-        </div>
-        {#if showModels}
-          <div
-            class="pb-6 justify-self-end"
-            transition:slide={{ duration: 200 }}
-            id="assets-model-list"
-          >
-            <!-- TODO: fix the object property access back to m.id from m["id"] once svelte fixes it -->
-            {#each $persistentModelStore.entities as query, i (query.id)}
-              {@const derivedModel = $derivedModelStore.entities.find(
-                (m) => m["id"] === query["id"]
-              )}
-              <CollapsibleTableSummary
-                on:select={() => {
-                  dataModelerService.dispatch("setActiveAsset", [
-                    EntityType.Model,
-                    query.id,
-                  ]);
-                }}
-                on:delete={() => {
-                  dataModelerService.dispatch("deleteModel", [query.id]);
-                }}
-                indentLevel={1}
-                icon={ModelIcon}
-                name={query.name}
-                cardinality={derivedModel?.cardinality ?? 0}
-                profile={derivedModel?.profile ?? []}
-                head={derivedModel?.preview ?? []}
-                sizeInBytes={derivedModel?.sizeInBytes ?? 0}
-                emphasizeTitle={query?.id === $store?.activeEntity?.id}
-              />
-            {/each}
-          </div>
-        {/if}
-      {/if}
+      <TableAssets {fileUploadElement} />
+      <ModelAssets />
     </div>
     <!-- assets pane footer. -->
     <div


### PR DESCRIPTION
simplifies the asset sidebar in advance of adding a section for metrics definitions:
- break up one big component into smaller components
- move file upload functionality to a JS function rather than needing a permanent input element