### PR TITLE
Set a max column width for the Preview Table

### DIFF
--- a/src/lib/components/table/PreviewTable.svelte
+++ b/src/lib/components/table/PreviewTable.svelte
@@ -16,8 +16,9 @@
   export let columnNames: ColumnName[];
   export let rows: any[];
 
-  let selectedColumns = [];
+  const MAX_COLUMN_WIDTH = "250px";
 
+  let selectedColumns = [];
   let activeIndex;
 
   function columnIsPinned(name, selectedCols) {
@@ -49,6 +50,7 @@
           on:pin={() => {
             togglePin(name, type, selectedColumns);
           }}
+          maxWidth={MAX_COLUMN_WIDTH}
         />
       {/each}
     </TableRow>
@@ -61,6 +63,7 @@
             {type}
             value={row[name]}
             isNull={row[name] === null}
+            maxWidth={MAX_COLUMN_WIDTH}
           />
         {/each}
       </TableRow>
@@ -78,6 +81,7 @@
             <PreviewTableHeader
               {name}
               {type}
+              maxWidth={MAX_COLUMN_WIDTH}
               pinned={thisColumnIsPinned}
               on:pin={() => {
                 togglePin(name, type, selectedColumns);
@@ -96,6 +100,7 @@
                 {index}
                 isNull={row[name] === null}
                 value={row[name]}
+                maxWidth={MAX_COLUMN_WIDTH}
               />
             {/each}
           </TableRow>

--- a/src/lib/components/table/PreviewTableHeader.svelte
+++ b/src/lib/components/table/PreviewTableHeader.svelte
@@ -16,12 +16,13 @@
   export let name: string;
   export let type: string;
   export let pinned = false;
+  export let maxWidth = "";
 
   const dispatch = createEventDispatcher();
   const { shiftClickAction } = createShiftClickAction();
 </script>
 
-<TableHeader>
+<TableHeader {maxWidth}>
   <div
     use:shiftClickAction
     on:shift-click={async () => {

--- a/src/lib/components/table/TableCell.svelte
+++ b/src/lib/components/table/TableCell.svelte
@@ -29,6 +29,7 @@
   export let name;
   export let index = undefined;
   export let isNull = false;
+  export let maxWidth = "";
 
   const dispatch = createEventDispatcher();
   /**
@@ -81,6 +82,7 @@
         border-gray-200
         {activeCell && 'bg-gray-200'}
     "
+    style={maxWidth && `max-width: ${maxWidth}`}
   >
     <button
       class="text-left w-full text-ellipsis overflow-hidden whitespace-nowrap"

--- a/src/lib/components/table/TableHeader.svelte
+++ b/src/lib/components/table/TableHeader.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   export let sticky = "top";
+  export let maxWidth = "";
 </script>
 
 <th
@@ -8,6 +9,7 @@
   class:top-0={sticky === "top"}
   class:left-0={sticky === "left"}
   class:z-10={!!sticky}
+  style={maxWidth && `max-width: ${maxWidth}`}
 >
   <div
     class="


### PR DESCRIPTION
Wide, unbounded columns were mistakenly introduced by #440. This commit adds a `max-width` to the table cells.