### PR TITLE
fix fix rule `no-useless-escape` #334, fix fix rule `typescript-eslin…

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -25,8 +25,6 @@ module.exports = {
     "@typescript-eslint/no-explicit-any": "warn",
     "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
     "@typescript-eslint/ban-ts-comment": "warn",
-    "no-useless-escape": "warn",
-    "@typescript-eslint/no-empty-interface": "warn",
   },
   globals: {
     RILL_VERSION: true,


### PR DESCRIPTION
fixes #334 and fixes #335 -- turns out no additional work is needed, apparently the offending code is no longer present, so we can just remove the "warn" from those rules