### PR TITLE
Fix a non-deterministic UI test

### DIFF
--- a/test/ui/DataModeler.spec.ts
+++ b/test/ui/DataModeler.spec.ts
@@ -244,7 +244,7 @@ export class DataModelerTest extends TestBase {
   ) {
     await page.goto(URL);
 
-    const error = page.locator(".error");
+    const error = page.locator(".error").first();
 
     await this.execute(page, query);
 
@@ -276,7 +276,7 @@ export class DataModelerTest extends TestBase {
    * @param sql {string} - SQL to execute.
    */
   private async execute(page: Page, sql: string) {
-    const activeLine = page.locator(".cm-activeLine");
+    const activeLine = page.locator(".cm-activeLine").first();
 
     await activeLine.fill(sql);
 


### PR DESCRIPTION
The `testInvalidSql` test was randomly erroring ~30% of the time due to `page.locator()` picking up multiple elements and throwing an error. I didn't investigate _why_ there is randomly >1 element, but taking the first element in the array avoids the error.