### PR TITLE
Metrics explore remove num format example

### DIFF
--- a/src/lib/util/humanize-numbers.ts
+++ b/src/lib/util/humanize-numbers.ts
@@ -21,20 +21,20 @@ export enum NicelyFormattedTypes {
 }
 
 export const nicelyFormattedTypesSelectorOptions = [
-  { value: NicelyFormattedTypes.HUMANIZE, label: "Humanize (e.g. 12.3k)" },
+  { value: NicelyFormattedTypes.HUMANIZE, label: "Humanize" },
   {
     value: NicelyFormattedTypes.NONE,
-    label: "No formatting (e.g. 12345.6789)",
+    label: "No formatting",
   },
   {
     value: NicelyFormattedTypes.CURRENCY,
-    label: "Currency (USD) (e.g. $12.3k)",
+    label: "Currency (USD)",
   },
   {
     value: NicelyFormattedTypes.PERCENTAGE,
-    label: "Percentage (e.g. 12345.6789%)",
+    label: "Percentage",
   },
-  { value: NicelyFormattedTypes.DECIMAL, label: "Decimal (e.g. 12,345.67)" },
+  { value: NicelyFormattedTypes.DECIMAL, label: "Decimal" },
 ];
 
 const DEFAULT_OPTIONS = {


### PR DESCRIPTION
@hamilton per our discussion yesterday, removing number format examples from dropdown