### PR TITLE
Makes it possible to run the command `npm run dev` On windows

### DIFF
--- a/src/dev.ts
+++ b/src/dev.ts
@@ -2,9 +2,13 @@ import { spawn } from "node:child_process";
 
 function spawnNpmProcess(scriptName) {
   console.log(`Starting "npm run ${scriptName}"`);
-  const childProcess = spawn("npm", ["run", scriptName], {
-    stdio: "inherit",
-  });
+  const childProcess = spawn(
+    /^win/.test(process.platform) ? "npm.cmd" : "npm",
+    ["run", scriptName],
+    {
+      stdio: "inherit",
+    }
+  );
   childProcess.on("error", (err) => {
     console.log(`Script "npm run ${scriptName}" failed.`, err);
   });


### PR DESCRIPTION
This PR makes it possible to run dev mode on windows, though there is still some breakage in the dev mode server. However this initial PR is an incremental step towards the rest of the debugging that is required , because without the two subsidiary scripts won't even run at all