### PR TITLE
Remove tailwind console warning

### DIFF
--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,10 +1,9 @@
 module.exports = {
-  purge: [
+  content: [
     "./src/**/*.html",
     "./src/**/*.svelte",
     "./src/lib/duckdb-data-types.ts",
   ],
-  content: [],
   theme: {
     extend: {},
   },


### PR DESCRIPTION
We've been getting this console warning everytime we start the dev server:
<img width="558" alt="image" src="https://user-images.githubusercontent.com/14206386/188689462-6dcc9b85-a35c-4a8b-86b4-848a7bc9102f.png">

This PR follows the Tailwind upgrade guide to remove that warning.