### PR TITLE
model inspector header: fixes issue with timestamp detection when nothing is selected

### DIFF
--- a/src/routes/_surfaces/inspector/ModelInspectorHeader.svelte
+++ b/src/routes/_surfaces/inspector/ModelInspectorHeader.svelte
@@ -95,7 +95,7 @@
   const detectTimestampColumn = (model: DerivedModelEntity) => {
     if (!model) return false;
     const profile = model.profile;
-    const timestampColumn = profile.find((column) => {
+    const timestampColumn = profile?.find((column) => {
       return TIMESTAMPS.has(column.type);
     });
     return !!timestampColumn;


### PR DESCRIPTION
Noticing that we're doing some sort of timestamp detection. I removed my query (deleted the select statement to start over) and the UI broke. This fixes that issue.