### PR TITLE
Enable source drop on full screen

### DIFF
--- a/src/lib/components/overlay/FileDrop.svelte
+++ b/src/lib/components/overlay/FileDrop.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import Overlay from "./Overlay.svelte";
+  import { onSourceDrop } from "$lib/util/file-upload";
+
+  export let showDropOverlay: boolean;
+</script>
+
+<Overlay bg="rgba(0,0,0,.6)">
+  <div
+    class="w-screen h-screen grid place-content-center"
+    on:drop|preventDefault|stopPropagation={(e) => {
+      showDropOverlay = false;
+      onSourceDrop(e);
+    }}
+    on:mouseup|preventDefault|stopPropagation={() => {
+      showDropOverlay = false;
+    }}
+    on:drag|preventDefault|stopPropagation
+    on:dragenter|preventDefault|stopPropagation
+    on:dragover|preventDefault|stopPropagation
+    on:dragleave|preventDefault|stopPropagation
+  >
+    <div
+      class="grid place-content-center grid-gap-2 text-white m-auto p-6 break-all"
+      style:font-size="32px"
+    >
+      <span class="place-content-center">
+        Drop your files to add new source
+      </span>
+    </div>
+  </div>
+</Overlay>

--- a/src/lib/components/overlay/FileDrop.svelte
+++ b/src/lib/components/overlay/FileDrop.svelte
@@ -21,11 +21,10 @@
     on:dragleave|preventDefault|stopPropagation
   >
     <div
-      class="grid place-content-center grid-gap-2 text-white m-auto p-6 break-all"
-      style:font-size="32px"
+      class="grid place-content-center grid-gap-2 text-white m-auto p-6 break-all text-3xl"
     >
       <span class="place-content-center">
-        Drop your files to add new source
+        drop your files to add new source
       </span>
     </div>
   </div>

--- a/src/routes/_surfaces/assets/TableAssets.svelte
+++ b/src/routes/_surfaces/assets/TableAssets.svelte
@@ -15,7 +15,7 @@
     PersistentTableStore,
   } from "$lib/application-state-stores/table-stores";
 
-  import { onSourceDrop, uploadFilesWithDialog } from "$lib/util/file-upload";
+  import { uploadFilesWithDialog } from "$lib/util/file-upload";
 
   const persistentTableStore = getContext(
     "rill:app:persistent-table-store"
@@ -31,11 +31,6 @@
 <div
   class="pl-4 pb-3 pr-4 pt-5 grid justify-between"
   style="grid-template-columns: auto max-content;"
-  on:drop|preventDefault|stopPropagation={onSourceDrop}
-  on:drag|preventDefault|stopPropagation
-  on:dragenter|preventDefault|stopPropagation
-  on:dragover|preventDefault|stopPropagation
-  on:dragleave|preventDefault|stopPropagation
 >
   <CollapsibleSectionTitle tooltipText={"sources"} bind:active={showTables}>
     <h4 class="flex flex-row items-center gap-x-2">
@@ -52,15 +47,7 @@
   </ContextButton>
 </div>
 {#if showTables}
-  <div
-    class="pb-6"
-    transition:slide|local={{ duration: 200 }}
-    on:drop|preventDefault|stopPropagation={onSourceDrop}
-    on:drag|preventDefault|stopPropagation
-    on:dragenter|preventDefault|stopPropagation
-    on:dragover|preventDefault|stopPropagation
-    on:dragleave|preventDefault|stopPropagation
-  >
+  <div class="pb-6" transition:slide|local={{ duration: 200 }}>
     {#if $persistentTableStore?.entities && $derivedTableStore?.entities}
       <!-- TODO: fix the object property access back to t.id from t["id"] once svelte fixes it -->
       {#each $persistentTableStore.entities as { tableName, id } (id)}

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -9,6 +9,7 @@
 
   import ImportingTable from "$lib/components/overlay/ImportingTable.svelte";
   import ExportingDataset from "$lib/components/overlay/ExportingDataset.svelte";
+  import FileDrop from "$lib/components/overlay/FileDrop.svelte";
 
   import type {
     PersistentModelStore,
@@ -31,6 +32,7 @@
   } from "$lib/application-state-stores/layout-store";
   import { EntityStatus } from "$common/data-modeler-state-service/entity-state-service/EntityStateService";
 
+  let showDropOverlay = false;
   let assetsHovered = false;
   let inspectorHovered = false;
 
@@ -73,9 +75,20 @@
     importName={persistentImportedTable.path}
     tableName={persistentImportedTable.name}
   />
+{:else if showDropOverlay}
+  <FileDrop bind:showDropOverlay />
 {/if}
 
-<div class="absolute w-screen h-screen bg-gray-100">
+<div
+  class="absolute w-screen h-screen bg-gray-100"
+  on:drop|preventDefault|stopPropagation
+  on:drag|preventDefault|stopPropagation
+  on:dragenter|preventDefault|stopPropagation
+  on:dragover|preventDefault|stopPropagation={() => {
+    showDropOverlay = true;
+  }}
+  on:dragleave|preventDefault|stopPropagation
+>
   <!-- left assets pane expansion button -->
   <!-- make this the first element to select with tab by placing it first.-->
   <SurfaceControlButton


### PR DESCRIPTION
Closes #425 

The below UI feedback is shown to user when a drag event comes into the app
<img width="1511" alt="Screenshot 2022-06-24 at 4 50 41 PM" src="https://user-images.githubusercontent.com/4402679/175524608-8b7a1ba8-a3a2-454e-bc45-d5390872536d.png">
