### PR TITLE
Add `Modal` and `Button` components

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -42,6 +42,15 @@ body {
   overscroll-behavior: none;
 }
 
+input {
+  border: 1px solid #7b7b7b;
+  border-radius: 0.25rem;
+  font-family: "MD IO";
+  font-size: 12px;
+  padding: 0.25rem 0.5rem;
+  width: 100%;
+}
+
 .stack-list > * + * {
   margin-top: var(--gap, 1rem);
 }

--- a/src/app.css
+++ b/src/app.css
@@ -42,15 +42,6 @@ body {
   overscroll-behavior: none;
 }
 
-input {
-  border: 1px solid #7b7b7b;
-  border-radius: 0.25rem;
-  font-family: "MD IO";
-  font-size: 12px;
-  padding: 0.25rem 0.5rem;
-  width: 100%;
-}
-
 .stack-list > * + * {
   margin-top: var(--gap, 1rem);
 }

--- a/src/app.css
+++ b/src/app.css
@@ -42,51 +42,12 @@ body {
   overscroll-behavior: none;
 }
 
-button {
-  font-family: "MD IO";
-}
-
 .stack-list > * + * {
   margin-top: var(--gap, 1rem);
 }
 
 .stack + .stack {
   margin-top: var(--gap, 1rem);
-}
-
-.button {
-  padding: 0;
-  margin: 0;
-  padding: 0.5rem 1rem;
-  font-weight: bold;
-  background-color: black;
-  color: white;
-  border: none;
-}
-
-.small-action-button,
-.inspector-button {
-  padding: 0;
-  margin: 0;
-  background: transparent;
-  border: 1px solid transparent;
-  font-size: 0.75rem;
-  width: 1.5rem;
-  height: 1.5rem;
-  color: hsl(217, 5%, 60%);
-  display: inline-grid;
-  place-items: center;
-}
-
-.small-action-button:hover {
-  background-color: hsl(217, 15%, 95%);
-  cursor: pointer;
-  color: black;
-}
-
-.small-action-button.selected {
-  background-color: hsl(217, 15%, 85%);
-  color: black;
 }
 
 .hljs-punctuation {

--- a/src/lib/components/Button.svelte
+++ b/src/lib/components/Button.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   export let onClick: (event: any) => Promise<void> | void;
-  export let primary: boolean = false;
+  export let primary = false;
 </script>
 
 <button

--- a/src/lib/components/Button.svelte
+++ b/src/lib/components/Button.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  export let onClick: (event: any) => Promise<void> | void;
+  export let primary: boolean = false;
+</script>
+
+<button
+  class="px-4 py-2 rounded border border-gray-500 flex flex-row gap-x-2 {primary
+    ? 'bg-blue-400/50 hover:bg-blue-300 hover:border-blue-300'
+    : 'hover:bg-gray-200 hover:border-gray-200 transition-tranform duration-100'}"
+  on:click={onClick}
+>
+  <slot />
+</button>

