### PR TITLE
Quick metrics tweaks

### DIFF
--- a/src/lib/components/metrics-definition/MetricsDefinitionGenerateButton.svelte
+++ b/src/lib/components/metrics-definition/MetricsDefinitionGenerateButton.svelte
@@ -1,12 +1,20 @@
 <script lang="ts">
+  import { getContext } from "svelte";
+
   import Tooltip from "$lib/components/tooltip/Tooltip.svelte";
   import TooltipContent from "$lib/components/tooltip/TooltipContent.svelte";
-  import { generateMeasuresAndDimensionsApi } from "$lib/redux-store/metrics-definition/metrics-definition-apis";
+  import {
+    generateMeasuresAndDimensionsApi,
+    updateMetricsDefsApi,
+  } from "$lib/redux-store/metrics-definition/metrics-definition-apis";
   import { store } from "$lib/redux-store/store-root";
   import { getMetricsDefReadableById } from "$lib/redux-store/metrics-definition/metrics-definition-readables";
   import MetricsDefinitionGenerateButtonModal from "./MetricsDefinitionGenerateButtomModal.svelte";
   import { getDimensionsByMetricsId } from "$lib/redux-store/dimension-definition/dimension-definition-readables";
   import { getMeasuresByMetricsId } from "$lib/redux-store/measure-definition/measure-definition-readables";
+  import { TIMESTAMPS } from "$lib/duckdb-data-types";
+  import type { DerivedModelStore } from "$lib/application-state-stores/model-stores";
+  import type { ProfileColumn } from "$lib/types";
 
   $: selectedMetricsDef = getMetricsDefReadableById(metricsDefId);
   $: selectedDimensions = getDimensionsByMetricsId(metricsDefId);
@@ -16,16 +24,49 @@
 
   function handleGenerateClick() {
     store.dispatch(generateMeasuresAndDimensionsApi(metricsDefId));
+    if (!$selectedMetricsDef?.timeDimension && timestampColumns.length > 0) {
+      // select the first available timestamp column if one has not been
+      // selected and there are some available
+      store.dispatch(
+        updateMetricsDefsApi({
+          id: metricsDefId,
+          changes: { timeDimension: timestampColumns[0].name },
+        })
+      );
+    }
     closeModal();
+  }
+
+  const derivedModelStore = getContext(
+    "rill:app:derived-model-store"
+  ) as DerivedModelStore;
+
+  let timestampColumns: Array<ProfileColumn>;
+
+  $: if ($selectedMetricsDef?.sourceModelId && $derivedModelStore?.entities) {
+    timestampColumns = $derivedModelStore?.entities
+      .find((model) => model.id === $selectedMetricsDef.sourceModelId)
+      .profile.filter((column) => TIMESTAMPS.has(column.type));
+  } else {
+    timestampColumns = [];
+  }
+
+  function updateMetricsDefinitionTimestamp(evt: Event) {
+    store.dispatch(
+      updateMetricsDefsApi({
+        id: metricsDefId,
+        changes: { timeDimension: (<HTMLSelectElement>evt.target).value },
+      })
+    );
   }
 
   let tooltipText = "";
   let buttonDisabled = true;
