### PR TITLE
Add `--version` command to Rill CLI

### DIFF
--- a/src/cli/data-modeler-cli.ts
+++ b/src/cli/data-modeler-cli.ts
@@ -1,25 +1,28 @@
 #!/usr/bin/env node
 import "../moduleAlias";
-import { Command } from "commander";
-import { InitCommand } from "$cli/InitCommand";
-import { ImportTableCommand } from "$cli/ImportTableCommand";
-import { StartCommand } from "$cli/StartCommand";
-import { InfoCommand } from "$cli/InfoCommand";
+
 import { DropTableCommand } from "$cli/DropTableCommand";
 import { ExampleProjectCommand } from "$cli/ExampleProjectCommand";
+import { ImportTableCommand } from "$cli/ImportTableCommand";
+import { InfoCommand } from "$cli/InfoCommand";
+import { InitCommand } from "$cli/InitCommand";
+import { StartCommand } from "$cli/StartCommand";
+import { Command } from "commander";
+import { version } from "../../package.json";
 
 const program = new Command();
 
 program
   .name("rill-developer")
   .description("Rill Developer CLI.")
+  .version(version, "-v, --version", "Output the current version.")
   // Override help to add a capital D for display.
   .helpOption("-h, --help", "Displays help for all commands. ")
-  .addHelpCommand("help [command]", "Displays help for a specific command. ")
+  .addHelpCommand("help [command]", "Displays help for a specific command.")
   // common across all commands
   .option(
-    "--project <projectPath> ",
-    "Optionally indicate the path to your project. This path defaults to the current directory. "
+    "--project <projectPath>",
+    "Optionally indicate the path to your project. This path defaults to the current directory."
   );
 
 [


### PR DESCRIPTION
This makes `rill --version` and `rill -v` output the Rill version number.

Closes #410 