### PR TITLE
Adding optional query profile emitting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ export/
 
 # generated content
 log
+profile.log
 saved-state.json
 last-query-output.json
 staging-databases

--- a/src/common/connection/DuckDbConnection.ts
+++ b/src/common/connection/DuckDbConnection.ts
@@ -42,7 +42,9 @@ export class DuckDbConnection extends DataConnection {
   public async sync(): Promise<void> {
     const tables = await this.duckDbClient.execute<{ table_name: string }>(
       "SELECT table_name FROM information_schema.tables " +
-        "WHERE table_type NOT ILIKE '%TEMPORARY' AND table_type NOT ILIKE '%VIEW';"
+        "WHERE table_type NOT ILIKE '%TEMPORARY' AND table_type NOT ILIKE '%VIEW';",
+      false,
+      true
     );
     const persistentTables = this.dataModelerStateService
       .getEntityStateService(EntityType.Table, StateType.Persistent)

--- a/src/common/database-service/DatabaseTableActions.ts
+++ b/src/common/database-service/DatabaseTableActions.ts
@@ -33,7 +33,9 @@ export class DatabaseTableActions extends DatabaseActions {
     tableName: string
   ): Promise<number> {
     const [cardinality] = await this.databaseClient.execute<{ count: number }>(
-      `select count(*) as count FROM '${tableName}';`
+      `select count(*) as count FROM '${tableName}';`,
+      false,
+      true
     );
     return cardinality.count;
   }

--- a/src/common/database-service/DuckDBClient.ts
+++ b/src/common/database-service/DuckDBClient.ts
@@ -1,5 +1,8 @@
 import duckdb from "duckdb";
 import type { DatabaseConfig } from "$common/config/DatabaseConfig";
+import { open } from "node:fs/promises";
+import type { FileHandle } from "node:fs/promises";
+import { readFileSync } from "fs";
 
 interface DuckDB {
   // TODO: define concrete styles
@@ -7,6 +10,9 @@ interface DuckDB {
   exec: (...args: Array<unknown>) => unknown;
   prepare: (...args: Array<unknown>) => unknown;
 }
+
+const DuckDBProfilingEnv = "RILL_QUERY_PROFILE_PATH";
+const DuckDBProfileFile = "./profile.log";
 
 /**
  * Runs a duckdb instance. Database name can be configured {@link DatabaseConfig}
@@ -16,6 +22,7 @@ interface DuckDB {
  */
 export class DuckDBClient {
   protected db: DuckDB;
+  protected logFile: FileHandle;
 
   protected onCallback: () => void;
   protected offCallback: () => void;
@@ -35,17 +42,25 @@ export class DuckDBClient {
     // we can later on swap this over to WASM and update data loader
     this.db = new duckdb.Database(this.databaseConfig.databaseName);
     this.db.exec("PRAGMA threads=32;PRAGMA log_query_path='./log';");
+    if (process.env[DuckDBProfilingEnv]) {
+      this.db.exec(
+        `PRAGMA enable_profiling;PRAGMA profile_output='${DuckDBProfileFile}';`
+      );
+      this.logFile = await open(process.env[DuckDBProfilingEnv], "a");
+    }
   }
 
   public execute<Row = Record<string, unknown>>(
     query: string,
-    log = false
+    log = false,
+    skipAppend = false
   ): Promise<Array<Row>> {
     this.onCallback?.();
     if (log) console.log(query);
     return new Promise((resolve, reject) => {
       try {
         this.db.all(query, (err, res) => {
+          if (!skipAppend) this.appendToFile();
           if (err !== null) {
             reject(err);
           } else {
@@ -67,5 +82,9 @@ export class DuckDBClient {
         else resolve(stmt);
       });
     });
+  }
+
+  private appendToFile() {
+    this.logFile?.write(`${readFileSync(DuckDBProfileFile).toString()}\n\n`);
   }
 }


### PR DESCRIPTION
Running with `RILL_QUERY_PROFILE_PATH=/path/to/log` will emit duckdb's query profile output.