### PR TITLE
Adding expression validation response

### DIFF
--- a/src/common/data-modeler-state-service/entity-state-service/MeasureDefinitionStateService.ts
+++ b/src/common/data-modeler-state-service/entity-state-service/MeasureDefinitionStateService.ts
@@ -10,6 +10,7 @@ import {
   StateType,
 } from "$common/data-modeler-state-service/entity-state-service/EntityStateService";
 import type { NicelyFormattedTypes } from "$lib/util/humanize-numbers";
+import type { ParseExpressionError } from "$common/utils/parseExpression";
 
 export interface BasicMeasureDefinition {
   id: string;
@@ -27,6 +28,7 @@ export interface MeasureDefinitionEntity
   description?: string;
   formatPreset?: NicelyFormattedTypes;
   expressionIsValid?: ValidationState;
+  expressionValidationError?: ParseExpressionError;
   sqlNameIsValid?: ValidationState;
 }
 

--- a/src/common/rill-developer-service/MeasuresActions.ts
+++ b/src/common/rill-developer-service/MeasuresActions.ts
@@ -1,6 +1,6 @@
 import { RillDeveloperActions } from "$common/rill-developer-service/RillDeveloperActions";
 import type { MetricsDefinitionContext } from "$common/rill-developer-service/MetricsDefinitionActions";
-import { parseExpression } from "$common/utils/parseQuery";
+import { parseExpression } from "$common/utils/parseExpression";
 import {
   EntityType,
   StateType,
@@ -103,6 +103,7 @@ export class MeasuresActions extends RillDeveloperActions {
       expressionIsValid: expressionIsValid
         ? ValidationState.OK
         : ValidationState.ERROR,
+      expressionValidationError: parsedExpression.error,
     });
   }
 }

--- a/src/server/parse-test.ts
+++ b/src/server/parse-test.ts
@@ -1,6 +1,0 @@
-import "../moduleAlias";
-import { parseExpression } from "$common/utils/parseQuery";
-
-console.log(JSON.stringify(parseExpression("avg(a) - sum(b)"), null, 2));
-console.log(JSON.stringify(parseExpression("a"), null, 2));
-console.log(JSON.stringify(parseExpression("distinct a"), null, 2));

--- a/test/unit/parseExpression.spec.ts
+++ b/test/unit/parseExpression.spec.ts
@@ -1,0 +1,58 @@
+import { parseExpression } from "$common/utils/parseExpression";
+
+describe("parseExpression", () => {
+  (
+    [
+      ["count(*)", ["*"]],
+      ["avg(a::INT)", ["a"]],
+      ["avg(a) - sum(b)", ["a", "b"]],
+      ["avg(a) + 100 / 2.5", ["a"]],
+    ] as Array<[string, Array<string>]>
+  ).forEach((validExpressionTest) => {
+    it(`Valid Expression: ${validExpressionTest[0]}`, () => {
+      const parsedExpression = parseExpression(validExpressionTest[0]);
+      expect(parsedExpression.isValid).toBe(true);
+      expect(parsedExpression.columns).toMatchObject(validExpressionTest[1]);
+    });
+  });
+
+  (
+    [
+      ["a", "ref", [0, 1]],
+      ["a + b", "ref", [4, 5]],
+      ["case when a = null then 0 else a end", "case", [0, 36]],
+    ] as Array<[string, string, [number, number]]>
+  ).forEach((disallowedExpressionTest) => {
+    it(`Disallowed Syntax: ${disallowedExpressionTest[0]}`, () => {
+      const parsedExpression = parseExpression(disallowedExpressionTest[0]);
+      expect(parsedExpression.isValid).toBe(false);
+      expect(parsedExpression.error.disallowedSyntax).toBe(
+        disallowedExpressionTest[1]
+      );
+      expect(parsedExpression.error.location.start).toBe(
+        disallowedExpressionTest[2][0]
+      );
+      expect(parsedExpression.error.location.end).toBe(
+        disallowedExpressionTest[2][1]
+      );
+    });
+  });
+
+  (
+    [
+      ["sum(1", [4, 4]],
+      ["sum(a+)", [6, 7]],
+    ] as Array<[string, [number, number]]>
+  ).forEach((errorExpressionTest) => {
+    it(`Error syntax: ${errorExpressionTest}`, () => {
+      const parsedExpression = parseExpression(errorExpressionTest[0]);
+      expect(parsedExpression.isValid).toBe(false);
+      expect(parsedExpression.error.location.start).toBe(
+        errorExpressionTest[1][0]
+      );
+      expect(parsedExpression.error.location.end).toBe(
+        errorExpressionTest[1][1]
+      );
+    });
+  });
+});


### PR DESCRIPTION
closes #552
Adding `expressionValidationError` to give error message and location. Also adds `disallowedSyntax` for syntaxes that are valid but are not allowed in measure expression.