### PR TITLE
moves to duckdb `0.5.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "d3-shape": "^3.1.0",
         "d3-time": "^3.0.0",
         "d3-time-format": "^4.1.0",
-        "duckdb": "0.4.0",
+        "duckdb": "0.5.0",
         "express": "^4.17.3",
         "express-fileupload": "^1.3.1",
         "glob": "^7.2.0",
@@ -5503,9 +5503,9 @@
       }
     },
     "node_modules/duckdb": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/duckdb/-/duckdb-0.4.0.tgz",
-      "integrity": "sha512-xSi5ZMm+OVegutwn4IQxP7zui/lV4r4S8y6+abkcLIiA6b7WWV97UrEYLdN5lxg67nS9aZ+YDfNm3hCgnpruqw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/duckdb/-/duckdb-0.5.0.tgz",
+      "integrity": "sha512-CBl1m5QywUx017RCWn/ENsQxy2xm44xhLYnoizX0LWcGCTgYebQIfsYgCBtbfecU0CWjAbMj9sIceGVHkNEMUw==",
       "hasInstallScript": true,
       "dependencies": {
         "@mapbox/node-pre-gyp": "^1.0.0",
@@ -18470,9 +18470,9 @@
       }
     },
     "duckdb": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/duckdb/-/duckdb-0.4.0.tgz",
-      "integrity": "sha512-xSi5ZMm+OVegutwn4IQxP7zui/lV4r4S8y6+abkcLIiA6b7WWV97UrEYLdN5lxg67nS9aZ+YDfNm3hCgnpruqw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/duckdb/-/duckdb-0.5.0.tgz",
+      "integrity": "sha512-CBl1m5QywUx017RCWn/ENsQxy2xm44xhLYnoizX0LWcGCTgYebQIfsYgCBtbfecU0CWjAbMj9sIceGVHkNEMUw==",
       "requires": {
         "@mapbox/node-pre-gyp": "^1.0.0",
         "node-addon-api": "*",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "d3-shape": "^3.1.0",
     "d3-time": "^3.0.0",
     "d3-time-format": "^4.1.0",
-    "duckdb": "0.4.0",
+    "duckdb": "0.5.0",
     "express": "^4.17.3",
     "express-fileupload": "^1.3.1",
     "glob": "^7.2.0",


### PR DESCRIPTION
This is temporary until we have the new Runtime, but was playing with `0.5.0` and the new features are very nice / work in Rill Developer.