### PR TITLE
Fixing docker-publish step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ jobs:
     - stage: publish
       name: "Build & Publish docker"
       if: tag IS NOT present AND branch = main
+      install: docker --version
       script:
         - SHORT_SHA=$(git rev-parse --short HEAD)
         - echo ${DOCKERHUB_CRED} | docker login --username ${DOCKERHUB_USER} --password-stdin


### PR DESCRIPTION
Docker publish is failing during `npm ci`. This is not needed in docker publish. Disabling the install script for the docker publish step.