### PR TITLE
Add `like`, `ilike`, and `glob` to DuckDB keywords

### DIFF
--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -165,7 +165,7 @@
 
   const DuckDBSQL: SQLDialect = SQLDialect.define({
     keywords:
-      "select from where group by all having order limit sample unnest with window qualify values filter exclude replace",
+      "select from where group by all having order limit sample unnest with window qualify values filter exclude replace like ilike glob",
   });
 
   function makeAutocompleteConfig(schema: { [table: string]: string[] }) {


### PR DESCRIPTION
These keywords get added to autocomplete and syntax highlighting.