### PR TITLE
refinement to editable-table selector dropdown

### DIFF
--- a/src/lib/components/metrics-definition/DimensionColumns.ts
+++ b/src/lib/components/metrics-definition/DimensionColumns.ts
@@ -1,56 +1,47 @@
-import type { DimensionDefinitionEntity } from "$common/data-modeler-state-service/entity-state-service/DimensionDefinitionStateService";
-import type { ColumnConfig } from "$lib/components/table-editable/ColumnConfig";
-
-import TableCellInput from "$lib/components/table-editable/TableCellInput.svelte";
-import { NicelyFormattedTypes } from "$lib/util/humanize-numbers";
-import TableCellSelector from "../table-editable/TableCellSelector.svelte";
+import {
+  ColumnConfig,
+  CellConfigInput,
+  CellConfigSelector,
+} from "$lib/components/table-editable/ColumnConfig";
 
 export const initDimensionColumns = (inputChangeHandler, dimensionOptions) =>
-  [
+  <ColumnConfig<CellConfigInput | CellConfigSelector>[]>[
     {
       name: "labelSingle",
       label: "label (single)",
-      tooltip: "a human readable name for this dimension",
-      renderer: TableCellInput,
-      onchange: inputChangeHandler,
+      headerTooltip: "a human readable name for this dimension (optional)",
+      cellRenderer: new CellConfigInput(inputChangeHandler),
     },
 
     {
       name: "dimensionColumn",
       label: "dimension column",
-      tooltip:
+      headerTooltip:
         "a categorical column from the data model that this metrics set is based on",
-      renderer: TableCellSelector,
-      onchange: inputChangeHandler,
-      options: dimensionOptions,
-      validation: (row: DimensionDefinitionEntity) => row.dimensionIsValid,
+      cellRenderer: new CellConfigSelector(
+        inputChangeHandler,
+        dimensionOptions,
+        "select a column..."
+      ),
     },
     {
       name: "description",
-      tooltip: "a human readable description of this dimension",
-      renderer: TableCellInput,
-      onchange: inputChangeHandler,
-    },
-    {
-      name: "formatPreset",
-      label: "format preset",
-      tooltip: "a format for this dimension",
-      renderer: TableCellSelector,
-      onchange: inputChangeHandler,
-      options: Object.values(NicelyFormattedTypes),
+      headerTooltip:
+        "a human readable description of this dimension (optional)",
+      cellRenderer: new CellConfigInput(inputChangeHandler),
     },
     {
       name: "labelPlural",
       label: "label (plural)",
-      tooltip: "an optional pluralized human readable name for this dimension",
-      renderer: TableCellInput,
-      onchange: inputChangeHandler,
+      headerTooltip:
+        "an pluralized human readable name for this dimension (optional)",
+      cellRenderer: new CellConfigInput(inputChangeHandler),
     },
     // FIXME will be needed later for API
     // {
     //   name: "sqlName",
     //   label: "identifier",
-    //   tooltip: "a unique SQL identifier for this dimension",
+    //   headerTooltip: "a unique SQL identifier for this dimension",
     //   renderer: TableCellInput,
     //   onchange: inputChangeHandler,
     //   validation: (row: DimensionDefinitionEntity) => row.sqlNameIsValid,
@@ -60,7 +51,7 @@ export const initDimensionColumns = (inputChangeHandler, dimensionOptions) =>
     // {
     //   name: "id",
     //   label: "unique values",
-    //   tooltip: "the number of unique values present in this dimension",
+    //   headerTooltip: "the number of unique values present in this dimension",
     //   renderer: TabelCellCardinality
     // },
-  ] as ColumnConfig[];
+  ];

--- a/src/lib/components/metrics-definition/MeasuresColumns.ts
+++ b/src/lib/components/metrics-definition/MeasuresColumns.ts
@@ -1,53 +1,58 @@
 import type { MeasureDefinitionEntity } from "$common/data-modeler-state-service/entity-state-service/MeasureDefinitionStateService";
-import TableCellInput from "$lib/components/table-editable/TableCellInput.svelte";
-import type { ColumnConfig } from "$lib/components/table-editable/ColumnConfig";
-import TableCellSelector from "../table-editable/TableCellSelector.svelte";
-import { NicelyFormattedTypes } from "$lib/util/humanize-numbers";
+
+import {
+  ColumnConfig,
+  CellConfigInput,
+  CellConfigSelector,
+} from "$lib/components/table-editable/ColumnConfig";
+import { nicelyFormattedTypesSelectorOptions } from "$lib/util/humanize-numbers";
 
 export const initMeasuresColumns = (inputChangeHandler) =>
