### PR TITLE
Make export work on build

### DIFF
--- a/src/server/ExpressServer.ts
+++ b/src/server/ExpressServer.ts
@@ -144,7 +144,7 @@ export class ExpressServer {
         "Content-Disposition",
         `attachment; filename="${fileName}"`
       );
-      res.sendFile(fullPath);
+      res.sendFile(path.resolve(fullPath));
     } else {
       res.status(500);
       res.send(`Failed to export file ${fileName}`);


### PR DESCRIPTION
Relative path is considered malicious. We get ForbiddenError if we export from a build.

This PR fixes the above issue.