### PR TITLE
Add independent time range arguments to time series API

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -10,7 +10,6 @@ scripts/
 state/
 static/
 temp/
-test/data/
 
 *.sql
 *.csv

--- a/src/common/database-service/DatabaseTimeSeriesActions.ts
+++ b/src/common/database-service/DatabaseTimeSeriesActions.ts
@@ -25,8 +25,8 @@ export interface TimeSeriesRollup {
 }
 export interface TimeSeriesTimeRange {
   interval?: string;
-  start?: string | number;
-  end?: string | number;
+  start?: string;
+  end?: string;
 }
 
 export class DatabaseTimeSeriesActions extends DatabaseActions {

--- a/src/common/database-service/DuckDBClient.ts
+++ b/src/common/database-service/DuckDBClient.ts
@@ -51,6 +51,7 @@ export class DuckDBClient {
           }
         });
       } catch (err) {
+        if (log) console.error(err);
         reject(err);
       }
     });

--- a/src/common/rill-developer-service/RillDeveloperService.ts
+++ b/src/common/rill-developer-service/RillDeveloperService.ts
@@ -92,7 +92,6 @@ export class RillDeveloperService {
       if (!returnResponse)
         returnResponse = ActionResponseFactory.getSuccessResponse();
     } catch (err) {
-      console.log(err);
       returnResponse = ActionResponseFactory.getErrorResponse(err);
     }
 

--- a/src/lib/redux-store/big-number/big-number-apis.ts
+++ b/src/lib/redux-store/big-number/big-number-apis.ts
@@ -28,11 +28,8 @@ export const generateBigNumbersApi = createAsyncThunk(
     thunkAPI
   ) => {
     const state = thunkAPI.getState() as RillReduxState;
-    const { prunedFilters, normalisedMeasures } = selectMetricsExploreParams(
-      state,
-      id,
-      { measures, filters }
-    );
+    const { metricsExplore, prunedFilters, normalisedMeasures } =
+      selectMetricsExploreParams(state, id, { measures, filters });
     const anythingSelected = isAnythingSelected(prunedFilters);
 
     const stream = streamingFetchWrapper<BigNumberResponse>(
@@ -41,6 +38,7 @@ export const generateBigNumbersApi = createAsyncThunk(
       {
         measures: normalisedMeasures,
         filters: prunedFilters,
+        timeRange: metricsExplore.selectedTimeRange,
       }
     );
     for await (const bigNumberEntity of stream) {

--- a/src/lib/redux-store/explore/explore-apis.ts
+++ b/src/lib/redux-store/explore/explore-apis.ts
@@ -1,11 +1,12 @@
 import { EntityType } from "$common/data-modeler-state-service/entity-state-service/EntityStateService";
 import type { RillReduxState } from "$lib/redux-store/store-root";
 import { prune } from "../../../routes/_surfaces/workspace/explore/utils";
-import { streamingFetchWrapper } from "$lib/util/fetchWrapper";
+import { fetchWrapper, streamingFetchWrapper } from "$lib/util/fetchWrapper";
 import {
   clearSelectedLeaderboardValues,
   initMetricsExplore,
   MetricsExploreEntity,
+  setExploreTimeRange,
   setLeaderboardDimensionValues,
   setMeasureId,
   toggleExploreMeasure,
@@ -138,5 +139,20 @@ export const updateLeaderboardValuesApi = createAsyncThunk(
         )
       );
     }
+  }
+);
+
+/**
+ * Fetches time range for the selected timestamp column.
+ * Store the response in MetricsExplore slice by calling {@link setExploreTimeRange}
+ */
+export const fetchTimestampColumnRangeApi = createAsyncThunk(
+  `${EntityType.MetricsLeaderboard}/getTimestampColumnRange`,
+  async (metricsDefId: string, thunkAPI) => {
+    const timeRange = await fetchWrapper(
+      `metrics/${metricsDefId}/time-range`,
+      "GET"
+    );
+    thunkAPI.dispatch(setExploreTimeRange(metricsDefId, timeRange));
   }
 );

--- a/src/lib/redux-store/explore/explore-selectors.ts
+++ b/src/lib/redux-store/explore/explore-selectors.ts
@@ -6,6 +6,7 @@ import type { ActiveValues } from "$lib/redux-store/explore/explore-slice";
 import { prune } from "../../../routes/_surfaces/workspace/explore/utils";
 import { selectMeasureById } from "$lib/redux-store/measure-definition/measure-definition-selectors";
 import type { BasicMeasureDefinition } from "$common/data-modeler-state-service/entity-state-service/MeasureDefinitionStateService";
