### PR TITLE
Fix rename bug

### DIFF
--- a/src/lib/components/column-profile/CollapsibleTableSummary.svelte
+++ b/src/lib/components/column-profile/CollapsibleTableSummary.svelte
@@ -89,14 +89,14 @@
               >
                 query {name}
               </MenuItem>
+              <MenuItem
+                on:select={() => {
+                  dispatch("rename");
+                }}
+              >
+                rename {name}
+              </MenuItem>
             {/if}
-            <MenuItem
-              on:select={() => {
-                dispatch("rename");
-              }}
-            >
-              rename {name}
-            </MenuItem>
             <MenuItem
               on:select={() => {
                 dispatch("delete");


### PR DESCRIPTION
This PR ensures we only have a  "Rename X" for the Source assets. Later, we can add rename implementations for the Model and Metrics Definition assets.