### PR TITLE
Replace rect in Histograms

### DIFF
--- a/src/lib/application-config.ts
+++ b/src/lib/application-config.ts
@@ -7,7 +7,7 @@
 export const COLUMN_PROFILE_CONFIG = {
   // width of summary value
   // width of null %
-  nullPercentageWidth: 74,
+  nullPercentageWidth: 76,
   mediumCutoff: 300,
   compactBreakpoint: 350,
   hideRight: 325,

--- a/src/lib/components/viz/histogram/HistogramBase.svelte
+++ b/src/lib/components/viz/histogram/HistogramBase.svelte
@@ -75,19 +75,29 @@
   }
 
   let histogramID = guidGenerator();
+
+  // reduce data to construct path for polyline
+  $: lineData = data.reduce((pointsPathString, datum) => {
+    const {low, high, count} = datum
+    const x = X(low) + separateQuantity
+    const width = X(high) - X(low) - separateQuantity * 2
+    const y = Y(0) * (1 - $tw) + Y(count) * $tw
+    const height = Math.min(Y(0), Y(0) * $tw - Y(count) * $tw)
+
+    const currentPoints = `${x},${y+height} ${x},${y} ${x+width},${y}, ${x+width},${y+height} `
+
+    return pointsPathString + currentPoints
+  }, "")
+
 </script>
 
 <svg {width} {height}>
   <!-- histogram -->
   <g shape-rendering="crispEdges">
-    {#each data as { low, high, count }, i}
-      {@const x = X(low) + separateQuantity}
-      {@const width = X(high) - X(low) - separateQuantity * 2}
-      {@const y = Y(0) * (1 - $tw) + Y(count) * $tw}
-      {@const height = Math.min(Y(0), Y(0) * $tw - Y(count) * $tw)}
-
-      <rect {x} {width} {y} {height} class={fillColor} />
-    {/each}
+    <polyline
+      class={fillColor}
+      points={lineData}
+    />
     <line
       x1={left + vizOffset}
       x2={width * $tw - right - vizOffset}


### PR DESCRIPTION
**Rects to Polyline** 
Fixes #347 

Have replaced `rects` with `polyline`.
The original discussion was to replace `rect` with `path` but I believe `polyline` was more suited  as we don't have any need for curves in the path.

Also didn't go for a [stepped path approach](https://github.com/d3/d3-shape#curveStep) as there is always some margin gap between two bars.

Here's the column profile before rect and after using polyline

With Rect            |  With Polyline
:-------------------------:|:-------------------------:
<img width="411" alt="with rect" src="https://user-images.githubusercontent.com/4402679/172348899-e41ea918-709f-428a-a49f-fb513d52716c.png"> |  <img width="411" alt="with polyline" src="https://user-images.githubusercontent.com/4402679/172348907-3afb536f-dd03-4e82-be47-61c94b5d18b3.png">

**Prevent Wrapping when null value is 100% for numericals** 
Fixes #355 

Increased `nullPercentageWidth` to accommodate the string "∅ 100%" in a single line.


