### PR TITLE
add `unobserve` callback to all svelte resize observers

### DIFF
--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -276,6 +276,7 @@
       editorHeight = componentContainer?.offsetHeight;
     });
     obs.observe(componentContainer);
+    return () => obs.unobserve(componentContainer);
   });
 
   // REACTIVE FUNCTIONS

--- a/src/lib/components/column-profile/CollapsibleTableSummary.svelte
+++ b/src/lib/components/column-profile/CollapsibleTableSummary.svelte
@@ -62,6 +62,7 @@
       containerWidth = container?.clientWidth ?? 0;
     });
     observer.observe(container);
+    return () => observer.unobserve(container);
   });
 
   let cardinalityTween = tweened(cardinality, { duration: 600, easing });

--- a/src/routes/_surfaces/inspector/Model.svelte
+++ b/src/routes/_surfaces/inspector/Model.svelte
@@ -153,6 +153,7 @@
       containerWidth = container.clientWidth;
     });
     observer.observe(container);
+    return () => observer.unobserve(container);
   });
 </script>
 


### PR DESCRIPTION
fixes console errors like
```
Model.svelte:153 Uncaught TypeError: Cannot read properties of null (reading 'clientWidth')
    at ResizeObserver.<anonymous> (Model.svelte:153:34)
```
see:
https://blog.sethcorker.com/question/how-do-you-use-the-resize-observer-api-in-svelte/