### PR TITLE
Apply Inter as the main font

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@codemirror/search": "^0.20.0",
         "@codemirror/state": "^0.20.0",
         "@codemirror/view": "^0.20.0",
+        "@fontsource/inter": "^4.5.11",
         "@types/d3-scale": "^4.0.2",
         "@types/d3-shape": "^3.1.0",
         "axios": "^0.27.2",
@@ -1934,6 +1935,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@fontsource/inter": {
+      "version": "4.5.11",
+      "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-4.5.11.tgz",
+      "integrity": "sha512-toizzQkfXL8YJcG/f8j3EYXYGQe4OxiDEItThSigvHU+cYNDw8HPp3wLYQX745hddsnHqOGCM4exitFSBOU8+w=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.9.5",
@@ -15447,6 +15453,11 @@
           "dev": true
         }
       }
+    },
+    "@fontsource/inter": {
+      "version": "4.5.11",
+      "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-4.5.11.tgz",
+      "integrity": "sha512-toizzQkfXL8YJcG/f8j3EYXYGQe4OxiDEItThSigvHU+cYNDw8HPp3wLYQX745hddsnHqOGCM4exitFSBOU8+w=="
     },
     "@humanwhocodes/config-array": {
       "version": "0.9.5",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "@codemirror/search": "^0.20.0",
     "@codemirror/state": "^0.20.0",
     "@codemirror/view": "^0.20.0",
+    "@fontsource/inter": "^4.5.11",
     "@types/d3-scale": "^4.0.2",
     "@types/d3-shape": "^3.1.0",
     "axios": "^0.27.2",

--- a/src/app.css
+++ b/src/app.css
@@ -16,7 +16,10 @@ html {
 }
 
 body {
-  font-family: "MD IO";
+  font-family: "Inter";
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: 'tnum' on;      /* low-level (all new browsers) */
+
   font-size: 12px;
 
   /* Use this for a few keyboard characters in tooltips, etc. */

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -1,22 +1,23 @@
 <script>
-  import "../fonts.css";
-  import "../app.css";
-  import { onMount, setContext } from "svelte";
-  import { createStore } from "$lib/application-state-stores/application-store";
+  import "@fontsource/inter"; // Defaults to weight 400.
   import { browser } from "$app/env";
+  import { createStore } from "$lib/application-state-stores/application-store";
+  import { onMount, setContext } from "svelte";
+  import "../app.css";
+  import "../fonts.css";
 
-  import NotificationCenter from "$lib/components/notifications/NotificationCenter.svelte";
   import notification from "$lib/components/notifications/";
+  import NotificationCenter from "$lib/components/notifications/NotificationCenter.svelte";
 
+  import {
+    createDerivedModelStore,
+    createPersistentModelStore,
+  } from "$lib/application-state-stores/model-stores";
   import { createQueryHighlightStore } from "$lib/application-state-stores/query-highlight-store";
   import {
     createDerivedTableStore,
     createPersistentTableStore,
   } from "$lib/application-state-stores/table-stores";
-  import {
-    createDerivedModelStore,
-    createPersistentModelStore,
-  } from "$lib/application-state-stores/model-stores";
   import { initMetrics } from "$lib/metrics/initMetrics";
   import { syncApplicationState } from "$lib/redux-store/application/application-apis";
 


### PR DESCRIPTION
This brings in Inter and uses tabular numbers.

Did this as an experiment. We would need to re-design the type usage thorughout the app but as a first pass, it could be worse.

<img width="1721" alt="Screen Shot 2022-07-28 at 4 59 32 PM" src="https://user-images.githubusercontent.com/95735/181656575-79c03df8-9e6f-4026-9f61-470d5cdb161b.png">
 