### PR TITLE
Remove overlay on invalid drop

### DIFF
--- a/src/lib/util/file-upload.ts
+++ b/src/lib/util/file-upload.ts
@@ -69,6 +69,7 @@ export function handleFileUploads(filesArray: File[]) {
     );
   }
   if (invalidFiles.length) {
+    importOverlayVisible.set(false);
     reportFileErrors(invalidFiles);
   }
 }


### PR DESCRIPTION
If you drop an invalid file (non csv, parquet), the UI is stuck at an overlay screen. This got introduced in #436 