### PR TITLE
Moving deploy from common config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,18 +8,6 @@ cache:
     - "$TRAVIS_BUILD_DIR/data"
     - "node_modules"
 
-deploy:
-  provider: releases
-  api_key: ${GITHUB_TOKEN}
-  # explicitly mention all types of binaries
-  # travis doesnt support folder upload as of now
-  file:
-    - rilldata/rill-macos-x64
-    - rilldata/rill-linux-x64
-    - rilldata/rill-win-x64.exe
-  skip_cleanup: true
-  on:
-    tags: true
 
 env:
   global:
@@ -88,6 +76,18 @@ jobs:
         - npm run build
         - echo "Building vercel/pkg binary"
         - npm run build-vercel-pkg
+      deploy: &deploy-vercel-pkg
+        provider: releases
+        api_key: ${GITHUB_TOKEN}
+        # explicitly mention all types of binaries
+        # travis doesnt support folder upload as of now
+        file:
+          - rilldata/rill-macos-x64
+          - rilldata/rill-linux-x64
+          - rilldata/rill-win-x64.exe
+        skip_cleanup: true
+        on:
+          tags: true
 
     - stage: publish
       name: "Build & Publish linux binary"
@@ -95,6 +95,7 @@ jobs:
       before_install: *python-setup
       install: *slow-npm-ci
       script: *build-vercel-pkg
+      deploy: *deploy-vercel-pkg
 
     - stage: publish
       name: "Build & Publish windows binary"
@@ -102,3 +103,4 @@ jobs:
       os: windows
       install: *slow-npm-ci
       script: *build-vercel-pkg
+      deploy: *deploy-vercel-pkg


### PR DESCRIPTION
Having deploy in the common config was causing issues with other jobs. Moving it to binary publish jobs.