### PR TITLE
Fix bump version script

### DIFF
--- a/src/cli/bump-version.ts
+++ b/src/cli/bump-version.ts
@@ -11,10 +11,7 @@ const PACKAGE_JSON_FILE = "./package.json";
 const PACKAGE_LOCK_JSON_FILE = "./package-lock.json";
 const execSyncToStdout = (cmd) => execSync(cmd, { stdio: "inherit" });
 
-const packageJsonString = readFileSync(PACKAGE_JSON_FILE).toString();
-const currentVersion = JSON.parse(packageJsonString).version;
 const bumpType = process.argv[2];
-
 if (!(bumpType in BUMP_TYPES)) {
   console.log(
     `Invalid version bump type: ${bumpType}. Can be one of ${Object.keys(
@@ -28,6 +25,8 @@ console.log("Pulling latest changes from main branch");
 execSyncToStdout("git checkout main");
 execSyncToStdout("git pull");
 
+const packageJsonString = readFileSync(PACKAGE_JSON_FILE).toString();
+const currentVersion = JSON.parse(packageJsonString).version;
 const newVersion = semverInc(currentVersion, bumpType);
 
 console.log(`Bumping version from ${currentVersion} to ${newVersion}`);

--- a/src/cli/bump-version.ts
+++ b/src/cli/bump-version.ts
@@ -37,13 +37,8 @@ writeFileSync(
     `"version": "${newVersion}",`
   )
 );
-writeFileSync(
-  PACKAGE_LOCK_JSON_FILE,
-  packageJsonString.replace(
-    `"version": "${currentVersion}",`,
-    `"version": "${newVersion}",`
-  )
-);
+console.log("Regenerating `package-lock.json`");
+execSyncToStdout(`npm install`);
 
 console.log("Creating new branch");
 const branchName = `release-candidate-${newVersion}`;


### PR DESCRIPTION
This PR addresses a few bugs:
- The script was generating a `package.json` file where it should have been generating a `package-lock.json` file.
- The script was reading the local `package.json` before not after `git pull`
- The script used a find-replace for the `package-lock.json` file. A better approach is to regenerate the lockfile.