--- a/src/lib/components/Input.svelte
+++ b/src/lib/components/Input.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  export let id = "";
+  export let label = "";
+  export let error: string;
+  export let value: string;
+</script>
+
+<label for={id} class="text-xs">{label}</label>
+<input
+  type="text"
+  {id}
+  class="border border-gray-400 rounded px-1 py-2 cursor-pointer focus:outline-blue-500 w-full text-xs"
+  bind:value
+/>
+{#if error}
+  <div class="text-red-500 text-xs">{error}</div>
+{/if}

--- a/src/lib/components/modal/Modal.svelte
+++ b/src/lib/components/modal/Modal.svelte
@@ -8,11 +8,13 @@
 {#if open}
   <Portal>
     <div
+      id="overlay"
       class="fixed z-40 top-0 bottom-0 left-0 right-0 backdrop-contrast-50"
       on:click={onBackdropClick}
     />
     <div
-      class="fixed z-50 w-1/4 top-1/3 left-1/2 -translate-x-1/2 -translate-y-1/2 border border-gray-500 rounded px-8 py-6 bg-white"
+      id="modal"
+      class="fixed z-50 w-1/2 lg:w-2/5 xl:w-1/3 2xl:w-1/4 top-1/3 left-1/2 -translate-x-1/2 -translate-y-1/2 border border-gray-500 rounded px-8 py-6 bg-white"
     >
       <slot />
     </div>

--- a/src/lib/components/modal/Modal.svelte
+++ b/src/lib/components/modal/Modal.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  import Portal from "../Portal.svelte";
+
+  export let open: boolean = false;
+  export let onBackdropClick: () => void = () => {};
+</script>
+
+{#if open}
+  <Portal>
+    <div
+      class="fixed z-40 top-0 bottom-0 left-0 right-0 backdrop-contrast-50"
+      on:click={onBackdropClick}
+    />
+    <div
+      class="fixed z-50 w-1/4 top-1/3 left-1/2 -translate-x-1/2 -translate-y-1/2 border border-gray-500 rounded px-8 py-6 bg-white"
+    >
+      <slot />
+    </div>
+  </Portal>
+{/if}

--- a/src/lib/components/modal/Modal.svelte
+++ b/src/lib/components/modal/Modal.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import Portal from "../Portal.svelte";
 
-  export let open: boolean = false;
-  export let onBackdropClick: () => void = () => {};
+  export let open = false;
+  export let onBackdropClick: () => void;
 </script>
 
 {#if open}

--- a/src/lib/components/modal/ModalAction.svelte
+++ b/src/lib/components/modal/ModalAction.svelte
@@ -2,7 +2,7 @@
   import Button from "../Button.svelte";
 
   export let onClick: (event: any) => void;
-  export let primary: boolean = false;
+  export let primary = false;
 </script>
 
 <Button {onClick} {primary}>

--- a/src/lib/components/modal/ModalAction.svelte
+++ b/src/lib/components/modal/ModalAction.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import Button from "../Button.svelte";
+
+  export let onClick: (event: any) => void;
+  export let primary: boolean = false;
+</script>
+
+<Button {onClick} {primary}>
+  <slot />
+</Button>

--- a/src/lib/components/modal/ModalActions.svelte
+++ b/src/lib/components/modal/ModalActions.svelte
@@ -1,0 +1,3 @@
+<div class="flex justify-between mt-5">
+  <slot />
+</div>

--- a/src/lib/components/modal/ModalContent.svelte
+++ b/src/lib/components/modal/ModalContent.svelte
@@ -1,0 +1,1 @@
+<p class="text-lg"><slot /></p>

--- a/src/lib/components/modal/ModalTitle.svelte
+++ b/src/lib/components/modal/ModalTitle.svelte
@@ -1,0 +1,3 @@
+<h1 class="text-base font-bold mb-2">
+  <slot />
+</h1>

--- a/src/routes/_surfaces/inspector/Model.svelte
+++ b/src/routes/_surfaces/inspector/Model.svelte
@@ -36,6 +36,7 @@
   import CollapsibleTableSummary from "$lib/components/column-profile/CollapsibleTableSummary.svelte";
 
   import { COLUMN_PROFILE_CONFIG } from "$lib/application-config";
+  import Button from "$lib/components/Button.svelte";
 
   const persistentTableStore = getContext(
     "rill:app:persistent-table-store"
@@ -172,9 +173,8 @@
             distance={16}
             suppress={contextMenuOpen}
           >
-            <button
-              bind:this={contextMenu}
-              on:click={async (event) => {
+            <Button
+              onClick={async (event) => {
                 contextMenuOpen = !contextMenuOpen;
                 menuX = event.clientX;
                 menuY = event.clientY;
@@ -185,26 +185,10 @@
                   }, contextMenu);
                 }
               }}
-              style:grid-column="left-control"
-              class="
-          hover:bg-gray-300
-          hover:border-gray-300
-          border-black
-          transition-tranform 
-          duration-100
-          items-center
-          justify-center
-          border
-          border-transparent
-          rounded
-          flex flex-row gap-x-2
-          pl-4 pr-4
-          pt-2 pb-2
-        "
             >
               export
               <Export size="16px" />
-            </button>
+            </Button>
             <TooltipContent slot="tooltip-content">
               export this model as a dataset
             </TooltipContent>


### PR DESCRIPTION
Addresses #431.

To check out how these components look in practice, I use them on the `rename-source` branch: https://github.com/rilldata/rill-developer/tree/rename-source.  If you pull the branch and run the application, you'll find in the Source assets panel, the ellipsis button now includes a "rename {source}" option. Click that and it'll bring up a modal with buttons.