### PR TITLE
Reorganize-workspace-components

### DIFF
--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -276,6 +276,7 @@
       editorHeight = componentContainer?.offsetHeight;
     });
     obs.observe(componentContainer);
+    return () => obs.unobserve(componentContainer);
   });
 
   // REACTIVE FUNCTIONS

--- a/src/lib/components/column-profile/CollapsibleTableSummary.svelte
+++ b/src/lib/components/column-profile/CollapsibleTableSummary.svelte
@@ -62,6 +62,7 @@
       containerWidth = container?.clientWidth ?? 0;
     });
     observer.observe(container);
+    return () => observer.unobserve(container);
   });
 
   let cardinalityTween = tweened(cardinality, { duration: 600, easing });

--- a/src/routes/_surfaces/inspector/Model.svelte
+++ b/src/routes/_surfaces/inspector/Model.svelte
@@ -153,6 +153,7 @@
       containerWidth = container.clientWidth;
     });
     observer.observe(container);
+    return () => observer.unobserve(container);
   });
 </script>
 

--- a/src/routes/_surfaces/workspace/Header.svelte
+++ b/src/routes/_surfaces/workspace/Header.svelte
@@ -11,9 +11,8 @@
   import EditIcon from "$lib/components/icons/EditIcon.svelte";
   import type { PersistentModelStore } from "$lib/application-state-stores/model-stores";
   import type { PersistentModelEntity } from "$common/data-modeler-state-service/entity-state-service/PersistentModelEntityService";
-  import { EntityStatus } from "$common/data-modeler-state-service/entity-state-service/EntityStateService";
-  import Spinner from "$lib/components/Spinner.svelte";
   import { ActionStatus } from "$common/data-modeler-service/response/ActionResponse";
+  import WorkspaceHeaderStatusSpinner from "./WorkspaceHeaderStatusSpinner.svelte";
 
   const store = getContext("rill:app:store") as ApplicationStore;
   const persistentModelStore = getContext(
@@ -36,8 +35,6 @@
   let titleInputValue;
   let tooltipActive;
 
-  let menuX;
-  let menuY;
   let clickOutsideListener;
 
   $: if (!contextMenuOpen && clickOutsideListener) {
@@ -54,21 +51,7 @@
     }
   }
 
-  let contextMenu;
   let contextMenuOpen = false;
-
-  // debounce the application status to resolve any quick flickers that
-  // may occur from quick changes to the application status.
-  let applicationStatus = 0;
-  let asTimer;
-  function debounceStatus(status: EntityStatus) {
-    clearTimeout(asTimer);
-    asTimer = setTimeout(() => {
-      applicationStatus = status;
-    }, 100);
-  }
-
-  $: debounceStatus($store?.status as unknown as EntityStatus);
 </script>
 
 <svelte:window on:keydown={onKeydown} />
@@ -126,24 +109,5 @@
       </h1>
     {/if}
   </div>