-  [
+  <ColumnConfig<CellConfigInput | CellConfigSelector>[]>[
     {
       name: "label",
-      tooltip: "a human readable name for this measure",
-      renderer: TableCellInput,
-      onchange: inputChangeHandler,
+      headerTooltip: "a human readable name for this measure (optional)",
+      cellRenderer: new CellConfigInput(inputChangeHandler),
     },
     {
       name: "expression",
-      tooltip: "a valid SQL aggregation expression for this measure",
-      renderer: TableCellInput,
-      onchange: inputChangeHandler,
-      validation: (row: MeasureDefinitionEntity) => row.expressionIsValid,
+      headerTooltip: "a valid SQL aggregation expression for this measure",
+      cellRenderer: new CellConfigInput(
+        inputChangeHandler,
+        (row: MeasureDefinitionEntity) => row.expressionIsValid
+      ),
     },
     {
       name: "description",
-      tooltip: "a human readable description of this measure",
-      onchange: inputChangeHandler,
-      renderer: TableCellInput,
+      headerTooltip: "a human readable description of this measure (optional)",
+
+      cellRenderer: new CellConfigInput(inputChangeHandler),
     },
     {
       name: "formatPreset",
-      label: "format preset",
-      tooltip: "a format for this measure",
-      renderer: TableCellSelector,
-      onchange: inputChangeHandler,
-      options: Object.values(NicelyFormattedTypes),
+      label: "number formatting",
+      headerTooltip:
+        "the number formatting used for this measure in the Metrics Explorer",
+      cellRenderer: new CellConfigSelector(
+        inputChangeHandler,
+        nicelyFormattedTypesSelectorOptions
+      ),
     },
     // FIXME: will be needed later for API
     // {
     //   name: "sqlName",
     //   label: "identifier",
-    //   tooltip: "a unique SQL identifier for this measure",
-    //   renderer: TableCellInput,
+    //   headerTooltip: "a unique SQL identifier for this measure",
+    //   cellRenderer: TableCellInput,
     //   onchange: inputChangeHandler,
     //   validation: (row: MeasureDefinitionEntity) => row.sqlNameIsValid,
     // },
 
-    // FIXME: willbe needed later for sparkline summary
+    // FIXME: will be needed later for sparkline summary
     // {
     //   name: "id",
     //   label: "preview",
     //   tooltip: "a preview of this measure over the selected time dimension",
-    //   renderer: TableCellSparkline,
+    //   cellRenderer: TableCellSparkline,
     // },
-  ] as ColumnConfig[];
+  ];

--- a/src/lib/components/table-editable/ColumnConfig.ts
+++ b/src/lib/components/table-editable/ColumnConfig.ts
@@ -3,6 +3,9 @@ import type { ValidationState } from "$common/data-modeler-state-service/entity-
 
 import type { SvelteComponent } from "svelte";
 