-  $: if (
-    $selectedMetricsDef?.sourceModelId === undefined ||
-    $selectedMetricsDef?.timeDimension === undefined
-  ) {
-    tooltipText = "";
+  $: if ($selectedMetricsDef?.sourceModelId === undefined) {
+    tooltipText = "select a model before populating these metrics";
+    buttonDisabled = true;
+  } else if (timestampColumns.length === 0) {
+    tooltipText = "cannot create metrics for a model with no timestamps";
     buttonDisabled = true;
   } else {
     tooltipText = undefined;
@@ -77,13 +118,16 @@
         `}>quick metrics</button
   >
   <TooltipContent slot="tooltip-content">
-    <div style:width="30em">
+    <div>
       {#if buttonDisabled}
-        select a model and a timestamp column before populating these metrics
+        {tooltipText}
       {:else}
-        add initial measure <em>events per time period</em>, and add all
-        categorical columns as slicing dimensions.
-        <br /> <strong>warning:</strong> replaces current measures and dimensions
+        <div style="max-width: 30em;">
+          Add initial measure <em>events per time period</em>, and add all
+          categorical columns as slicing dimensions. If no timestamp is
+          selected, the first time column from the model will be used.
+          <br /> <strong>Warning:</strong> Replaces current measures and dimensions.
+        </div>
       {/if}
     </div>
   </TooltipContent>

--- a/src/lib/components/metrics-definition/MetricsDefinitionGenerateButton.svelte
+++ b/src/lib/components/metrics-definition/MetricsDefinitionGenerateButton.svelte
@@ -63,10 +63,10 @@
   let tooltipText = "";
   let buttonDisabled = true;
   $: if ($selectedMetricsDef?.sourceModelId === undefined) {
-    tooltipText = "select a model before populating these metrics";
+    tooltipText = "Select a model before populating these metrics";
     buttonDisabled = true;
   } else if (timestampColumns.length === 0) {
-    tooltipText = "cannot create metrics for a model with no timestamps";
+    tooltipText = "Cannot create metrics for a model with no timestamps";
     buttonDisabled = true;
   } else {
     tooltipText = undefined;

--- a/src/lib/components/metrics-definition/MetricsDefinitionGenerateButton.svelte
+++ b/src/lib/components/metrics-definition/MetricsDefinitionGenerateButton.svelte
@@ -5,8 +5,12 @@
   import { store } from "$lib/redux-store/store-root";
   import { getMetricsDefReadableById } from "$lib/redux-store/metrics-definition/metrics-definition-readables";
   import MetricsDefinitionGenerateButtonModal from "./MetricsDefinitionGenerateButtomModal.svelte";
+  import { getDimensionsByMetricsId } from "$lib/redux-store/dimension-definition/dimension-definition-readables";
+  import { getMeasuresByMetricsId } from "$lib/redux-store/measure-definition/measure-definition-readables";
 
   $: selectedMetricsDef = getMetricsDefReadableById(metricsDefId);
+  $: selectedDimensions = getDimensionsByMetricsId(metricsDefId);
+  $: selectedMeasures = getMeasuresByMetricsId(metricsDefId);
 
   export let metricsDefId: string;
 
@@ -30,6 +34,14 @@
 
   let modalIsOpen = false;
 
+  const openModelIfNeeded = () => {
+    if ($selectedDimensions.length > 0 || $selectedMeasures.length > 0) {
+      openModal();
+    } else {
+      handleGenerateClick();
+    }
+  };
+
   const openModal = () => {
     modalIsOpen = true;
   };
@@ -47,7 +59,7 @@
 <Tooltip location="right" alignment="middle" distance={5}>
   <button
     disabled={buttonDisabled}
-    on:click={openModal}
+    on:click={openModelIfNeeded}
     class={`bg-white
           border-gray-400
           hover:border-gray-900

--- a/src/lib/components/metrics-definition/MetricsDefinitionGenerateButton.svelte
+++ b/src/lib/components/metrics-definition/MetricsDefinitionGenerateButton.svelte
@@ -51,15 +51,6 @@
     timestampColumns = [];
   }
 
-  function updateMetricsDefinitionTimestamp(evt: Event) {
-    store.dispatch(
-      updateMetricsDefsApi({
-        id: metricsDefId,
-        changes: { timeDimension: (<HTMLSelectElement>evt.target).value },
-      })
-    );
-  }
-
   let tooltipText = "";
   let buttonDisabled = true;
   $: if ($selectedMetricsDef?.sourceModelId === undefined) {


### PR DESCRIPTION
reworks the "quick metrics" button to fix #625 and #626

new behavior:
- modal only pops if the metrics definition is empty
- a timestamp no longer needs to be manually selected to use "quick metrics"
    - if a model with a timestamp is selected, "quick start" will choose the first time column from the model
    - if a model with no timestamp is selected, "quick start" is disabled with tooltip "cannot create metrics for a model with no timestamps"

