### PR TITLE
fix a console error and a warning

### DIFF
--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -14,9 +14,10 @@
 
   const dispatch = createEventDispatcher();
   export let content;
-  export let componentContainer;
   export let editorHeight = 0;
   export let selections = [];
+
+  let componentContainer;
 
   $: editorHeight = componentContainer?.offsetHeight || 0;
 
@@ -127,7 +128,7 @@
       parent: editorContainerComponent,
     });
     const obs = new ResizeObserver(() => {
-      editorHeight = componentContainer.offsetHeight;
+      editorHeight = componentContainer?.offsetHeight;
     });
     obs.observe(componentContainer);
   });


### PR DESCRIPTION
Fixes the console error below, as well as a warning about Editor being created without prop `componentContainer` (which is never passed in at any of the places this component is used).
![image](https://user-images.githubusercontent.com/2380975/169106530-9e044a8b-7595-49b5-a15e-0b2cb82b5c66.png)
