### PR TITLE
Update data-modeler-cli.ts

### DIFF
--- a/src/cli/data-modeler-cli.ts
+++ b/src/cli/data-modeler-cli.ts
@@ -11,7 +11,7 @@ import { ExampleProjectCommand } from "$cli/ExampleProjectCommand";
 const program = new Command();
 
 program
-  .name("rill-developer")
+  .name("rill")
   .description("Rill Developer CLI.")
   // Override help to add a capital D for display.
   .helpOption("-h, --help", "Displays help for all commands. ")


### PR DESCRIPTION
Not sure if this code edit achieves the desired result, but my intent is:  our command-line documentation should refer to the rill command as simply 'rill' not 'rill-developer'.  This would be consistent with our documentation and the way in which we recommend users install rill on their localhost.  

https://docs.rilldata.com/cli