### PR TITLE
Add overlay for large import

### DIFF
--- a/src/lib/application-state-stores/layout-store.ts
+++ b/src/lib/application-state-stores/layout-store.ts
@@ -45,3 +45,5 @@ export const modelPreviewVisible = writable(true);
 modelPreviewVisible.subscribe((tf) => {
   modelPreviewVisibilityTween.set(tf ? 0 : 1);
 });
+
+export const importOverlayVisible = writable(false);

--- a/src/lib/components/overlay/PreparingImport.svelte
+++ b/src/lib/components/overlay/PreparingImport.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import BlockingOverlayContainer from "./BlockingOverlayContainer.svelte";
+</script>
+
+<BlockingOverlayContainer
+  bg="linear-gradient(to right, rgba(50,0,0,.6), rgba(50,0,30,.8))"
+>
+  <div slot="title">
+    <span class="font-bold">Preparing source for import</span>
+  </div>
+</BlockingOverlayContainer>

--- a/src/lib/util/file-upload.ts
+++ b/src/lib/util/file-upload.ts
@@ -2,6 +2,7 @@ import { extractFileExtension } from "$lib/util/extract-table-name";
 import { FILE_EXTENSION_TO_TABLE_TYPE } from "$lib/types";
 import notifications from "$lib/components/notifications";
 import { config } from "$lib/application-state-stores/application-store";
+import { importOverlayVisible } from "$lib/application-state-stores/layout-store";
 
 /**
  * uploadTableFiles
@@ -22,6 +23,10 @@ export function uploadTableFiles(files, apiBase: string) {
     }
   });
 
+  if (validFiles) {
+    importOverlayVisible.set(true)
+  }
+
   validFiles.forEach((validFile) =>
     uploadFile(validFile, `${apiBase}/table-upload`)
   );
@@ -37,7 +42,8 @@ export function uploadFile(file: File, url: string) {
     body: formData,
   })
     .then((...args) => console.error(...args))
-    .catch((...args) => console.error(...args));
+    .catch((...args) => console.error(...args))
+    .finally(() => importOverlayVisible.set(false));
 }
 
 function reportFileErrors(invalidFiles: File[]) {

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -28,8 +28,10 @@
     inspectorVisibilityTween,
     inspectorVisible,
     SIDE_PAD,
+    importOverlayVisible,
   } from "$lib/application-state-stores/layout-store";
   import { EntityStatus } from "$common/data-modeler-state-service/entity-state-service/EntityStateService";
+  import PreparingImport from "$lib/components/overlay/PreparingImport.svelte";
 
   let assetsHovered = false;
   let inspectorHovered = false;
@@ -73,6 +75,8 @@
     importName={persistentImportedTable.path}
     tableName={persistentImportedTable.name}
   />
+{:else if $importOverlayVisible}
+  <PreparingImport />
 {/if}
 
 <div class="absolute w-screen h-screen bg-gray-100">


### PR DESCRIPTION
Fix for #409 

Previously, the overlay only came up when the file was being ingested into duckdb. For large source files, there is some extra computation time required to prepare an API request for the file before it can be ingested. To address that have added a message stating "preparing source for import"

Overlay when user starts importing a large file
<img width="621" alt="image" src="https://user-images.githubusercontent.com/4402679/175005025-d174d310-20ff-4b38-9f7e-ee527a5be4e3.png">

Overlay when ingestion into duckdb begins
<img width="549" alt="image" src="https://user-images.githubusercontent.com/4402679/175005076-00ea64fa-51e6-474a-a058-1863f22d2762.png">

