### PR TITLE
Use prepare instead of execute for metrics validation

### DIFF
--- a/src/common/database-service/DatabaseMetricsExplorerActions.ts
+++ b/src/common/database-service/DatabaseMetricsExplorerActions.ts
@@ -88,7 +88,7 @@ export class DatabaseMetricsExplorerActions extends DatabaseActions {
     expression: string
   ): Promise<string> {
     try {
-      await this.databaseClient.execute(`select ${expression} from ${table}`);
+      await this.databaseClient.prepare(`select ${expression} from ${table}`);
     } catch (err) {
       return err.message;
     }


### PR DESCRIPTION
On a large dataset metrics validation takes lot of time, since it was actually executing the query. 
As we do not need the results, changing to prepare. 

Before - 
<img width="1031" alt="Screenshot 2022-08-22 at 3 37 03 PM" src="https://user-images.githubusercontent.com/5023786/185899078-db29217a-bb89-4bd7-a288-e271608ccef2.png">
After - 
<img width="831" alt="Screenshot 2022-08-22 at 3 55 30 PM" src="https://user-images.githubusercontent.com/5023786/185900102-126ce930-1ea0-45e9-ad40-6924170475de.png">

Thanks @AdityaHegde for helping figure this out. 