+import TableCellInput from "$lib/components/table-editable/TableCellInput.svelte";
+import TableCellSelector from "../table-editable/TableCellSelector.svelte";
+
 export type CellRendererComponent = new (
   // FIXME: these types are the   ones taken by the components
   // columnConfig: ColumnConfig,
@@ -11,25 +14,50 @@ export type CellRendererComponent = new (
   ...args: any[]
 ) => SvelteComponent;
 
+export type SelectorOption = {
+  label: string;
+  value: string;
+};
+
+export type TableEventHandler = (
+  rowIndex: number,
+  columnName: string,
+  value: string
+) => void;
+
+export interface CellConfig {
+  component: CellRendererComponent;
+}
+
+export class CellConfigInput implements CellConfig {
+  component = TableCellInput;
+  constructor(
+    public onchange: TableEventHandler,
+    public validation?: (row: EntityRecord, value: unknown) => ValidationState
+  ) {}
+}
+
+export class CellConfigSelector implements CellConfig {
+  component = TableCellSelector;
+  constructor(
+    public onchange: TableEventHandler,
+    public options: SelectorOption[],
+    public placeholderLabel?: string
+  ) {}
+}
+
 /**
  * config info for table columns
  *
  * name: the property name used in an EntityRecord
  * label?: label used for display in table header (`name` is used if not provided)
- * tooltip: tooltip when hovering over column header
+ * headerTooltip: tooltip when hovering over column header
+ * cellRenderer: svelte component and other options used to render cell content (event handlers, etc.)
  */
-export interface ColumnConfig {
+export interface ColumnConfig<T extends CellConfig> {
   //FIXME: specify types based on CellRendererComponent
   name: string;
   label?: string;
-  type?: string;
-
-  renderer: CellRendererComponent;
-  tooltip?: string;
-  onchange?: (rowIndex: number, columnName: string, value: string) => void;
-
-  validation?: (row: EntityRecord, value: unknown) => ValidationState;
-  options?: string[];
-
-  copyable?: boolean;
+  headerTooltip?: string;
+  cellRenderer: T;
 }

--- a/src/lib/components/table-editable/EditableTableHeader.svelte
+++ b/src/lib/components/table-editable/EditableTableHeader.svelte
@@ -3,14 +3,11 @@
   import TableHeader from "./TableHeader.svelte";
   import Tooltip from "$lib/components/tooltip/Tooltip.svelte";
   import TooltipContent from "$lib/components/tooltip/TooltipContent.svelte";
-  import Pin from "$lib/components/icons/Pin.svelte";
 
   import type { ColumnConfig } from "./ColumnConfig";
 
-  export let pinned = false;
-  export let columnConfig: ColumnConfig;
+  export let columnConfig: ColumnConfig<any>;
 
-  const dispatch = createEventDispatcher();
   const name = columnConfig.label ?? columnConfig.name;
 </script>
 
@@ -33,10 +30,14 @@
         </span>
       </div>
       <TooltipContent slot="tooltip-content">
-        {columnConfig.tooltip}
+        {columnConfig.headerTooltip}
       </TooltipContent>
     </Tooltip>
-    <Tooltip location="top" alignment="middle" distance={16}>
+    <!--
+      FIXME: in conversation with Marissa, we decided to remove pins for now,
+      but we'll want to revisit our strategy for freezing columns if the table grows.
+     -->
+    <!-- <Tooltip location="top" alignment="middle" distance={16}>
       <button
         class:text-gray-900={pinned}
         class:text-gray-400={!pinned}
@@ -52,6 +53,6 @@
           ? "unpin this column from the right side of the table"
           : "pin this column to the right side of the table"}
       </TooltipContent>
-    </Tooltip>
+    </Tooltip> -->
   </div>
 </TableHeader>

--- a/src/lib/components/table-editable/PinnableTable.svelte
+++ b/src/lib/components/table-editable/PinnableTable.svelte
@@ -14,8 +14,8 @@
 
   const dispatch = createEventDispatcher();
 
-  export let columnNames: ColumnConfig[];
-  export let selectedColumns: ColumnConfig[];
+  export let columnNames: ColumnConfig<any>[];
+  export let selectedColumns: ColumnConfig<any>[];
   export let rows: any[];
 </script>
 

--- a/src/lib/components/table-editable/PreviewTable.svelte
+++ b/src/lib/components/table-editable/PreviewTable.svelte
@@ -13,7 +13,7 @@
 
   const dispatch = createEventDispatcher();
 
-  export let columnNames: ColumnConfig[];
+  export let columnNames: ColumnConfig<any>[];
   export let tableConfig: TableConfig;
   export let rows: any[];
 
@@ -47,7 +47,6 @@
         on:pin={handlePin}
         on:change={(evt) => dispatch("change", evt.detail)}
         on:delete={(evt) => dispatch("delete", evt.detail)}
-        tableConfig={{ ...tableConfig, enableAdd: false }}
         {activeIndex}
         columnNames={selectedColumns}
         {selectedColumns}

--- a/src/lib/components/table-editable/TableCellInput.svelte
+++ b/src/lib/components/table-editable/TableCellInput.svelte
@@ -2,20 +2,27 @@
   import { ValidationState } from "$common/data-modeler-state-service/entity-state-service/MetricsDefinitionEntityService";
   import ErrorIcon from "$lib/components/icons/CrossIcon.svelte";
   import WarningIcon from "$lib/components/icons/WarningIcon.svelte";
-  import type { ColumnConfig } from "$lib/components/table-editable/ColumnConfig";
+  import type {
+    ColumnConfig,
+    CellConfigInput,
+  } from "$lib/components/table-editable/ColumnConfig";
   import type { EntityRecord } from "$common/data-modeler-state-service/entity-state-service/EntityStateService";
 
-  export let columnConfig: ColumnConfig;
+  export let columnConfig: ColumnConfig<CellConfigInput>;
   export let index = undefined;
   export let row: EntityRecord;
-  export let value;
+  $: value = row[columnConfig.name];
 
   let inputElt: HTMLInputElement;
 
   let editing = false;
   const onchangeHandler = (evt) => {
     stopEditing();
-    columnConfig.onchange(index, columnConfig.name, evt.target.value);
+    columnConfig.cellRenderer.onchange(
+      index,
+      columnConfig.name,
+      evt.target.value
+    );
   };
   const startEditing = () => {
     editing = true;
@@ -27,8 +34,8 @@
   };
   // FIXME: validation is business logic that should be handled in
   // application state management, NOT in the component.
-  $: validation = columnConfig.validation
-    ? columnConfig.validation(row, row[columnConfig.name])
+  $: validation = columnConfig.cellRenderer.validation
+    ? columnConfig.cellRenderer.validation(row, row[columnConfig.name])
     : ValidationState.OK;
 </script>
 

--- a/src/lib/components/table-editable/TableCellRenderer.svelte
+++ b/src/lib/components/table-editable/TableCellRenderer.svelte
@@ -1,13 +1,15 @@
 <script lang="ts">
-  import type { ColumnConfig } from "$lib/components/table-editable/ColumnConfig";
-  export let columnConfig: ColumnConfig;
+  import type {
+    ColumnConfig,
+    CellConfig,
+  } from "$lib/components/table-editable/ColumnConfig";
+  export let columnConfig: ColumnConfig<CellConfig>;
   export let index: number;
   export let row: any;
 </script>
 
 <svelte:component
-  this={columnConfig.renderer}
-  value={row[columnConfig.name]}
+  this={columnConfig.cellRenderer.component}
   {index}
   {row}
   {columnConfig}

--- a/src/lib/components/table-editable/TableCellSelector.svelte
+++ b/src/lib/components/table-editable/TableCellSelector.svelte
@@ -1,34 +1,66 @@
 <script lang="ts">
-  import type { ColumnConfig } from "$lib/components/table-editable/ColumnConfig";
+  import type {
+    ColumnConfig,
+    CellConfigSelector,
+  } from "$lib/components/table-editable/ColumnConfig";
   import type { EntityRecord } from "$common/data-modeler-state-service/entity-state-service/EntityStateService";
 
-  export let columnConfig: ColumnConfig;
+  export let columnConfig: ColumnConfig<CellConfigSelector>;
   export let index: number;
   export let row: EntityRecord;
-  export let value: string;
+
+  const placeholderLabel = columnConfig.cellRenderer.placeholderLabel;
+
+  let value = undefined;
+  let placeholderStyles = "";
+  $: if (row[columnConfig.name]) {
+    // if there is an actual value, use it
+    value = row[columnConfig.name];
+  } else if (placeholderLabel) {
+    // if there no actual value, use the placeholder label
+    value = "__PLACEHOLDER_VALUE__";
+    placeholderStyles = "font-style: italic; color: rgb(107, 114, 128);";
+  } else {
+    // if there is no placeholder label and no actual value, use the first option in the options list
+    value = columnConfig.cellRenderer.options[0].value;
+  }
 
   const onchangeHandler = (evt) => {
-    columnConfig.onchange(index, columnConfig.name, evt.target.value);
+    columnConfig.cellRenderer.onchange(
+      index,
+      columnConfig.name,
+      evt.target.value
+    );
   };
 
-  $: options = columnConfig.options;
-  $: initialValue = options.length > 0 ? options[0] : "__DEFAULT_VALUE__";
-
-  value = value ?? initialValue;
+  $: options = columnConfig.cellRenderer.options;
 </script>
 
 <td class="py-2 px-4 border border-gray-200 hover:bg-gray-200">
   <select
-    class="italic hover:bg-gray-100 rounded border border-6 border-transparent hover:font-bold hover:border-gray-100"
-    style="background-color: #FFF; width:18em;"
-    value={value ?? initialValue}
+    class="table-select bg-transparent"
+    style={placeholderStyles}
+    {value}
     on:change={onchangeHandler}
   >
-    <option value="__DEFAULT_VALUE__" disabled selected hidden
-      >select a timestamp...</option
-    >
+    {#if placeholderLabel}
+      <option value="__PLACEHOLDER_VALUE__" disabled selected hidden
+        >{placeholderLabel}</option
+      >
+    {/if}
+
     {#each options as option}
-      <option value={option}>{option}</option>
+      <option value={option.value}>{option.label}</option>
     {/each}
   </select>
 </td>
+
+<style>
+  .table-select {
+    cursor: default;
+  }
+  .table-select:focus-visible {
+    border: none;
+    outline: none;
+  }
+</style>

--- a/src/lib/components/table-editable/pinnableUtils.ts
+++ b/src/lib/components/table-editable/pinnableUtils.ts
@@ -1,10 +1,16 @@
-import type { ColumnConfig } from "$lib/components/table-editable/ColumnConfig";
+import type {
+  ColumnConfig,
+  CellConfig,
+} from "$lib/components/table-editable/ColumnConfig";
 
-export function columnIsPinned(name, selectedColumns: Array<ColumnConfig>) {
+export function columnIsPinned(
+  name,
+  selectedColumns: Array<ColumnConfig<CellConfig>>
+) {
   return selectedColumns.map((column) => column.name).includes(name);
 }
 
-export function togglePin(columnConfig: ColumnConfig, selectedColumns) {
+export function togglePin(columnConfig: ColumnConfig<any>, selectedColumns) {
   // if column is already pinned, remove.
   if (columnIsPinned(columnConfig.name, selectedColumns)) {
     return [

--- a/src/lib/util/humanize-numbers.ts
+++ b/src/lib/util/humanize-numbers.ts
@@ -20,6 +20,22 @@ export enum NicelyFormattedTypes {
   DECIMAL = "comma_separators",
 }
 
+export const nicelyFormattedTypesSelectorOptions = [
+  { value: NicelyFormattedTypes.HUMANIZE, label: "Humanize - 12k" },
+  { value: NicelyFormattedTypes.NONE, label: "No formatting - 12345.6789" },
+  {
+    value: NicelyFormattedTypes.CURRENCY,
+    label: "Currency (USD) - $12,345.67",
+  },
+  { value: NicelyFormattedTypes.PERCENTAGE, label: "Percentage - 12345.6789%" },
+  { value: NicelyFormattedTypes.DECIMAL, label: "Decimal - 12,345.67" },
+];
+
+console.log(
+  "nicelyFormattedTypesSelectorOptions",
+  nicelyFormattedTypesSelectorOptions
+);
+
 const DEFAULT_OPTIONS = {
   locale: "en-US",
   style: "decimal",

--- a/src/lib/util/humanize-numbers.ts
+++ b/src/lib/util/humanize-numbers.ts
@@ -31,11 +31,6 @@ export const nicelyFormattedTypesSelectorOptions = [
   { value: NicelyFormattedTypes.DECIMAL, label: "Decimal - 12,345.67" },
 ];
 
-console.log(
-  "nicelyFormattedTypesSelectorOptions",
-  nicelyFormattedTypesSelectorOptions
-);
-
 const DEFAULT_OPTIONS = {
   locale: "en-US",
   style: "decimal",

--- a/src/routes/_surfaces/workspace/metrics-def/MetricsDefWorkspace.svelte
+++ b/src/routes/_surfaces/workspace/metrics-def/MetricsDefWorkspace.svelte
@@ -30,6 +30,7 @@
   import MetricsDefEntityTable from "./MetricsDefEntityTable.svelte";
   import { CATEGORICALS } from "$lib/duckdb-data-types";
   import { getMetricsDefReadableById } from "$lib/redux-store/metrics-definition/metrics-definition-readables";
+  import type { SelectorOption } from "$lib/components/table-editable/ColumnConfig";
 
   export let metricsDefId;
 
@@ -84,22 +85,22 @@
     "rill:app:derived-model-store"
   ) as DerivedModelStore;
 
-  let validDimensions: string[] = [];
+  let validDimensionSelectorOption: SelectorOption[] = [];
   $: if ($selectedMetricsDef?.sourceModelId && $derivedModelStore?.entities) {
     const selectedMetricsDefModelProfile = $derivedModelStore?.entities.find(
       (model) => model.id === $selectedMetricsDef.sourceModelId
     ).profile;
-    validDimensions = selectedMetricsDefModelProfile
+    validDimensionSelectorOption = selectedMetricsDefModelProfile
       .filter((column) => CATEGORICALS.has(column.type))
-      .map((column) => column.name);
+      .map((column) => ({ label: column.name, value: column.name }));
   } else {
-    validDimensions = [];
+    validDimensionSelectorOption = [];
   }
 
   $: MeasuresColumns = initMeasuresColumns(handleUpdateMeasure);
   $: DimensionColumns = initDimensionColumns(
     handleUpdateDimension,
-    validDimensions
+    validDimensionSelectorOption
   );
 </script>
 


### PR DESCRIPTION
@hamilton  here are the user-facing labels in the dropdown along with a number of other refinements to the dropdowns, and a few other things sprinkled in. As you suggested this morning, I added in examples of the numeric formatting in the dropdown, but I think my cut of that idea really doesn't work -- if you had something particular in mind, it will be a quick matter for you to experiment with other ways of showing the example, but at this point I'm kind of leaning towards the perspective that we should leave that out for now and find some way to have an overview elsewhere that looks more like @djbarnwal 's demo page in the dev route