### PR TITLE
Filtering out errored out measures

### DIFF
--- a/src/lib/components/data-graphic/elements/GraphicContext.svelte
+++ b/src/lib/components/data-graphic/elements/GraphicContext.svelte
@@ -194,7 +194,6 @@ for any of its children.
   const yMaxStore = getContext(contexts.max("y")) as ExtremumResolutionStore;
 
   $: if (yMaxTweenProps) {
-    console.log("changing");
     yMaxStore.setTweenProps(yMaxTweenProps);
   }
 

--- a/src/lib/redux-store/explore/explore-apis.ts
+++ b/src/lib/redux-store/explore/explore-apis.ts
@@ -25,6 +25,7 @@ import type { MeasureDefinitionEntity } from "$common/data-modeler-state-service
 import { generateBigNumbersApi } from "$lib/redux-store/big-number/big-number-apis";
 import type { TimeSeriesTimeRange } from "$common/database-service/DatabaseTimeSeriesActions";
 import { getArrayDiff } from "$common/utils/getArrayDiff";
+import { selectValidMeasures } from "$lib/redux-store/measure-definition/measure-definition-selectors";
 
 /**
  * A wrapper to dispatch updates to explore.
@@ -53,6 +54,8 @@ export const syncExplore = (
   measures: Array<MeasureDefinitionEntity>,
   force = false
 ) => {
+  if (measures) measures = selectValidMeasures(measures);
+
   let shouldUpdate = false;
   if (!metricsExplore) {
     dispatch(initMetricsExplore(metricsDefId, dimensions, measures));

--- a/src/lib/redux-store/explore/explore-selectors.ts
+++ b/src/lib/redux-store/explore/explore-selectors.ts
@@ -1,11 +1,18 @@
 import { generateEntitySelectors } from "$lib/redux-store/utils/selector-utils";
-import type { MetricsExploreEntity } from "$lib/redux-store/explore/explore-slice";
+import type {
+  ActiveValues,
+  MetricsExploreEntity,
+} from "$lib/redux-store/explore/explore-slice";
 import type { RillReduxState } from "$lib/redux-store/store-root";
-import type { MeasureDefinitionEntity } from "$common/data-modeler-state-service/entity-state-service/MeasureDefinitionStateService";
-import type { ActiveValues } from "$lib/redux-store/explore/explore-slice";
+import type {
+  BasicMeasureDefinition,
+  MeasureDefinitionEntity,
+} from "$common/data-modeler-state-service/entity-state-service/MeasureDefinitionStateService";
 import { prune } from "../../../routes/_surfaces/workspace/explore/utils";
-import { selectMeasureById } from "$lib/redux-store/measure-definition/measure-definition-selectors";
-import type { BasicMeasureDefinition } from "$common/data-modeler-state-service/entity-state-service/MeasureDefinitionStateService";
+import {
+  selectMeasureById,
+  selectValidMeasures,
+} from "$lib/redux-store/measure-definition/measure-definition-selectors";
 import type { DimensionDefinitionEntity } from "$common/data-modeler-state-service/entity-state-service/DimensionDefinitionStateService";
 
 export const {
@@ -43,6 +50,7 @@ export const selectMetricsExploreParams = (
       selectMeasureById(state, measureId)
     );
   }
+  measures = selectValidMeasures(measures);
 
   return {
     metricsExplore,

--- a/src/lib/redux-store/measure-definition/measure-definition-readables.ts
+++ b/src/lib/redux-store/measure-definition/measure-definition-readables.ts
@@ -5,6 +5,7 @@ import {
   selectMeasureFieldNameByIdAndIndex,
   selectMeasuresByIds,
   selectMeasuresByMetricsId,
+  selectValidMeasuresByMetricsId,
 } from "$lib/redux-store/measure-definition/measure-definition-selectors";
 import type { MeasureDefinitionEntity } from "$common/data-modeler-state-service/entity-state-service/MeasureDefinitionStateService";
 
@@ -16,6 +17,10 @@ export const getMeasureById = createReadableFactoryWithSelector<
 export const getMeasuresByMetricsId = createReadableFactoryWithSelector(
   store,
   selectMeasuresByMetricsId
+);
+export const getValidMeasuresByMetricsId = createReadableFactoryWithSelector(
+  store,
+  selectValidMeasuresByMetricsId
 );
 
 export const getMeasuresByIds = createReadableFactoryWithSelector(

--- a/src/lib/redux-store/measure-definition/measure-definition-selectors.ts
+++ b/src/lib/redux-store/measure-definition/measure-definition-selectors.ts
@@ -1,7 +1,8 @@
 import { generateFilteredEntitySelectors } from "$lib/redux-store/utils/selector-utils";
 import type { MeasureDefinitionEntity } from "$common/data-modeler-state-service/entity-state-service/MeasureDefinitionStateService";
-import type { RillReduxState } from "$lib/redux-store/store-root";
 import { getFallbackMeasureName } from "$common/data-modeler-state-service/entity-state-service/MeasureDefinitionStateService";
+import type { RillReduxState } from "$lib/redux-store/store-root";
+import { ValidationState } from "$common/data-modeler-state-service/entity-state-service/MetricsDefinitionEntityService";
 
 export const {
   singleSelector: selectMeasureById,
@@ -21,3 +22,16 @@ export const selectMeasureFieldNameByIdAndIndex = (
   const measure = selectMeasureById(store, id);
   return measure ? getFallbackMeasureName(index, measure.sqlName) : "";
 };
+
+export const measureIsValid = (measure: MeasureDefinitionEntity) =>
+  measure.expressionIsValid === ValidationState.OK;
+export const selectValidMeasures = (
+  measures: Array<MeasureDefinitionEntity>
+) => {
+  return measures.filter(measureIsValid);
+};
+
+export const selectValidMeasuresByMetricsId = (
+  state: RillReduxState,
+  metricsDefId: string
+) => selectValidMeasures(selectMeasuresByMetricsId(state, metricsDefId));

--- a/src/lib/redux-store/utils/api-utils.ts
+++ b/src/lib/redux-store/utils/api-utils.ts
@@ -39,14 +39,24 @@ export function generateApis<
   }
 ) {
   return {
+    // TODO: add caching here to prevent too many fetchManyApi calls
     fetchManyApi: createAsyncThunk(
       `${entityType}/fetchManyApi`,
       async (args: FetchManyParams, thunkAPI) => {
-        thunkAPI.dispatch(
-          addManyAction(
-            await fetchWrapper(`${endpoint}${getQueryArgs(args)}`, "GET")
-          )
+        let entities = await fetchWrapper(
+          `${endpoint}${getQueryArgs(args)}`,
+          "GET"
         );
+        entities = await Promise.all(
+          entities.map(async (entity) => {
+            const changes = await validateEntity(entity, entity, validations);
+            return {
+              ...entity,
+              ...changes,
+            };
+          })
+        );
+        thunkAPI.dispatch(addManyAction(entities));
       }
     ),
     createApi: createAsyncThunk(

--- a/src/routes/_surfaces/workspace/explore/leaderboards/LeaderboardDisplay.svelte
+++ b/src/routes/_surfaces/workspace/explore/leaderboards/LeaderboardDisplay.svelte
@@ -71,6 +71,7 @@
   let observer: ResizeObserver;
 
   function onResize() {
+    if (!leaderboardContainer) return;
     availableWidth = leaderboardContainer.offsetWidth;
     columns = Math.floor(availableWidth / (315 + 20));
   }

--- a/src/routes/_surfaces/workspace/explore/time-series-charts/MetricsTimeSeriesCharts.svelte
+++ b/src/routes/_surfaces/workspace/explore/time-series-charts/MetricsTimeSeriesCharts.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { getMeasuresByMetricsId } from "$lib/redux-store/measure-definition/measure-definition-readables";
+  import { getValidMeasuresByMetricsId } from "$lib/redux-store/measure-definition/measure-definition-readables";
   import { fly } from "svelte/transition";
   import MeasureBigNumber from "./MeasureBigNumber.svelte";
   import TimeSeriesBody from "./TimeSeriesBody.svelte";
@@ -22,7 +22,7 @@
 
   // get all the measure ids that are available.
 
-  $: allMeasures = getMeasuresByMetricsId(metricsDefId);
+  $: allMeasures = getValidMeasuresByMetricsId(metricsDefId);
 
   // get the active big numbers
 
@@ -87,12 +87,10 @@
     </SimpleDataGraphic>
     <!-- bignumbers and line charts -->
     {#each $allMeasures as measure, index (measure.id)}
-      <!-- FIXME: I can't select the big number by the measure id.
-    -->
+      <!-- FIXME: I can't select the big number by the measure id. -->
       {@const bigNum = $bigNumbers?.bigNumbers?.[`measure_${index}`]}
 
-      <!-- FIXME: I can't select a time series by measure id. 
-    -->
+      <!-- FIXME: I can't select a time series by measure id. -->
       <MeasureBigNumber
         value={bigNum}
         description={measure?.description ||


### PR DESCRIPTION
Closes #546

Filtering out measures based on `expressionIsValid` for display and related queries.