+import type { TimeSeriesTimeRange } from "$common/database-service/DatabaseTimeSeriesActions";
 
 export const {
   manySelector: selectMetricsExplores,
@@ -23,7 +24,10 @@ export const selectMetricsExploreParams = (
   {
     measures,
     filters,
-  }: { measures?: Array<MeasureDefinitionEntity>; filters?: ActiveValues }
+  }: {
+    measures?: Array<MeasureDefinitionEntity>;
+    filters?: ActiveValues;
+  }
 ) => {
   const metricsExplore = selectMetricsExploreById(state, id);
 

--- a/src/lib/redux-store/explore/explore-slice.ts
+++ b/src/lib/redux-store/explore/explore-slice.ts
@@ -5,6 +5,7 @@ import {
 import type { PayloadAction } from "@reduxjs/toolkit";
 import type { DimensionDefinitionEntity } from "$common/data-modeler-state-service/entity-state-service/DimensionDefinitionStateService";
 import type { MeasureDefinitionEntity } from "$common/data-modeler-state-service/entity-state-service/MeasureDefinitionStateService";
+import type { TimeSeriesTimeRange } from "$common/database-service/DatabaseTimeSeriesActions";
 
 export interface LeaderboardValues {
   values: Array<unknown>;
@@ -21,6 +22,8 @@ export interface MetricsExploreEntity {
   leaderboards: Array<LeaderboardValues>;
   activeValues: ActiveValues;
   selectedCount: number;
+  // time range of the selected timestamp column
+  timeRange?: TimeSeriesTimeRange;
 }
 
 const metricsExploreAdapter = createEntityAdapter<MetricsExploreEntity>();
@@ -205,6 +208,21 @@ export const exploreSlice = createSlice({
       },
       prepare: (id) => ({ payload: id }),
     },
+
+    setExploreTimeRange: {
+      reducer: (
+        state,
+        {
+          payload: { id, timeRange },
+        }: PayloadAction<{ id: string; timeRange: TimeSeriesTimeRange }>
+      ) => {
+        if (!state.entities[id]) return;
+        state.entities[id].timeRange = timeRange;
+      },
+      prepare: (id: string, timeRange: TimeSeriesTimeRange) => ({
+        payload: { id, timeRange },
+      }),
+    },
   },
 });
 
@@ -215,6 +233,7 @@ export const {
   toggleLeaderboardActiveValue,
   setLeaderboardDimensionValues,
   clearSelectedLeaderboardValues,
+  setExploreTimeRange,
 } = exploreSlice.actions;
 export const MetricsLeaderboardSliceActions = exploreSlice.actions;
 export type MetricsLeaderboardSliceTypes =

--- a/src/lib/redux-store/explore/explore-slice.ts
+++ b/src/lib/redux-store/explore/explore-slice.ts
@@ -7,8 +7,12 @@ import type { DimensionDefinitionEntity } from "$common/data-modeler-state-servi
 import type { MeasureDefinitionEntity } from "$common/data-modeler-state-service/entity-state-service/MeasureDefinitionStateService";
 import type { TimeSeriesTimeRange } from "$common/database-service/DatabaseTimeSeriesActions";
 
+export interface LeaderboardValue {
+  value: number;
+  label: string;
+}
 export interface LeaderboardValues {
-  values: Array<unknown>;
+  values: Array<LeaderboardValue>;
   displayName: string;
 }
 
@@ -24,6 +28,8 @@ export interface MetricsExploreEntity {
   selectedCount: number;
   // time range of the selected timestamp column
   timeRange?: TimeSeriesTimeRange;
+  // user selected time range
+  selectedTimeRange?: TimeSeriesTimeRange;
 }
 
 const metricsExploreAdapter = createEntityAdapter<MetricsExploreEntity>();
@@ -170,7 +176,7 @@ export const exploreSlice = createSlice({
         }: PayloadAction<{
           id: string;
           dimensionName: string;
-          values: Array<unknown>;
+          values: Array<LeaderboardValue>;
         }>
       ) => {
         if (!state.entities[id]) return;
@@ -190,7 +196,11 @@ export const exploreSlice = createSlice({
           ];
         }
       },
-      prepare: (id: string, dimensionName: string, values: Array<unknown>) => ({
+      prepare: (
+        id: string,
+        dimensionName: string,
+        values: Array<LeaderboardValue>
+      ) => ({
         payload: { id, dimensionName, values },
       }),
     },
@@ -223,6 +233,31 @@ export const exploreSlice = createSlice({
         payload: { id, timeRange },
       }),
     },
+
+    setExploreSelectedTimeRange: {
+      reducer: (
+        state,
+        {
+          payload: { id, selectedTimeRange },
+        }: PayloadAction<{
+          id: string;
+          selectedTimeRange: Partial<TimeSeriesTimeRange>;
+        }>
+      ) => {
+        if (!state.entities[id]) return;
+        // overrides only the ones passed
+        state.entities[id].selectedTimeRange = {
+          ...(state.entities[id].selectedTimeRange ?? {}),
+          ...selectedTimeRange,
+        };
+      },
+      prepare: (
+        id: string,
+        selectedTimeRange: Partial<TimeSeriesTimeRange>
+      ) => ({
+        payload: { id, selectedTimeRange },
+      }),
+    },
   },
 });
 
@@ -234,6 +269,7 @@ export const {
   setLeaderboardDimensionValues,
   clearSelectedLeaderboardValues,
   setExploreTimeRange,
+  setExploreSelectedTimeRange,
 } = exploreSlice.actions;
 export const MetricsLeaderboardSliceActions = exploreSlice.actions;
 export type MetricsLeaderboardSliceTypes =

