### PR TITLE
Change default model names

### DIFF
--- a/scripts/example-project.sh
+++ b/scripts/example-project.sh
@@ -32,7 +32,7 @@ echo "Importing example SQL transforamtions into the project..."
 mv -v ${PROJECT_BASE}/rill-developer-example/example-assets/models/* ${PROJECT_BASE}/rill-developer-example/models
 
 echo "Cleaning up the project..."
-rm ${PROJECT_BASE}/rill-developer-example/models/query_1.sql
+rm ${PROJECT_BASE}/rill-developer-example/models/model_1.sql
 rm -rf ${PROJECT_BASE}/rill-developer-example/example-assets
 rm -rf ${PROJECT_BASE}/rill-developer-example/__MACOSX
 rm -rf ${PROJECT_BASE}/rill-developer-example/example-assets.zip

--- a/src/common/data-modeler-state-service/entity-state-service/PersistentModelEntityService.ts
+++ b/src/common/data-modeler-state-service/entity-state-service/PersistentModelEntityService.ts
@@ -38,7 +38,7 @@ export class PersistentModelEntityService extends EntityStateService<
       initialState.modelNumber = 0;
     }
     initialState.entities.forEach((entity) => {
-      const match = entity.name.match(/query_(\d*).sql/);
+      const match = entity.name.match(/model_(\d*).sql/);
       const num = Number(match?.[1]);
       if (!Number.isNaN(num)) {
         initialState.modelNumber = Math.max(

--- a/src/common/stateInstancesFactory.ts
+++ b/src/common/stateInstancesFactory.ts
@@ -1,20 +1,20 @@
-import type { DataModelerState } from "$lib/types";
-import { guidGenerator } from "$lib/util/guid";
-import {
-  extractTableName,
-  sanitizeTableName,
-} from "$lib/util/extract-table-name";
-import type { PersistentTableEntity } from "$common/data-modeler-state-service/entity-state-service/PersistentTableEntityService";
+import type { DerivedModelEntity } from "$common/data-modeler-state-service/entity-state-service/DerivedModelEntityService";
+import type { DerivedTableEntity } from "$common/data-modeler-state-service/entity-state-service/DerivedTableEntityService";
+import type { DimensionDefinitionEntity } from "$common/data-modeler-state-service/entity-state-service/DimensionDefinitionStateService";
 import {
   EntityStatus,
   EntityType,
 } from "$common/data-modeler-state-service/entity-state-service/EntityStateService";
-import type { PersistentModelEntity } from "$common/data-modeler-state-service/entity-state-service/PersistentModelEntityService";
-import type { DerivedModelEntity } from "$common/data-modeler-state-service/entity-state-service/DerivedModelEntityService";
-import type { DerivedTableEntity } from "$common/data-modeler-state-service/entity-state-service/DerivedTableEntityService";
-import type { MetricsDefinitionEntity } from "$common/data-modeler-state-service/entity-state-service/MetricsDefinitionEntityService";
 import type { MeasureDefinitionEntity } from "$common/data-modeler-state-service/entity-state-service/MeasureDefinitionStateService";
-import type { DimensionDefinitionEntity } from "$common/data-modeler-state-service/entity-state-service/DimensionDefinitionStateService";
+import type { MetricsDefinitionEntity } from "$common/data-modeler-state-service/entity-state-service/MetricsDefinitionEntityService";
+import type { PersistentModelEntity } from "$common/data-modeler-state-service/entity-state-service/PersistentModelEntityService";
+import type { PersistentTableEntity } from "$common/data-modeler-state-service/entity-state-service/PersistentTableEntityService";
+import type { DataModelerState } from "$lib/types";
+import {
+  extractTableName,
+  sanitizeTableName,
+} from "$lib/util/extract-table-name";
+import { guidGenerator } from "$lib/util/guid";
 
 interface NewModelArguments {
   query?: string;
@@ -50,7 +50,7 @@ export function getNewModel(
 ): PersistentModelEntity {
   const query = params.query || "";
   const name = `${
-    params.name ? cleanModelName(params.name) : `query_${modelNumber}`
+    params.name ? cleanModelName(params.name) : `model_${modelNumber}`
   }.sql`;
   return {
     id: guidGenerator(),

--- a/src/lib/redux-store/source/source-apis.ts
+++ b/src/lib/redux-store/source/source-apis.ts
@@ -1,24 +1,24 @@
-import { dataModelerService } from "$lib/application-state-stores/application-store";
-import { EntityType } from "$common/data-modeler-state-service/entity-state-service/EntityStateService";
-import notificationStore from "$lib/components/notifications";
-import { store } from "$lib/redux-store/store-root";
-import {
-  createMetricsDefsApi,
-  generateMeasuresAndDimensionsApi,
-} from "$lib/redux-store/metrics-definition/metrics-definition-apis";
 import type { DerivedTableEntity } from "$common/data-modeler-state-service/entity-state-service/DerivedTableEntityService";
-import { TIMESTAMPS } from "$lib/duckdb-data-types";
+import { EntityType } from "$common/data-modeler-state-service/entity-state-service/EntityStateService";
 import type { PersistentModelEntity } from "$common/data-modeler-state-service/entity-state-service/PersistentModelEntityService";
-import { selectMetricsDefinitionMatchingName } from "$lib/redux-store/metrics-definition/metrics-definition-selectors";
+import { dataModelerService } from "$lib/application-state-stores/application-store";
 import {
   resetQuickStartDashboardOverlay,
   showQuickStartDashboardOverlay,
 } from "$lib/application-state-stores/layout-store";
+import notificationStore from "$lib/components/notifications";
+import { TIMESTAMPS } from "$lib/duckdb-data-types";
+import {
+  createMetricsDefsApi,
+  generateMeasuresAndDimensionsApi,
+} from "$lib/redux-store/metrics-definition/metrics-definition-apis";
+import { selectMetricsDefinitionMatchingName } from "$lib/redux-store/metrics-definition/metrics-definition-selectors";
 import { updateModelQueryApi } from "$lib/redux-store/model/model-apis";
 import {
   selectDerivedModelBySourceName,
   selectPersistentModelById,
 } from "$lib/redux-store/model/model-selector";
+import { store } from "$lib/redux-store/store-root";
 
 // Source doesn't have a slice as of now.
 // This file has simple code that will eventually be moved into async thunks
@@ -133,13 +133,13 @@ const createModelFromSourceAndGetId = async (
 ): Promise<string> => {
   // check existing models to avoid a name conflict
   const existingNames = models
-    .filter((model) => model.name.includes(`query_${sourceName}`))
+    .filter((model) => model.name.includes(`${sourceName}_model`))
     .map((model) => model.tableName)
     .sort();
   const nextName =
     existingNames.length === 0
-      ? `query_${sourceName}`
-      : `query_${sourceName}_${existingNames.length + 1}`;
+      ? `${sourceName}_model`
+      : `${sourceName}_model_${existingNames.length + 1}`;
 
   const response = await dataModelerService.dispatch("addModel", [
     {

--- a/test/functional/DataLoader.spec.ts
+++ b/test/functional/DataLoader.spec.ts
@@ -1,20 +1,20 @@
-import { TestBase } from "@adityahegde/typescript-test-utils";
-import { FunctionalTestBase } from "./FunctionalTestBase";
-import {
-  ParquetFileTestData,
-  CSVFileTestData,
-  FileImportTestDataProvider,
-  TestDataColumns,
-} from "../data/DataLoader.data";
-import { DATA_FOLDER } from "../data/generator/data-constants";
+import { ActionStatus } from "$common/data-modeler-service/response/ActionResponse";
+import { ActionErrorType } from "$common/data-modeler-service/response/ActionResponseMessage";
+import { asyncWait } from "$common/utils/waitUtils";
 import {
   extractFileExtension,
   extractTableName,
 } from "$lib/util/extract-table-name";
-import { ActionStatus } from "$common/data-modeler-service/response/ActionResponse";
-import { ActionErrorType } from "$common/data-modeler-service/response/ActionResponseMessage";
+import { TestBase } from "@adityahegde/typescript-test-utils";
+import {
+  CSVFileTestData,
+  FileImportTestDataProvider,
+  ParquetFileTestData,
+  TestDataColumns,
+} from "../data/DataLoader.data";
+import { DATA_FOLDER } from "../data/generator/data-constants";
 import { SingleTableQuery, TwoTableJoinQuery } from "../data/ModelQuery.data";
-import { asyncWait } from "$common/utils/waitUtils";
+import { FunctionalTestBase } from "./FunctionalTestBase";
 
 const UserFile = "test/data/Users.csv";
 
@@ -94,7 +94,7 @@ export class DataLoaderSpec extends FunctionalTestBase {
       ]),
     ]);
     await this.clientDataModelerService.dispatch("addModel", [
-      { name: "query_0", query: SingleTableQuery },
+      { name: "model_0", query: SingleTableQuery },
     ]);
     await this.waitForTables();
     await this.waitForModels();
@@ -108,7 +108,7 @@ export class DataLoaderSpec extends FunctionalTestBase {
     expect(table).toBeUndefined();
     expect(derivedTable).toBeUndefined();
 
-    const [model] = this.getModels("tableName", "query_0");
+    const [model] = this.getModels("tableName", "model_0");
     const response = await this.clientDataModelerService.dispatch(
       "updateModelQuery",
       [model.id, TwoTableJoinQuery]

--- a/test/functional/DatabaseColumnActions.spec.ts
+++ b/test/functional/DatabaseColumnActions.spec.ts
@@ -8,13 +8,13 @@ export class DatabaseColumns extends FunctionalTestBase {
   private databaseDispatchSpy: SinonSpy;
 
   private async testHistogramSummary(input, output) {
-    const [model] = this.getModels("tableName", "query_0");
+    const [model] = this.getModels("tableName", "model_0");
     await this.clientDataModelerService.dispatch("updateModelQuery", [
       model.id,
       input,
     ]);
     await this.waitForModels();
-    const [, derivedModel] = this.getModels("tableName", "query_0");
+    const [, derivedModel] = this.getModels("tableName", "model_0");
     expect(derivedModel.profile[0].summary.histogram).toEqual(output);
   }
 
@@ -31,7 +31,7 @@ export class DatabaseColumns extends FunctionalTestBase {
   public async setupTests() {
     await this.clientDataModelerService.dispatch("clearAllModels", []);
     await this.clientDataModelerService.dispatch("addModel", [
-      { name: "query_0", query: "" },
+      { name: "model_0", query: "" },
     ]);
   }
 

--- a/test/functional/DatabasePriorityQueue.spec.ts
+++ b/test/functional/DatabasePriorityQueue.spec.ts
@@ -1,4 +1,5 @@
-import { FunctionalTestBase } from "./FunctionalTestBase";
+import { EntityType } from "$common/data-modeler-state-service/entity-state-service/EntityStateService";
+import { asyncWait } from "$common/utils/waitUtils";
 import { assert } from "sinon";
 import {
   SingleTableQuery,
@@ -6,8 +7,7 @@ import {
   TwoTableJoinQuery,
   TwoTableJoinQueryColumnsTestData,
 } from "../data/ModelQuery.data";
-import { asyncWait } from "$common/utils/waitUtils";
-import { EntityType } from "$common/data-modeler-state-service/entity-state-service/EntityStateService";
+import { FunctionalTestBase } from "./FunctionalTestBase";
 
 @FunctionalTestBase.Suite
 export class DatabasePriorityQueueSpec extends FunctionalTestBase {
@@ -16,7 +16,7 @@ export class DatabasePriorityQueueSpec extends FunctionalTestBase {
     await this.clientDataModelerService.dispatch("clearAllTables", []);
     await this.clientDataModelerService.dispatch("clearAllModels", []);
     await this.clientDataModelerService.dispatch("addModel", [
-      { name: "query_0", query: "" },
+      { name: "model_0", query: "" },
     ]);
   }
 
@@ -28,7 +28,7 @@ export class DatabasePriorityQueueSpec extends FunctionalTestBase {
     );
     await asyncWait(1);
 
-    const [model] = this.getModels("tableName", "query_0");
+    const [model] = this.getModels("tableName", "model_0");
     const modelQueryPromise = this.clientDataModelerService.dispatch(
       "updateModelQuery",
       [model.id, SingleTableQuery]
@@ -46,7 +46,7 @@ export class DatabasePriorityQueueSpec extends FunctionalTestBase {
       "test/data/AdImpressions.parquet",
     ]);
 
-    const [model] = this.getModels("tableName", "query_0");
+    const [model] = this.getModels("tableName", "model_0");
     const modelQueryOnePromise = this.clientDataModelerService.dispatch(
       "updateModelQuery",
       [model.id, TwoTableJoinQuery]
@@ -61,7 +61,7 @@ export class DatabasePriorityQueueSpec extends FunctionalTestBase {
       modelQueryOnePromise,
       modelQueryTwoPromise
     );
-    const [, derivedModel] = this.getModels("tableName", "query_0");
+    const [, derivedModel] = this.getModels("tableName", "model_0");
     this.assertColumns(derivedModel.profile, SingleTableQueryColumnsTestData);
   }
 
@@ -74,10 +74,10 @@ export class DatabasePriorityQueueSpec extends FunctionalTestBase {
       "test/data/AdImpressions.parquet",
     ]);
     await this.clientDataModelerService.dispatch("addModel", [
-      { name: "query_1", query: "" },
+      { name: "model_1", query: "" },
     ]);
 
-    const [model0] = this.getModels("tableName", "query_1");
+    const [model0] = this.getModels("tableName", "model_1");
     const modelQueryOnePromise = this.clientDataModelerService.dispatch(
       "updateModelQuery",
       [model0.id, TwoTableJoinQuery]
@@ -87,7 +87,7 @@ export class DatabasePriorityQueueSpec extends FunctionalTestBase {
       model0.id,
     ]);
     await asyncWait(50);
-    const [model1] = this.getModels("tableName", "query_0");
+    const [model1] = this.getModels("tableName", "model_0");
     const modelQueryTwoPromise = this.clientDataModelerService.dispatch(
       "updateModelQuery",
       [model1.id, SingleTableQuery]
@@ -110,7 +110,7 @@ export class DatabasePriorityQueueSpec extends FunctionalTestBase {
       "test/data/AdImpressions.parquet",
     ]);
 
-    const [model] = this.getModels("tableName", "query_0");
+    const [model] = this.getModels("tableName", "model_0");
     const modelQueryTwoPromise = this.clientDataModelerService.dispatch(
       "updateModelQuery",
       [model.id, TwoTableJoinQuery]
@@ -125,7 +125,7 @@ export class DatabasePriorityQueueSpec extends FunctionalTestBase {
       modelQueryOnePromise,
       modelQueryTwoPromise
     );
-    const [, derivedModel] = this.getModels("tableName", "query_0");
+    const [, derivedModel] = this.getModels("tableName", "model_0");
     this.assertColumns(derivedModel.profile, TwoTableJoinQueryColumnsTestData);
   }
 

--- a/test/functional/EntityStatus.spec.ts
+++ b/test/functional/EntityStatus.spec.ts
@@ -1,12 +1,12 @@
-import { FunctionalTestBase } from "./FunctionalTestBase";
+import { ApplicationStatus } from "$common/data-modeler-state-service/entity-state-service/ApplicationEntityService";
 import {
   EntityStatus,
   EntityType,
 } from "$common/data-modeler-state-service/entity-state-service/EntityStateService";
-import { EntityStatusTracker } from "../utils/EntityStatusTracker";
 import { asyncWait } from "$common/utils/waitUtils";
 import { TwoTableJoinQuery } from "../data/ModelQuery.data";
-import { ApplicationStatus } from "$common/data-modeler-state-service/entity-state-service/ApplicationEntityService";
+import { EntityStatusTracker } from "../utils/EntityStatusTracker";
+import { FunctionalTestBase } from "./FunctionalTestBase";
 
 @FunctionalTestBase.Suite
 export class EntityStatusSpec extends FunctionalTestBase {
@@ -54,10 +54,10 @@ export class EntityStatusSpec extends FunctionalTestBase {
   //         "addOrUpdateTableFromFile", ["test/data/AdBids.csv"]);
   //     await this.waitForTables();
   //     await this.clientDataModelerService.dispatch(
-  //         "addModel", [{name: "query_0", query: ""}]);
+  //         "addModel", [{name: "model_0", query: ""}]);
   //     await asyncWait(50);
 
-  //     const [model] = this.getModels("name", "query_0.sql");
+  //     const [model] = this.getModels("name", "model_0.sql");
   //     this.entityStatusTracker.startTracker(EntityType.Model);
   //     await asyncWait(50);
 
@@ -88,11 +88,11 @@ export class EntityStatusSpec extends FunctionalTestBase {
     ]);
     await this.waitForTables();
     await this.clientDataModelerService.dispatch("addModel", [
-      { name: "query_0", query: TwoTableJoinQuery },
+      { name: "model_0", query: TwoTableJoinQuery },
     ]);
     await asyncWait(50);
 
-    const [model] = this.getModels("name", "query_0.sql");
+    const [model] = this.getModels("name", "model_0.sql");
     this.entityStatusTracker.startTracker(EntityType.Model);
     await asyncWait(50);
 
@@ -117,13 +117,13 @@ export class EntityStatusSpec extends FunctionalTestBase {
   // @FunctionalTestBase.Test()
   // public async shouldOnlySwitchApplicationStatusOnce() {
   //     await this.clientDataModelerService.dispatch(
-  //         "addModel", [{name: "query_0", query: ""}]);
+  //         "addModel", [{name: "model_0", query: ""}]);
   //     await this.clientDataModelerService.dispatch(
-  //         "addModel", [{name: "query_1", query: ""}]);
+  //         "addModel", [{name: "model_1", query: ""}]);
   //     await asyncWait(50);
 
-  //     const [model0] = this.getModels("name", "query_0.sql");
-  //     const [model1] = this.getModels("name", "query_1.sql");
+  //     const [model0] = this.getModels("name", "model_0.sql");
+  //     const [model1] = this.getModels("name", "model_1.sql");
 
   //     this.entityStatusTracker.startTracker(EntityType.Table);
   //     await asyncWait(50);

--- a/test/functional/ModelFileSync.spec.ts
+++ b/test/functional/ModelFileSync.spec.ts
@@ -1,7 +1,9 @@
-import { FunctionalTestBase } from "./FunctionalTestBase";
-import { RootConfig } from "$common/config/RootConfig";
 import { DatabaseConfig } from "$common/config/DatabaseConfig";
+import { RootConfig } from "$common/config/RootConfig";
 import { StateConfig } from "$common/config/StateConfig";
+import { expect } from "@playwright/test";
+import { existsSync, readFileSync, writeFileSync } from "fs";
+import { execSync } from "node:child_process";
 import {
   NestedQuery,
   NestedQueryColumnsTestData,
@@ -10,14 +12,12 @@ import {
   TwoTableJoinQuery,
   TwoTableJoinQueryColumnsTestData,
 } from "../data/ModelQuery.data";
-import { existsSync, readFileSync, writeFileSync } from "fs";
-import { expect } from "@playwright/test";
-import { execSync } from "node:child_process";
+import { FunctionalTestBase } from "./FunctionalTestBase";
 
 const SYNC_TEST_FOLDER = "temp/model-sync-test";
 const MODEL_FOLDER = `${SYNC_TEST_FOLDER}/models`;
-const QUERY_0_FILE = `${MODEL_FOLDER}/query_0.sql`;
-const QUERY_1_FILE = `${MODEL_FOLDER}/query_1.sql`;
+const MODEL_0_FILE = `${MODEL_FOLDER}/model_0.sql`;
+const MODEL_1_FILE = `${MODEL_FOLDER}/model_1.sql`;
 
 @FunctionalTestBase.Suite
 export class ModelFileSyncSpec extends FunctionalTestBase {
@@ -45,15 +45,15 @@ export class ModelFileSyncSpec extends FunctionalTestBase {
 
   @FunctionalTestBase.Test()
   public async shouldUpdateModelFileAndViceVersa() {
-    expect(existsSync(QUERY_0_FILE)).toBe(false);
+    expect(existsSync(MODEL_0_FILE)).toBe(false);
 
     await this.clientDataModelerService.dispatch("addModel", [
-      { name: "query_0", query: "" },
+      { name: "model_0", query: "" },
     ]);
     await this.waitForModels();
-    expect(existsSync(QUERY_0_FILE)).toBe(true);
+    expect(existsSync(MODEL_0_FILE)).toBe(true);
 
-    const [model] = this.getModels("tableName", "query_0");
+    const [model] = this.getModels("tableName", "model_0");
     await this.clientDataModelerService.dispatch("updateModelQuery", [
       model.id,
       SingleTableQuery,
@@ -61,17 +61,17 @@ export class ModelFileSyncSpec extends FunctionalTestBase {
     await this.waitForModels();
 
     // updating query from client should update the file
-    expect(readFileSync(QUERY_0_FILE).toString()).toBe(SingleTableQuery);
-    const [, persistentModel] = this.getModels("tableName", "query_0");
+    expect(readFileSync(MODEL_0_FILE).toString()).toBe(SingleTableQuery);
+    const [, persistentModel] = this.getModels("tableName", "model_0");
     this.assertColumns(
       persistentModel.profile,
       SingleTableQueryColumnsTestData
     );
 
     // updating query from file should update profiling data
-    writeFileSync(QUERY_0_FILE, TwoTableJoinQuery);
+    writeFileSync(MODEL_0_FILE, TwoTableJoinQuery);
     await this.waitForModels();
-    const [, newPersistentModel] = this.getModels("tableName", "query_0");
+    const [, newPersistentModel] = this.getModels("tableName", "model_0");
     this.assertColumns(
       newPersistentModel.profile,
       TwoTableJoinQueryColumnsTestData
@@ -81,83 +81,83 @@ export class ModelFileSyncSpec extends FunctionalTestBase {
   @FunctionalTestBase.Test()
   public async shouldDeleteModelOnFileDelete() {
     await this.clientDataModelerService.dispatch("addModel", [
-      { name: "query_0", query: SingleTableQuery },
+      { name: "model_0", query: SingleTableQuery },
     ]);
     await this.waitForModels();
-    expect(existsSync(QUERY_0_FILE)).toBe(true);
+    expect(existsSync(MODEL_0_FILE)).toBe(true);
 
     // file is recreated if deleted.
-    execSync(`rm ${QUERY_0_FILE}`);
+    execSync(`rm ${MODEL_0_FILE}`);
     await this.waitForModels();
-    const [model] = this.getModels("tableName", "query_0");
+    const [model] = this.getModels("tableName", "model_0");
     expect(model).toBe(undefined);
-    expect(existsSync(QUERY_0_FILE)).toBe(false);
+    expect(existsSync(MODEL_0_FILE)).toBe(false);
   }
 
   @FunctionalTestBase.Test()
   public async shouldRenameModelOnFileRename() {
     await this.clientDataModelerService.dispatch("addModel", [
-      { name: "query_0", query: SingleTableQuery },
+      { name: "model_0", query: SingleTableQuery },
     ]);
     await this.waitForModels();
-    expect(existsSync(QUERY_0_FILE)).toBe(true);
-    expect(existsSync(QUERY_1_FILE)).toBe(false);
+    expect(existsSync(MODEL_0_FILE)).toBe(true);
+    expect(existsSync(MODEL_1_FILE)).toBe(false);
 
     // file is renamed if deleted.
-    execSync(`mv ${QUERY_0_FILE} ${QUERY_1_FILE}`);
+    execSync(`mv ${MODEL_0_FILE} ${MODEL_1_FILE}`);
     await this.waitForModels();
-    const [model0] = this.getModels("tableName", "query_0");
-    const [model1, persistentModel1] = this.getModels("tableName", "query_1");
+    const [model0] = this.getModels("tableName", "model_0");
+    const [model1, persistentModel1] = this.getModels("tableName", "model_1");
     expect(model0).toBe(undefined);
-    expect(existsSync(QUERY_0_FILE)).toBe(false);
+    expect(existsSync(MODEL_0_FILE)).toBe(false);
     expect(model1.query).toBe(SingleTableQuery);
     this.assertColumns(
       persistentModel1.profile,
       SingleTableQueryColumnsTestData
     );
-    expect(existsSync(QUERY_1_FILE)).toBe(true);
+    expect(existsSync(MODEL_1_FILE)).toBe(true);
   }
 
   @FunctionalTestBase.Test()
   public async shouldAddNewModelsOnModelRename() {
-    const QUERY_00_FILE = `${MODEL_FOLDER}/query_00.sql`;
-    const QUERY_10_FILE = `${MODEL_FOLDER}/query_10.sql`;
+    const MODEL_00_FILE = `${MODEL_FOLDER}/model_00.sql`;
+    const MODEL_10_FILE = `${MODEL_FOLDER}/model_10.sql`;
 
     await this.clientDataModelerService.dispatch("addModel", [
-      { name: "query_0", query: SingleTableQuery },
+      { name: "model_0", query: SingleTableQuery },
     ]);
     await this.clientDataModelerService.dispatch("addModel", [
-      { name: "query_1", query: TwoTableJoinQuery },
+      { name: "model_1", query: TwoTableJoinQuery },
     ]);
     await this.waitForModels();
-    expect(existsSync(QUERY_0_FILE)).toBe(true);
-    expect(existsSync(QUERY_00_FILE)).toBe(false);
-    expect(existsSync(QUERY_1_FILE)).toBe(true);
-    expect(existsSync(QUERY_10_FILE)).toBe(false);
+    expect(existsSync(MODEL_0_FILE)).toBe(true);
+    expect(existsSync(MODEL_00_FILE)).toBe(false);
+    expect(existsSync(MODEL_1_FILE)).toBe(true);
+    expect(existsSync(MODEL_10_FILE)).toBe(false);
 
-    const [model0] = this.getModels("tableName", "query_0");
-    const [model1] = this.getModels("tableName", "query_1");
+    const [model0] = this.getModels("tableName", "model_0");
+    const [model1] = this.getModels("tableName", "model_1");
 
-    // rename query_0 => query_00, query_1 => query_10 then add a new file query_0.sql
+    // rename model_0 => model_00, model_1 => model_10 then add a new file model_0.sql
     await this.clientDataModelerService.dispatch("updateModelName", [
       model0.id,
-      "query_00",
+      "model_00",
     ]);
     await this.clientDataModelerService.dispatch("updateModelName", [
       model1.id,
-      "query_10",
+      "model_10",
     ]);
     await this.waitForModels();
-    writeFileSync(QUERY_0_FILE, NestedQuery);
+    writeFileSync(MODEL_0_FILE, NestedQuery);
     await this.waitForModels();
-    expect(readFileSync(QUERY_0_FILE).toString()).toBe(NestedQuery);
-    expect(readFileSync(QUERY_00_FILE).toString()).toBe(SingleTableQuery);
-    expect(existsSync(QUERY_1_FILE)).toBe(false);
-    expect(readFileSync(QUERY_10_FILE).toString()).toBe(TwoTableJoinQuery);
+    expect(readFileSync(MODEL_0_FILE).toString()).toBe(NestedQuery);
+    expect(readFileSync(MODEL_00_FILE).toString()).toBe(SingleTableQuery);
+    expect(existsSync(MODEL_1_FILE)).toBe(false);
+    expect(readFileSync(MODEL_10_FILE).toString()).toBe(TwoTableJoinQuery);
 
-    const [, persistentModel0] = this.getModels("tableName", "query_00");
-    const [, persistentModel1] = this.getModels("tableName", "query_10");
-    const [, persistentModel2] = this.getModels("tableName", "query_0");
+    const [, persistentModel0] = this.getModels("tableName", "model_00");
+    const [, persistentModel1] = this.getModels("tableName", "model_10");
+    const [, persistentModel2] = this.getModels("tableName", "model_0");
     this.assertColumns(
       persistentModel0?.profile,
       SingleTableQueryColumnsTestData
@@ -171,28 +171,28 @@ export class ModelFileSyncSpec extends FunctionalTestBase {
 
   @FunctionalTestBase.Test()
   public async shouldDeleteNonSqlFiles() {
-    const INVALID_FILE = "query_0.sq";
+    const INVALID_FILE = "model_0.sq";
     await this.clientDataModelerService.dispatch("addModel", [
-      { name: "query_0", query: SingleTableQuery },
+      { name: "model_0", query: SingleTableQuery },
     ]);
     await this.waitForModels();
-    expect(existsSync(QUERY_0_FILE)).toBe(true);
+    expect(existsSync(MODEL_0_FILE)).toBe(true);
 
     // file is renamed to invalid file. model is deleted
-    execSync(`mv ${QUERY_0_FILE} ${INVALID_FILE}`);
+    execSync(`mv ${MODEL_0_FILE} ${INVALID_FILE}`);
     await this.waitForModels();
-    let [model] = this.getModels("tableName", "query_0");
+    let [model] = this.getModels("tableName", "model_0");
     expect(model).toBe(undefined);
-    expect(existsSync(QUERY_0_FILE)).toBe(false);
+    expect(existsSync(MODEL_0_FILE)).toBe(false);
     // invalid file is not deleted
     expect(existsSync(INVALID_FILE)).toBe(true);
 
     // file is renamed back to .sql file
-    execSync(`mv ${INVALID_FILE} ${QUERY_0_FILE}`);
+    execSync(`mv ${INVALID_FILE} ${MODEL_0_FILE}`);
     await this.waitForModels();
-    [model] = this.getModels("tableName", "query_0");
-    expect(model.tableName).toBe("query_0");
-    expect(readFileSync(QUERY_0_FILE).toString()).toBe(SingleTableQuery);
+    [model] = this.getModels("tableName", "model_0");
+    expect(model.tableName).toBe("model_0");
+    expect(readFileSync(MODEL_0_FILE).toString()).toBe(SingleTableQuery);
     expect(existsSync(INVALID_FILE)).toBe(false);
   }
 }

--- a/test/functional/ModelQuery.spec.ts
+++ b/test/functional/ModelQuery.spec.ts
@@ -1,17 +1,17 @@
-import { FunctionalTestBase } from "./FunctionalTestBase";
+import { ActionStatus } from "$common/data-modeler-service/response/ActionResponse";
+import { ActionErrorType } from "$common/data-modeler-service/response/ActionResponseMessage";
+import {
+  EntityType,
+  StateType,
+} from "$common/data-modeler-state-service/entity-state-service/EntityStateService";
+import { asyncWait } from "$common/utils/waitUtils";
 import type { TestDataColumns } from "../data/DataLoader.data";
 import {
   ModelQueryTestData,
   ModelQueryTestDataProvider,
   SingleTableQuery,
 } from "../data/ModelQuery.data";
-import { asyncWait } from "$common/utils/waitUtils";
-import {
-  EntityType,
-  StateType,
-} from "$common/data-modeler-state-service/entity-state-service/EntityStateService";
-import { ActionErrorType } from "$common/data-modeler-service/response/ActionResponseMessage";
-import { ActionStatus } from "$common/data-modeler-service/response/ActionResponse";
+import { FunctionalTestBase } from "./FunctionalTestBase";
 
 @FunctionalTestBase.Suite
 export class ModelQuerySpec extends FunctionalTestBase {
@@ -19,7 +19,7 @@ export class ModelQuerySpec extends FunctionalTestBase {
   public async setupTables(): Promise<void> {
     await this.loadTestTables();
     await this.clientDataModelerService.dispatch("addModel", [
-      { name: "query_0", query: "" },
+      { name: "model_0", query: "" },
     ]);
   }
 
@@ -32,7 +32,7 @@ export class ModelQuerySpec extends FunctionalTestBase {
     query: string,
     columns: TestDataColumns
   ): Promise<void> {
-    const [model] = this.getModels("tableName", "query_0");
+    const [model] = this.getModels("tableName", "model_0");
     await this.clientDataModelerService.dispatch("updateModelQuery", [
       model.id,
       query,
@@ -41,7 +41,7 @@ export class ModelQuerySpec extends FunctionalTestBase {
 
     const [persistentModel, derivedModel] = this.getModels(
       "tableName",
-      "query_0"
+      "model_0"
     );
     expect(derivedModel.error).toBeUndefined();
     expect(persistentModel.query).toBe(query);
@@ -75,7 +75,7 @@ export class ModelQuerySpec extends FunctionalTestBase {
     newModel = service.getCurrentState().entities[1];
     expect(newModel.name).toBe(NEW_MODEL_UPDATE_NAME);
 
-    const OTHER_MODEL_NAME = "query_0.sql";
+    const OTHER_MODEL_NAME = "model_0.sql";
     await this.clientDataModelerService.dispatch("moveModelUp", [newModel.id]);
     await asyncWait(50);
     expect(service.getCurrentState().entities[0].name).toBe(
@@ -101,7 +101,7 @@ export class ModelQuerySpec extends FunctionalTestBase {
   public async shouldReturnModelQueryError(): Promise<void> {
     const INVALID_QUERY = "slect * from AdBids";
 
-    const [model] = this.getModels("tableName", "query_0");
+    const [model] = this.getModels("tableName", "model_0");
     // invalid query
     let response = await this.clientDataModelerService.dispatch(
       "updateModelQuery",
@@ -110,7 +110,7 @@ export class ModelQuerySpec extends FunctionalTestBase {
     await this.waitForModels();
     expect(response.status).toBe(ActionStatus.Failure);
     expect(response.messages[0].errorType).toBe(ActionErrorType.ModelQuery);
-    let [, derivedModel] = this.getModels("tableName", "query_0");
+    let [, derivedModel] = this.getModels("tableName", "model_0");
     expect(derivedModel.error).toBe(response.messages[0].message);
 
     response = await this.clientDataModelerService.dispatch(
@@ -120,7 +120,7 @@ export class ModelQuerySpec extends FunctionalTestBase {
     await this.waitForModels();
     expect(response.status).toBe(ActionStatus.Failure);
     expect(response.messages[0].errorType).toBe(ActionErrorType.ModelQuery);
-    [, derivedModel] = this.getModels("tableName", "query_0");
+    [, derivedModel] = this.getModels("tableName", "model_0");
     expect(derivedModel.error).toBe(response.messages[0].message);
 
     // clearing query should clear the error
@@ -130,7 +130,7 @@ export class ModelQuerySpec extends FunctionalTestBase {
     );
     expect(response.status).toBe(ActionStatus.Success);
     expect(response.messages.length).toBe(0);
-    [, derivedModel] = this.getModels("tableName", "query_0");
+    [, derivedModel] = this.getModels("tableName", "model_0");
     expect(derivedModel.error).toBeUndefined();
   }
 
@@ -138,14 +138,14 @@ export class ModelQuerySpec extends FunctionalTestBase {
   public async shouldSwitchActiveEntityOnDelete() {
     for (let i = 1; i <= 5; i++) {
       await this.clientDataModelerService.dispatch("addModel", [
-        { name: `query_${i}`, query: "" },
+        { name: `model_${i}`, query: "" },
       ]);
       await asyncWait(50);
     }
 
     const ids = [];
     for (let i = 0; i < 5; i++) {
-      const [model] = this.getModels("name", `query_${i}.sql`);
+      const [model] = this.getModels("name", `model_${i}.sql`);
       ids.push(model.id);
     }
 


### PR DESCRIPTION
This changes default model names to:
- Use "model" not "query" terminology (e.g. `model_1` not `query_1`). It's more consistent for models to be called models.
- Be a suffix not a prefix when autogenerated from a source (e.g. `mysource_model` not `query_mysource` or `model_mysource`). This makes it easier to scan your list of assets.