### PR TITLE
Stable instalId

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "d3-shape": "^3.1.0",
         "d3-time": "^3.0.0",
         "d3-time-format": "^4.1.0",
-        "duckdb": "^0.4.0",
+        "duckdb": "0.4.0",
         "express": "^4.17.3",
         "express-fileupload": "^1.3.1",
         "glob": "^7.2.0",

--- a/src/cli/post-install.ts
+++ b/src/cli/post-install.ts
@@ -26,10 +26,12 @@ import {
   if (existsSync(LocalConfigFile)) {
     configJson = JSON.parse(readFileSync(LocalConfigFile).toString());
   } else {
-    configJson = {};
+    // generate install id only for the 1st time
+    configJson = {
+      installId: guidGenerator(),
+    };
   }
   const configObject = new LocalConfig(configJson);
-  configObject.installId = guidGenerator();
 
   writeFileSync(LocalConfigFile, JSON.stringify(configObject));
 })();

--- a/src/cli/post-install.ts
+++ b/src/cli/post-install.ts
@@ -1,37 +1,4 @@
 import "../moduleAlias";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
-import { LocalConfig } from "$common/config/LocalConfig";
-import { guidGenerator } from "$lib/util/guid";
-import {
-  ApplicationConfigFolder,
-  LocalConfigFile,
-} from "$common/config/ConfigFolders";
+import { initLocalConfig } from "$common/utils/initLocalConfig";
 
-/**
- * Initializes the rill local config.
- * 1. Creates a folder under ApplicationConfigFolder
- * 2. Creates a config file LocalConfigFile
- * 3. Generates installId and saves into the LocalConfigFile
- *
- * This is run as postinstall npm script.
- */
-
-(async () => {
-  if (!existsSync(ApplicationConfigFolder)) {
-    mkdirSync(ApplicationConfigFolder, { recursive: true });
-    console.log("creating folder");
-  }
-
-  let configJson;
-  if (existsSync(LocalConfigFile)) {
-    configJson = JSON.parse(readFileSync(LocalConfigFile).toString());
-  } else {
-    // generate install id only for the 1st time
-    configJson = {
-      installId: guidGenerator(),
-    };
-  }
-  const configObject = new LocalConfig(configJson);
-
-  writeFileSync(LocalConfigFile, JSON.stringify(configObject));
-})();
+initLocalConfig();

--- a/src/common/utils/initLocalConfig.ts
+++ b/src/common/utils/initLocalConfig.ts
@@ -1,0 +1,39 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import {
+  ApplicationConfigFolder,
+  LocalConfigFile,
+} from "$common/config/ConfigFolders";
+import { guidGenerator } from "$lib/util/guid";
+import { LocalConfig } from "$common/config/LocalConfig";
+
+/**
+ * Initializes the rill local config.
+ * 1. Creates a folder under ApplicationConfigFolder
+ * 2. Creates a config file LocalConfigFile
+ * 3. Generates installId and saves into the LocalConfigFile
+ */
+export function initLocalConfig() {
+  if (!existsSync(ApplicationConfigFolder)) {
+    mkdirSync(ApplicationConfigFolder, { recursive: true });
+    console.log("creating folder");
+  }
+
+  let configJson;
+
+  if (existsSync(LocalConfigFile)) {
+    try {
+      configJson = JSON.parse(readFileSync(LocalConfigFile).toString());
+    } catch (err) {
+      console.error("Error reading local config.");
+    }
+  }
+  if (!configJson) {
+    // generate install id only for the 1st time
+    configJson = {
+      installId: guidGenerator(),
+    };
+    writeFileSync(LocalConfigFile, JSON.stringify(configJson));
+  }
+
+  return new LocalConfig(configJson);
+}

--- a/src/server/serverFactory.ts
+++ b/src/server/serverFactory.ts
@@ -40,6 +40,7 @@ import { ExpressServer } from "$server/ExpressServer";
 import type { RillDeveloper } from "$server/RillDeveloper";
 import { SocketServer } from "$server/SocketServer";
 import { existsSync, readFileSync } from "fs";
+import { initLocalConfig } from "$common/utils/initLocalConfig";
 
 let PACKAGE_JSON = "";
 try {
@@ -104,9 +105,7 @@ export function metricsServiceFactory(
 }
 
 export function dataModelerServiceFactory(config: RootConfig) {
-  if (existsSync(LocalConfigFile)) {
-    config.local = JSON.parse(readFileSync(LocalConfigFile).toString());
-  }
+  config.local = initLocalConfig();
   try {
     config.local.version = JSON.parse(
       readFileSync(PACKAGE_JSON).toString()

--- a/src/server/serverFactory.ts
+++ b/src/server/serverFactory.ts
@@ -1,4 +1,3 @@
-import { LocalConfigFile } from "$common/config/ConfigFolders";
 import type { RootConfig } from "$common/config/RootConfig";
 import { ApplicationActions } from "$common/data-modeler-service/ApplicationActions";
 import { DataModelerService } from "$common/data-modeler-service/DataModelerService";
@@ -39,7 +38,7 @@ import { SocketNotificationService } from "$common/socket/SocketNotificationServ
 import { ExpressServer } from "$server/ExpressServer";
 import type { RillDeveloper } from "$server/RillDeveloper";
 import { SocketServer } from "$server/SocketServer";
-import { existsSync, readFileSync } from "fs";
+import { readFileSync } from "fs";
 import { initLocalConfig } from "$common/utils/initLocalConfig";
 
 let PACKAGE_JSON = "";


### PR DESCRIPTION
Making installId stable across installs.
If the user's local config is deleted or if it failed to load, recreating it with a new instalId