### PR TITLE
sets null percentage to 72px to accommodate linux users

### DIFF
--- a/src/lib/application-config.ts
+++ b/src/lib/application-config.ts
@@ -8,7 +8,7 @@ export const COLUMN_PROFILE_CONFIG = {
   /** The null percentage should be _just_ big enough to show x 100.0%
    * For MD IO 0.4, this is 74px.
    */
-  nullPercentageWidth: 68,
+  nullPercentageWidth: 72,
   mediumCutoff: 300,
   compactBreakpoint: 350,
   hideRight: 325,


### PR DESCRIPTION
There appears to be a text rendering difference on Linux that causes overflow issues on our tighter null percentages. This should fix the issue until we move to a non-monospace font.