### PR TITLE
Remove mid tick in dates

### DIFF
--- a/src/lib/components/data-graphic/utils.ts
+++ b/src/lib/components/data-graphic/utils.ts
@@ -90,7 +90,7 @@ export function getTicks(
   let ticks = scale.ticks(tickCount);
 
   if (ticks.length <= 1) {
-    if (isDate) ticks = [...scale.domain(), ...ticks] as Date[];
+    if (isDate) ticks = scale.domain();
     else ticks = scale.nice().domain();
   }
 


### PR DESCRIPTION
Remove mid tick in dates to avoid the following placement of ticks

![Screenshot 2022-07-28 at 3 23 12 PM](https://user-images.githubusercontent.com/4402679/181540563-d720687a-0f48-489d-ae2d-0bb0ff2f39e1.png)