-  <div>
-    <div class="text-gray-400">
-      <Tooltip location="left" alignment="center" distance={16}>
-        <Spinner status={applicationStatus || EntityStatus.Idle} size="20px" />
-        <TooltipContent slot="tooltip-content">
-          {#if applicationStatus === EntityStatus.Idle}
-            idle
-          {:else if applicationStatus === EntityStatus.Running}
-            running
-          {:else if applicationStatus === EntityStatus.Exporting}
-            exporting a model resultset
-          {:else if applicationStatus === EntityStatus.Importing}
-            importing a table
-          {:else if applicationStatus === EntityStatus.Profiling}
-            profiling
-          {/if}
-        </TooltipContent>
-      </Tooltip>
-    </div>
-  </div>
+  <WorkspaceHeaderStatusSpinner />
 </header>

--- a/src/routes/_surfaces/workspace/ModelWorkspaceHeader.svelte
+++ b/src/routes/_surfaces/workspace/ModelWorkspaceHeader.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+  import { getContext } from "svelte";
+  import {
+    ApplicationStore,
+    dataModelerService,
+  } from "$lib/application-state-stores/application-store";
+
+  import type { PersistentModelStore } from "$lib/application-state-stores/model-stores";
+  import type { PersistentModelEntity } from "$common/data-modeler-state-service/entity-state-service/PersistentModelEntityService";
+  import { ActionStatus } from "$common/data-modeler-service/response/ActionResponse";
+  import WorkspaceHeader from "./WorkspaceHeader.svelte";
+
+  const store = getContext("rill:app:store") as ApplicationStore;
+  const persistentModelStore = getContext(
+    "rill:app:persistent-model-store"
+  ) as PersistentModelStore;
+
+  function formatModelName(str) {
+    let output = str.trim().replaceAll(" ", "_").replace(/\.sql/, "");
+    return output;
+  }
+
+  let currentModel: PersistentModelEntity;
+  $: if ($store?.activeEntity && $persistentModelStore?.entities)
+    currentModel = $persistentModelStore.entities.find(
+      (q) => q.id === $store.activeEntity.id
+    );
+
+  let titleInput = currentModel?.name;
+  $: titleInput = currentModel?.name;
+
+  // FIXME: this should eventually be a redux action dispatcher `onChangeAction`
+  const onChangeCallback = async (e) => {
+    if (currentModel?.id) {
+      const resp = await dataModelerService.dispatch("updateModelName", [
+        currentModel?.id,
+        formatModelName(e.target.value),
+      ]);
+      if (resp.status === ActionStatus.Failure) {
+        e.target.value = currentModel.name;
+      }
+    }
+  };
+</script>
+
+<WorkspaceHeader {...{ titleInput, onChangeCallback }} />

--- a/src/routes/_surfaces/workspace/WorkspaceHeaderStatusSpinner.svelte
+++ b/src/routes/_surfaces/workspace/WorkspaceHeaderStatusSpinner.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import { getContext } from "svelte";
+  import type { ApplicationStore } from "$lib/application-state-stores/application-store";
+
+  import Tooltip from "$lib/components/tooltip/Tooltip.svelte";
+  import TooltipContent from "$lib/components/tooltip/TooltipContent.svelte";
+  import { EntityStatus } from "$common/data-modeler-state-service/entity-state-service/EntityStateService";
+  import Spinner from "$lib/components/Spinner.svelte";
+
+  const store = getContext("rill:app:store") as ApplicationStore;
+
+  let applicationStatus = 0;
+  let asTimer;
+  function debounceStatus(status: EntityStatus) {
+    clearTimeout(asTimer);
+    asTimer = setTimeout(() => {
+      applicationStatus = status;
+    }, 100);
+  }
+
+  $: debounceStatus($store?.status as unknown as EntityStatus);
+
+  const applicationStatusTooltipMap = {
+    [EntityStatus.Idle]: "idle",
+    [EntityStatus.Running]: "running",
+    [EntityStatus.Exporting]: "exporting a model resultset",
+    [EntityStatus.Importing]: "importing a table",
+    [EntityStatus.Profiling]: "profiling",
+  };
+
+  $: applicationStatusTooltip = applicationStatusTooltipMap[applicationStatus];
+</script>
+
+<div>
+  <div class="text-gray-400">
+    <Tooltip location="left" alignment="center" distance={16}>
+      <Spinner status={applicationStatus || EntityStatus.Idle} size="20px" />
+      <TooltipContent slot="tooltip-content"
+        >{applicationStatusTooltip}
+      </TooltipContent>
+    </Tooltip>
+  </div>
+</div>

--- a/src/routes/_surfaces/workspace/index.svelte
+++ b/src/routes/_surfaces/workspace/index.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import ModelView from "./Model.svelte";
+  import Header from "./Header.svelte";
 </script>
 
+<Header />
 <ModelView />

--- a/src/routes/_surfaces/workspace/index.svelte
+++ b/src/routes/_surfaces/workspace/index.svelte
@@ -1,7 +1,21 @@
 <script lang="ts">
+  import { getContext } from "svelte";
   import ModelView from "./Model.svelte";
   import ModelWorkspaceHeader from "./ModelWorkspaceHeader.svelte";
+
+  import type { ApplicationStore } from "$lib/application-state-stores/application-store";
+
+  import { EntityType } from "$common/data-modeler-state-service/entity-state-service/EntityStateService";
+  const rillAppStore = getContext("rill:app:store") as ApplicationStore;
+
+  $: useModelWorkspace = $rillAppStore?.activeEntity?.type === EntityType.Model;
 </script>
 
-<ModelWorkspaceHeader />
-<ModelView />
+{#if useModelWorkspace}
+  <ModelWorkspaceHeader />
+  <ModelView />
+{:else}
+  <!-- FIXME: this placeholder is here to show where you would plug in another kind of workspace component -->
+  <ModelWorkspaceHeader />
+  <ModelView />
+{/if}

--- a/src/routes/_surfaces/workspace/index.svelte
+++ b/src/routes/_surfaces/workspace/index.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import ModelView from "./Model.svelte";
-  import Header from "./Header.svelte";
+  import ModelWorkspaceHeader from "./ModelWorkspaceHeader.svelte";
 </script>
 
-<Header />
+<ModelWorkspaceHeader />
 <ModelView />

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -3,7 +3,6 @@
   import Workspace from "./_surfaces/workspace/index.svelte";
   import InspectorSidebar from "./_surfaces/inspector/index.svelte";
   import AssetsSidebar from "./_surfaces/assets/index.svelte";
-  import Header from "./_surfaces/workspace/Header.svelte";
 
   import SurfaceViewIcon from "$lib/components/icons/SurfaceView.svelte";
   import SurfaceControlButton from "$lib/components/surface/SurfaceControlButton.svelte";
@@ -127,7 +126,6 @@
     style:top="0px"
     style:right="{$layout.inspectorWidth * (1 - $inspectorVisibilityTween)}px"
   >
-    <Header />
     <Workspace />
   </div>
 


### PR DESCRIPTION
this PR reorganizes the workspace component and so that components other than the Modeler workspace can be dropped in more easily. It also modularizes the header in particular so that it's not strongly coupled with Model entities, and so that other entities can be renamed via callback (although I guess you may not need that functionality Eric).

@ericpgreen2 this should enable you to entirely replace the modeler editor and it's container components, because that was the fastest thing to do in the short term and because I wasn't sure whether you'd need those containers for layout. even as I type this, I think it would probably be helpful to have some of that, so maybe I'll push some more commits to make this just a teeeeeny bit more modular so that you don't have to copy/paste a bunch of that layout code. But I'd say: don't wait on that, let's get this merged and we can follow up later. Also, we should sync up to talk about your plans and needs for the workspace table view.

This PR is also organized in such a way that stepping through the commits one by one may make the changes a bit clearer.