--- a/src/lib/redux-store/timeseries/timeseries-apis.ts
+++ b/src/lib/redux-store/timeseries/timeseries-apis.ts
@@ -34,11 +34,8 @@ export const generateTimeSeriesApi = createAsyncThunk(
     thunkAPI
   ) => {
     const state = thunkAPI.getState() as RillReduxState;
-    const { prunedFilters, normalisedMeasures } = selectMetricsExploreParams(
-      state,
-      id,
-      { measures, filters }
-    );
+    const { metricsExplore, prunedFilters, normalisedMeasures } =
+      selectMetricsExploreParams(state, id, { measures, filters });
 
     const stream = streamingFetchWrapper<TimeSeriesResponse>(
       `metrics/${id}/time-series`,
@@ -47,7 +44,7 @@ export const generateTimeSeriesApi = createAsyncThunk(
         measures: normalisedMeasures,
         filters: prunedFilters,
         pixels,
-        timeRange,
+        timeRange: timeRange ?? metricsExplore.selectedTimeRange,
       }
     );
     for await (const timeSeriesResponse of stream) {

--- a/src/lib/redux-store/timeseries/timeseries-apis.ts
+++ b/src/lib/redux-store/timeseries/timeseries-apis.ts
@@ -3,10 +3,12 @@ import type { MeasureDefinitionEntity } from "$common/data-modeler-state-service
 import { createAsyncThunk } from "$lib/redux-store/redux-toolkit-wrapper";
 import { EntityType } from "$common/data-modeler-state-service/entity-state-service/EntityStateService";
 import { streamingFetchWrapper } from "$lib/util/fetchWrapper";
-import type { TimeSeriesResponse } from "$common/database-service/DatabaseTimeSeriesActions";
+import type {
+  TimeSeriesResponse,
+  TimeSeriesTimeRange,
+} from "$common/database-service/DatabaseTimeSeriesActions";
 import { updateTimeSeries } from "$lib/redux-store/timeseries/timeseries-slice";
 import type { RillReduxState } from "$lib/redux-store/store-root";
-import type { RollupInterval } from "$common/database-service/DatabaseColumnActions";
 import { selectMetricsExploreParams } from "$lib/redux-store/explore/explore-selectors";
 
 /**
@@ -21,13 +23,13 @@ export const generateTimeSeriesApi = createAsyncThunk(
       measures,
       filters,
       pixels,
-      rollupInterval,
+      timeRange,
     }: {
       id: string;
       measures?: Array<MeasureDefinitionEntity>;
       filters?: ActiveValues;
       pixels?: number;
-      rollupInterval?: RollupInterval;
+      timeRange?: TimeSeriesTimeRange;
     },
     thunkAPI
   ) => {
@@ -45,7 +47,7 @@ export const generateTimeSeriesApi = createAsyncThunk(
         measures: normalisedMeasures,
         filters: prunedFilters,
         pixels,
-        rollupInterval,
+        timeRange,
       }
     );
     for await (const timeSeriesResponse of stream) {
@@ -53,7 +55,7 @@ export const generateTimeSeriesApi = createAsyncThunk(
         updateTimeSeries({
           id: timeSeriesResponse.id,
           values: timeSeriesResponse.results,
-          rollupInterval: timeSeriesResponse.rollupInterval,
+          timeRange: timeSeriesResponse.timeRange,
           spark: timeSeriesResponse.spark,
         })
       );

--- a/src/lib/redux-store/timeseries/timeseries-slice.ts
+++ b/src/lib/redux-store/timeseries/timeseries-slice.ts
@@ -2,6 +2,7 @@ import {
   createSlice,
   createEntityAdapter,
 } from "$lib/redux-store/redux-toolkit-wrapper";
+import type { TimeSeriesTimeRange } from "$common/database-service/DatabaseTimeSeriesActions";
 
 export type TimeSeriesValue = {
   ts: string;
@@ -10,7 +11,9 @@ export type TimeSeriesValue = {
 
 export interface TimeSeriesEntity {
   id: string;
-  rollupInterval: string;
+  // time range for the time series.
+  // this could be different from the one selected by the User
+  timeRange: TimeSeriesTimeRange;
   values: Array<TimeSeriesValue>;
   spark: Array<TimeSeriesValue>;
 }

--- a/src/routes/_surfaces/workspace/explore/ExploreHeader.svelte
+++ b/src/routes/_surfaces/workspace/explore/ExploreHeader.svelte
@@ -1,10 +1,6 @@
 <script lang="ts">
   import { fly } from "svelte/transition";
-  import CheckerFull from "$lib/components/icons/CheckerFull.svelte";
-  import CheckerHalf from "$lib/components/icons/CheckerHalf.svelte";
   import Close from "$lib/components/icons/Close.svelte";
-  import Tooltip from "$lib/components/tooltip/Tooltip.svelte";
-  import TooltipContent from "$lib/components/tooltip/TooltipContent.svelte";
   import { store } from "$lib/redux-store/store-root";
   import type { MetricsExploreEntity } from "$lib/redux-store/explore/explore-slice";
   import { isAnythingSelected } from "$lib/util/isAnythingSelected";

--- a/src/server/ExpressServer.ts
+++ b/src/server/ExpressServer.ts
@@ -58,6 +58,11 @@ export class ExpressServer {
     console.log(`Server started at ${this.config.server.serverUrl}`);
   }
 
+  public async destroy(): Promise<void> {
+    await this.socketServer.destroy();
+    this.server.close();
+  }
+
   private setupMiddlewares() {
     this.app.use(
       cors({

--- a/src/server/controllers/EntityController.ts
+++ b/src/server/controllers/EntityController.ts
@@ -94,6 +94,7 @@ export abstract class EntityController extends RillDeveloperController {
     res: Response,
     callback: (context: RillRequestContext) => Promise<ActionResponse>
   ) {
+    res.setHeader("Content-Type", "application/json");
     try {
       const response = await callback(RillRequestContext.getNewContext());
       if (!response || response.status === ActionStatus.Failure) {

--- a/src/server/controllers/MetricsExploreController.ts
+++ b/src/server/controllers/MetricsExploreController.ts
@@ -1,12 +1,14 @@
 import { RillDeveloperController } from "$server/controllers/RillDeveloperController";
 import type { Router, Request, Response } from "express";
-import { RillRequestContext } from "$common/rill-developer-service/RillRequestContext";
-import { RillActionsChannel } from "$common/utils/RillActionsChannel";
+import { EntityController } from "$server/controllers/EntityController";
 
 export class MetricsExploreController extends RillDeveloperController {
   protected setupRouter(router: Router) {
     router.post("/metrics/:id/time-series", (req: Request, res: Response) =>
       this.handleGetTimeSeries(req, res)
+    );
+    router.get("/metrics/:id/time-range", (req: Request, res: Response) =>
+      this.handleGetTimeRange(req, res)
     );
     router.post("/metrics/:id/leaderboards", (req: Request, res: Response) =>
       this.handleGetLeaderboards(req, res)
@@ -21,6 +23,14 @@ export class MetricsExploreController extends RillDeveloperController {
       this.rillDeveloperService.dispatch(context, "generateTimeSeries", [
         req.params.id,
         req.body,
+      ])
+    );
+  }
+
+  private async handleGetTimeRange(req: Request, res: Response) {
+    await EntityController.wrapAction(res, (context) =>
+      this.rillDeveloperService.dispatch(context, "getTimeRange", [
+        req.params.id,
       ])
     );
   }

--- a/src/server/controllers/MetricsExploreController.ts
+++ b/src/server/controllers/MetricsExploreController.ts
@@ -39,8 +39,7 @@ export class MetricsExploreController extends RillDeveloperController {
     return this.wrapHttpStream(res, (context) =>
       this.rillDeveloperService.dispatch(context, "getLeaderboardValues", [
         req.params.id,
-        req.body.measureId,
-        req.body.filters,
+        req.body,
       ])
     );
   }

--- a/test/data/MetricsExplore.data.ts
+++ b/test/data/MetricsExplore.data.ts
@@ -1,0 +1,156 @@
+import type { ActiveValues } from "$lib/redux-store/explore/explore-slice";
+import { PreviewRollupInterval } from "$lib/duckdb-data-types";
+import type { TimeSeriesTimeRange } from "$common/database-service/DatabaseTimeSeriesActions";
+import {
+  getTimeRange,
+  TimeSeriesMeasureRange,
+} from "../utils/time-series-helpers";
+
+export interface MetricsExploreTestDataType {
+  title: string;
+
+  // request arguments
+  measures?: Array<number>;
+  filters?: ActiveValues;
+  timeRange?: TimeSeriesTimeRange;
+
+  // assert arguments
+  previewRollupInterval: PreviewRollupInterval;
+  measureRanges?: Array<TimeSeriesMeasureRange>;
+  leaderboards: Array<[string, Array<string>]>;
+  bigNumber: TimeSeriesMeasureRange;
+}
+
+const DefaultDomainLeaderboard: [string, Array<string>] = [
+  "domain",
+  [
+    "facebook.com",
+    "google.com",
+    "msn.com",
+    "news.yahoo.com",
+    "instagram.com",
+    "news.google.com",
+    "sports.yahoo.com",
+  ],
+];
+const DefaultCityLeaderboard: [string, Array<string>] = [
+  "city",
+  [
+    "Bengaluru",
+    "Boston",
+    "Delhi",
+    "Dublin",
+    "Kolkata",
+    "London",
+    "Los Angeles",
+    "Mumbai",
+    "New York City",
+    "San Francisco",
+  ],
+];
+
+export const MetricsExploreTestData: Array<MetricsExploreTestDataType> = [
+  {
+    title: "basic request",
+    previewRollupInterval: PreviewRollupInterval.day,
+    leaderboards: [
+      ["publisher", ["Facebook", "Google", "Yahoo", "Microsoft"]],
+      DefaultDomainLeaderboard,
+      DefaultCityLeaderboard,
+      ["country", ["India", "USA", "Ireland", "UK"]],
+    ],
+    bigNumber: { impressions: [50000, 50000], bid_price: [2.75, 3.25] },
+  },
+  {
+    title: "request by month",
+    timeRange: getTimeRange(PreviewRollupInterval.month),
+    previewRollupInterval: PreviewRollupInterval.month,
+    leaderboards: [
+      ["publisher", ["Facebook", "Google", "Yahoo", "Microsoft"]],
+      DefaultDomainLeaderboard,
+      DefaultCityLeaderboard,
+      ["country", ["India", "USA", "Ireland", "UK"]],
+    ],
+    bigNumber: { impressions: [50000, 50000], bid_price: [2.75, 3.25] },
+  },
+  {
+    title: "request with filters",
+    timeRange: getTimeRange(PreviewRollupInterval.month),
+    previewRollupInterval: PreviewRollupInterval.month,
+    filters: {
+      domain: [["sports.yahoo.com", true]],
+    },
+    measureRanges: [
+      { impressions: [3500, 4500], bid_price: [3, 4] },
+      { impressions: [750, 1250], bid_price: [1, 2] },
+      { impressions: [750, 1250], bid_price: [1, 2] },
+    ],
+    leaderboards: [
+      ["publisher", ["Yahoo"]],
+      ["domain", ["sports.yahoo.com"]],
+      DefaultCityLeaderboard,
+      ["country", ["India", "USA", "Ireland", "UK"]],
+    ],
+    bigNumber: { impressions: [6000, 7000], bid_price: [2.5, 3] },
+  },
+  {
+    title: "request with filters and time range and single measure",
+    timeRange: getTimeRange(PreviewRollupInterval.month, "2022-02-01"),
+    previewRollupInterval: PreviewRollupInterval.month,
+    filters: {
+      publisher: [["Yahoo", false]],
+    },
+    measures: [1],
+    measureRanges: [{ bid_price: [2.5, 3] }, { bid_price: [3, 3.5] }],
+    leaderboards: [
+      ["publisher", ["Microsoft", "Facebook", "Google"]],
+      [
+        "domain",
+        [
+          "facebook.com",
+          "google.com",
+          "msn.com",
+          "instagram.com",
+          "news.google.com",
+        ],
+      ],
+      DefaultCityLeaderboard,
+      ["country", ["India", "Ireland", "UK", "USA"]],
+    ],
+    bigNumber: { bid_price: [2.75, 3.25] },
+  },
+  {
+    title: "request with missing start time",
+    timeRange: getTimeRange(
+      PreviewRollupInterval.month,
+      "2021-11-01",
+      "2022-02-28"
+    ),
+    previewRollupInterval: PreviewRollupInterval.month,
+    measures: [1],
+    measureRanges: [
+      { bid_price: [0, 0] },
+      { bid_price: [0, 0] },
+      { bid_price: [2.75, 3.25] },
+      { bid_price: [2.75, 3.25] },
+    ],
+    leaderboards: [
+      ["publisher", ["Google", "Yahoo", "Facebook", "Microsoft"]],
+      [
+        "domain",
+        [
+          "google.com",
+          "instagram.com",
+          "news.google.com",
+          "news.yahoo.com",
+          "sports.yahoo.com",
+          "facebook.com",
+          "msn.com",
+        ],
+      ],
+      DefaultCityLeaderboard,
+      ["country", ["India", "Ireland", "UK", "USA"]],
+    ],
+    bigNumber: { bid_price: [2.75, 3.25] },
+  },
+];

--- a/test/functional/metrics-explore.spec.ts
+++ b/test/functional/metrics-explore.spec.ts
@@ -1,0 +1,71 @@
+import { useInlineTestServer } from "../utils/useInlineTestServer";
+import type { MetricsDefinitionEntity } from "$common/data-modeler-state-service/entity-state-service/MetricsDefinitionEntityService";
+import type { MeasureDefinitionEntity } from "$common/data-modeler-state-service/entity-state-service/MeasureDefinitionStateService";
+import { useBasicMetricsDefinition } from "../utils/metrics-definition-helpers";
+import { MetricsExploreTestData } from "../data/MetricsExplore.data";
+import type { LeaderboardValues } from "$lib/redux-store/explore/explore-slice";
+import axios from "axios";
+import { normaliseLeaderboardOrder } from "../utils/normaliseLeaderboardOrder";
+import type { BigNumberResponse } from "$common/database-service/DatabaseMetricsExploreActions";
+import { assertBigNumber } from "../utils/time-series-helpers";
+
+describe("Metrics Explore", () => {
+  const { config, inlineServer } = useInlineTestServer(8083);
+  let metricsDef: MetricsDefinitionEntity;
+  let measures: Array<MeasureDefinitionEntity>;
+  useBasicMetricsDefinition(inlineServer, (selMetricsDef, selMeasures) => {
+    metricsDef = selMetricsDef;
+    measures = selMeasures;
+  });
+
+  describe("Metrics leaderboard", () => {
+    for (const MetricsExploreTest of MetricsExploreTestData) {
+      it(`Should return leaderboard for ${MetricsExploreTest.title}`, async () => {
+        // select measures based on index passed or default to all measures
+        const requestMeasures = MetricsExploreTest.measures
+          ? MetricsExploreTest.measures.map((index) => measures[index])
+          : measures;
+        const resp = await axios.post(
+          `${config.server.serverUrl}/api/metrics/${metricsDef.id}/leaderboards`,
+          {
+            measureId: requestMeasures[0].id,
+            filters: MetricsExploreTest.filters ?? {},
+            ...(MetricsExploreTest.timeRange
+              ? { timeRange: MetricsExploreTest.timeRange }
+              : {}),
+          }
+        );
+        const leaderboards = resp.data
+          .split("\n")
+          .filter((json) => !!json)
+          .map(JSON.parse) as Array<LeaderboardValues>;
+        expect(normaliseLeaderboardOrder(leaderboards)).toStrictEqual(
+          MetricsExploreTest.leaderboards
+        );
+      });
+    }
+  });
+
+  describe("Metrics explore big number", () => {
+    for (const MetricsExploreTest of MetricsExploreTestData) {
+      it(`Should return big number for ${MetricsExploreTest.title}`, async () => {
+        // select measures based on index passed or default to all measures
+        const requestMeasures = MetricsExploreTest.measures
+          ? MetricsExploreTest.measures.map((index) => measures[index])
+          : measures;
+        const resp = await axios.post(
+          `${config.server.serverUrl}/api/metrics/${metricsDef.id}/big-number`,
+          {
+            measures: requestMeasures,
+            filters: MetricsExploreTest.filters ?? {},
+            ...(MetricsExploreTest.timeRange
+              ? { timeRange: MetricsExploreTest.timeRange }
+              : {}),
+          }
+        );
+        const bigNumbers = resp.data as BigNumberResponse;
+        assertBigNumber(bigNumbers, MetricsExploreTest.bigNumber);
+      });
+    }
+  });
+});

--- a/test/functional/time-series.spec.ts
+++ b/test/functional/time-series.spec.ts
@@ -1,8 +1,4 @@
-import {
-  useInlineTestServer,
-  useTestModel,
-  useTestTables,
-} from "../utils/useInlineTestServer";
+import { useInlineTestServer } from "../utils/useInlineTestServer";
 import request from "supertest";
 import type { MetricsDefinitionEntity } from "$common/data-modeler-state-service/entity-state-service/MetricsDefinitionEntityService";
 import type { MeasureDefinitionEntity } from "$common/data-modeler-state-service/entity-state-service/MeasureDefinitionStateService";
@@ -10,48 +6,22 @@ import type {
   TimeSeriesResponse,
   TimeSeriesTimeRange,
 } from "$common/database-service/DatabaseTimeSeriesActions";
-import { PreviewRollupInterval } from "$lib/duckdb-data-types";
-import {
-  getMetricsDefinition,
-  setupMeasures,
-  useMetricsDefinition,
-} from "../utils/metrics-definition-helpers";
+import { useBasicMetricsDefinition } from "../utils/metrics-definition-helpers";
 import {
   assertTimeSeries,
   assertTimeSeriesMeasureRange,
-  getTimeRange,
-  TimeSeriesMeasureRange,
 } from "../utils/time-series-helpers";
-import type { ActiveValues } from "$lib/redux-store/explore/explore-slice";
-import { START_DATE } from "../data/generator/data-constants";
+import { MetricsExploreTestData } from "../data/MetricsExplore.data";
 
 describe("TimeSeries", () => {
   const { inlineServer } = useInlineTestServer(8082);
-  const AdEventsName = "AdEvents";
 
   let metricsDef: MetricsDefinitionEntity;
   let measures: Array<MeasureDefinitionEntity>;
-
-  useTestTables(inlineServer);
-  useTestModel(
-    inlineServer,
-    `select
-    bid.*, imp.user_id, imp.city, imp.country
-    from AdBids bid join AdImpressions imp on bid.id = imp.id`,
-    AdEventsName
-  );
-  useMetricsDefinition(inlineServer, AdEventsName, AdEventsName, "timestamp");
-  setupMeasures(inlineServer, AdEventsName, "impressions", [
-    { id: "", expression: "avg(bid_price)", sqlName: "bid_price" },
-  ]);
-  getMetricsDefinition(
-    inlineServer,
-    AdEventsName,
-    (selMetricsDef, selMeasures) => {
-      metricsDef = selMetricsDef;
-      measures = selMeasures;
-    }
-  );
+  useBasicMetricsDefinition(inlineServer, (selMetricsDef, selMeasures) => {
+    metricsDef = selMetricsDef;
+    measures = selMeasures;
+  });
 
   it("Should return estimated time", async () => {
     const resp = await request(inlineServer.app)
@@ -63,78 +33,19 @@ describe("TimeSeries", () => {
     expect(timeRange.end).not.toBeUndefined();
   });
 
-  const TimeSeriesTestData: Array<{
-    title: string;
-    measures?: Array<number>;
-    filters?: ActiveValues;
-    previewRollupInterval: PreviewRollupInterval;
-    timeRange?: TimeSeriesTimeRange;
-    measureRanges?: Array<TimeSeriesMeasureRange>;
-  }> = [
-    {
-      title: "Should return a basic time series",
-      previewRollupInterval: PreviewRollupInterval.day,
-    },
-    {
-      title: "Should return a time series by month",
-      timeRange: getTimeRange(PreviewRollupInterval.month),
-      previewRollupInterval: PreviewRollupInterval.month,
-    },
-    {
-      title: "Should return a time series with filters",
-      timeRange: getTimeRange(PreviewRollupInterval.month),
-      previewRollupInterval: PreviewRollupInterval.month,
-      filters: {
-        domain: [["sports.yahoo.com", true]],
-      },
-      measureRanges: [
-        { impressions: [3500, 4500], bid_price: [3, 4] },
-        { impressions: [750, 1250], bid_price: [1, 2] },
-        { impressions: [750, 1250], bid_price: [1, 2] },
-      ],
-    },
-    {
-      title:
-        "Should return a time series with filters and time range and single measure",
-      timeRange: getTimeRange(PreviewRollupInterval.month, "2022-02-01"),
-      previewRollupInterval: PreviewRollupInterval.month,
-      filters: {
-        publisher: [["Yahoo", false]],
-      },
-      measures: [1],
-      measureRanges: [{ bid_price: [2.5, 3] }, { bid_price: [3, 3.5] }],
-    },
-    {
-      title: "Should return a time series with missing start time",
-      timeRange: getTimeRange(
-        PreviewRollupInterval.month,
-        "2021-11-01",
-        "2022-02-28"
-      ),
-      previewRollupInterval: PreviewRollupInterval.month,
-      measures: [1],
-      measureRanges: [
-        { bid_price: [0, 0] },
-        { bid_price: [0, 0] },
-        { bid_price: [2.75, 3.25] },
-        { bid_price: [2.75, 3.25] },
-      ],
-    },
-  ];
-
-  for (const TimeSeriesTest of TimeSeriesTestData) {
-    it(TimeSeriesTest.title, async () => {
+  for (const MetricsExploreTest of MetricsExploreTestData) {
+    it(`Should return time series for ${MetricsExploreTest.title}`, async () => {
       // select measures based on index passed or default to all measures
-      const requestMeasures = TimeSeriesTest.measures
-        ? TimeSeriesTest.measures.map((index) => measures[index])
+      const requestMeasures = MetricsExploreTest.measures
+        ? MetricsExploreTest.measures.map((index) => measures[index])
         : measures;
       const resp = await request(inlineServer.app)
         .post(`/api/metrics/${metricsDef.id}/time-series`)
         .send({
           measures: requestMeasures,
-          filters: TimeSeriesTest.filters ?? {},
-          ...(TimeSeriesTest.timeRange
-            ? { timeRange: TimeSeriesTest.timeRange }
+          filters: MetricsExploreTest.filters ?? {},
+          ...(MetricsExploreTest.timeRange
+            ? { timeRange: MetricsExploreTest.timeRange }
             : {}),
         })
         .set("Accept", "application/json");
@@ -143,11 +54,14 @@ describe("TimeSeries", () => {
 
       assertTimeSeries(
         timeSeries,
-        TimeSeriesTest.previewRollupInterval,
+        MetricsExploreTest.previewRollupInterval,
         requestMeasures.map((measure) => measure.sqlName)
       );
-      if (TimeSeriesTest.measureRanges) {
-        assertTimeSeriesMeasureRange(timeSeries, TimeSeriesTest.measureRanges);
+      if (MetricsExploreTest.measureRanges) {
+        assertTimeSeriesMeasureRange(
+          timeSeries,
+          MetricsExploreTest.measureRanges
+        );
       }
     });
   }

--- a/test/utils/normaliseLeaderboardOrder.ts
+++ b/test/utils/normaliseLeaderboardOrder.ts
@@ -1,0 +1,57 @@
+import type { LeaderboardValues } from "$lib/redux-store/explore/explore-slice";
+
+const FuzzyGroupLargeThreshold = 500;
+const FuzzyGroupSmallThreshold = 0.25;
+const FuzzyGroupSmallNumber = 10;
+
+/**
+ * Normalises leaderboard values for a list of columns.
+ * Calls {@link normaliseArrayValues} for each column.
+ */
+export function normaliseLeaderboardOrder(
+  leaderboard: Array<LeaderboardValues>
+): Array<[string, Array<string>]> {
+  return leaderboard.map((l) => [
+    l.displayName,
+    normaliseArrayValues(l.values as Array<{ value: number; label: string }>),
+  ]);
+}
+
+/**
+ * Normalises leaderboard values. Expects values to be sorted.
+ * Finds sequence of labels with close values and sorts them alphabetically.
+ * Retails these sequences in order.
+ * EG: [L3: 4500, L1: 4300, L2: 2120, L0: 2090] => [L1, l3, L0, L2]
+ */
+function normaliseArrayValues(
+  values: Array<{ value: number; label: string }>
+): Array<string> {
+  const normalisedValues = new Array<string>();
+
+  let fuzzyGroupAvg = values[0].value;
+  let fuzzyGroup = new Array<string>(values[0].label);
+
+  // these thresholds are based on the data used.
+  // they are in no way a generic threshold
+  const FuzzyGroupThreshold =
+    fuzzyGroupAvg <= FuzzyGroupSmallNumber
+      ? FuzzyGroupSmallThreshold
+      : FuzzyGroupLargeThreshold;
+
+  const addToNormalValues = () => {
+    normalisedValues.push(...fuzzyGroup.sort());
+    fuzzyGroup = [];
+  };
+
+  for (let i = 1; i < values.length; i++) {
+    if (Math.abs(fuzzyGroupAvg - values[i].value) > FuzzyGroupThreshold) {
+      addToNormalValues();
+      fuzzyGroupAvg = values[i].value;
+    }
+    fuzzyGroup.push(values[i].label);
+  }
+
+  addToNormalValues();
+
+  return normalisedValues;
+}

--- a/test/utils/time-series-helpers.ts
+++ b/test/utils/time-series-helpers.ts
@@ -1,22 +1,24 @@
-import type { TimeSeriesResponse } from "$common/database-service/DatabaseTimeSeriesActions";
+import type {
+  TimeSeriesResponse,
+  TimeSeriesTimeRange,
+} from "$common/database-service/DatabaseTimeSeriesActions";
 import type { PreviewRollupInterval } from "$lib/duckdb-data-types";
 import { isTimestampDiffAccurate } from "./time-series-time-diff";
 import type { TimeSeriesValue } from "$lib/redux-store/timeseries/timeseries-slice";
 import { END_DATE, START_DATE } from "../data/generator/data-constants";
-import type { RollupInterval } from "$common/database-service/DatabaseColumnActions";
 
 export type TimeSeriesMeasureRange = Record<string, [min: number, max: number]>;
 
-export function getRollupInterval(
+export function getTimeRange(
   interval: string,
   startDate = START_DATE,
   endDate = END_DATE
 ) {
   return {
-    rollupInterval: interval,
-    minValue: new Date(`${startDate} UTC`).getTime(),
-    maxValue: new Date(`${endDate} UTC`).getTime(),
-  } as RollupInterval;
+    interval,
+    start: new Date(`${startDate} UTC`).getTime(),
+    end: new Date(`${endDate} UTC`).getTime(),
+  } as TimeSeriesTimeRange;
 }
 
 export function assertTimeSeries(
@@ -24,7 +26,7 @@ export function assertTimeSeries(
   rollupInterval: PreviewRollupInterval,
   measures: Array<string>
 ) {
-  expect(timeSeries.rollupInterval).toBe(rollupInterval);
+  expect(timeSeries.timeRange.interval).toBe(rollupInterval);
   const mismatchTimestamps = new Array<[string, string]>();
   const mismatchMeasures = new Array<
     [dimension: string, value: number, timestamp: string]

--- a/test/utils/time-series-helpers.ts
+++ b/test/utils/time-series-helpers.ts
@@ -6,6 +6,7 @@ import type { PreviewRollupInterval } from "$lib/duckdb-data-types";
 import { isTimestampDiffAccurate } from "./time-series-time-diff";
 import type { TimeSeriesValue } from "$lib/redux-store/timeseries/timeseries-slice";
 import { END_DATE, START_DATE } from "../data/generator/data-constants";
+import type { BigNumberResponse } from "$common/database-service/DatabaseMetricsExploreActions";
 
 export type TimeSeriesMeasureRange = Record<string, [min: number, max: number]>;
 
@@ -16,8 +17,8 @@ export function getTimeRange(
 ) {
   return {
     interval,
-    start: new Date(`${startDate} UTC`).getTime(),
-    end: new Date(`${endDate} UTC`).getTime(),
+    start: new Date(`${startDate} UTC`).toISOString(),
+    end: new Date(`${endDate} UTC`).toISOString(),
   } as TimeSeriesTimeRange;
 }
 
@@ -84,4 +85,26 @@ export function assertTimeSeriesMeasureRange(
     console.log("Mismatch measures value ranges: ", mismatchMeasures);
   }
   expect(mismatchMeasures.length).toBe(0);
+}
+
+export function assertBigNumber(
+  bigNumber: BigNumberResponse,
+  expectedBigNumber: TimeSeriesMeasureRange
+) {
+  const mismatchBigNumbers = new Array<[dimension: string, value: number]>();
+
+  for (const measureName in expectedBigNumber) {
+    const value = bigNumber.bigNumbers[measureName];
+    if (
+      value < expectedBigNumber[measureName][0] &&
+      value > expectedBigNumber[measureName][1]
+    ) {
+      mismatchBigNumbers.push([measureName, value]);
+    }
+  }
+
+  if (mismatchBigNumbers.length) {
+    console.log("Mismatch big numbers: ", mismatchBigNumbers);
+  }
+  expect(mismatchBigNumbers.length).toBe(0);
 }


### PR DESCRIPTION
Adding independent time interval, start and end timestamp arguments.
Call `fetchTimestampColumnRangeApi` with `metricsDefId` to fetch and update MetricsExplore with estimated time range.
Call `setExploreSelectedTimeRangeAndUpdate` with `metricsDefId` and user selected `selectedTimeRange` to update all explore queries to use this time range. This

This depends on changes from #507 for keeping things in sync.
