### PR TITLE
fix edge case error deleting node

### DIFF
--- a/src/lib/components/Portal.svelte
+++ b/src/lib/components/Portal.svelte
@@ -22,8 +22,8 @@
   });
 
   onDestroy(() => {
-    if (browser) {
-      document.body.removeChild(portal);
+    if (browser && portal) {
+      portal.remove();
     }
   });
 </script>


### PR DESCRIPTION
tiny change -- this fixes a rare bug by unconditionally removing the `portal` element from the DOM, instead of removing it as a child from `body` (which will sometimes fail).