### PR TITLE
Revamp UI of Dimension table

### DIFF
--- a/web-local/src/app.css
+++ b/web-local/src/app.css
@@ -83,3 +83,10 @@ body {
   background-color: transparent;
   border-right: none;
 }
+
+.line-clamp-2 {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}

--- a/web-local/src/lib/components/dimension/DimensionTable.svelte
+++ b/web-local/src/lib/components/dimension/DimensionTable.svelte
@@ -107,10 +107,12 @@ TableCells – the cell contents.
       });
     }
 
-    const estimateColumnSize = columns.map((column) => {
+    const estimateColumnSize = columns.map((column, i) => {
       /** if we are inferring column widths from the data,
        * let's utilize columnWidths, calculated above.
        */
+
+      if (i != 0) return DimensionTableConfig.defaultColumnWidth;
       const largestStringLength =
         (inferColumnWidthFromData
           ? columnWidths[column.name]
@@ -133,32 +135,15 @@ TableCells – the cell contents.
           ? DimensionTableConfig.minHeaderWidthWhenColumsAreSmall
           : headerWidth;
 
-      let hasUserDefinedColumnWidth =
-        $manuallyResizedColumns[column.name] !== undefined;
-
       return largestStringLength
-        ? /** the largest value for a column should be config.maxColumnWidth.
-           * the smallest value should either be the largestStringLength (which comes from the actual)
-           * table values, the header string, or the config.minColumnWidth.
-           */
-          Math.min(
-            /** Define the maximum column size. If the user has set the column width, go with that (meaning columns
-             * can be infinitely large if the user wants it). Otherwise, set a default width that is sensible.
-             */
-            hasUserDefinedColumnWidth
-              ? Infinity
-              : DimensionTableConfig.maxColumnWidth,
-            /** If user has set the column width, we'll go with that (as long as it is larger than minColumnWidth).
-             * If they haven't set it, we'll go with the effectiveHeaderWidth.
-             */
-            hasUserDefinedColumnWidth
-              ? $manuallyResizedColumns[column.name]
-              : Math.max(
-                  largestStringLength,
-                  effectiveHeaderWidth,
-                  /** All columns must be minColumnWidth regardless of user settings. */
-                  DimensionTableConfig.minColumnWidth
-                )
+        ? Math.min(
+            DimensionTableConfig.maxColumnWidth,
+            Math.max(
+              largestStringLength,
+              effectiveHeaderWidth,
+              /** All columns must be minColumnWidth regardless of user settings. */
+              DimensionTableConfig.minColumnWidth
+            )
           )
         : /** if there isn't a longet string length for some reason, let's go with a
            * default column width. We should not be in this state.

--- a/web-local/src/lib/components/dimension/DimensionTableConfig.ts
+++ b/web-local/src/lib/components/dimension/DimensionTableConfig.ts
@@ -1,7 +1,7 @@
 import type { VirtualizedTableConfig } from "../virtualized-table/types";
 
 export const DimensionTableConfig: VirtualizedTableConfig = {
-  defaultColumnWidth: 200,
+  defaultColumnWidth: 120,
   maxColumnWidth: 320,
   minColumnWidth: 104,
   minHeaderWidthWhenColumsAreSmall: 160,

--- a/web-local/src/lib/components/virtualized-table/core/Cell.svelte
+++ b/web-local/src/lib/components/virtualized-table/core/Cell.svelte
@@ -19,6 +19,7 @@
   import BarAndLabel from "../../viz/BarAndLabel.svelte";
 
   const config: VirtualizedTableConfig = getContext("config");
+  const isDimensionTable = config.table === "DimensionTable";
 
   export let row;
   export let column;
@@ -66,12 +67,6 @@
     }
   }
 
-  /** Show left border for Dimension table 
-  /* using the information that dimension column 
-  /* cells have no formatting present
-  */
-  const leftBorder = config.table === "DimensionTable" && !formattedValue;
-
   $: barColor = rowSelected
     ? "bg-blue-300"
     : atLeastOneSelected
@@ -97,8 +92,7 @@
       z-9 
       text-ellipsis 
       whitespace-nowrap 
-      border-r border-b 
-      {leftBorder ? 'border-l' : ''}
+      {isDimensionTable ? '' : 'border-r border-b'}
       {activityStatus}
       "
     style:left="{column.start}px"

--- a/web-local/src/lib/components/virtualized-table/core/Cell.svelte
+++ b/web-local/src/lib/components/virtualized-table/core/Cell.svelte
@@ -109,7 +109,7 @@
       <button
         class="
           {config.rowHeight <= 28 ? 'py-1' : 'py-2'}
-          px-4 
+          {isDimensionTable ? 'px-2' : 'px-4'}
           text-left w-full text-ellipsis overflow-x-hidden whitespace-nowrap
           "
         use:shiftClickAction

--- a/web-local/src/lib/components/virtualized-table/core/ColumnHeader.svelte
+++ b/web-local/src/lib/components/virtualized-table/core/ColumnHeader.svelte
@@ -100,7 +100,7 @@
           class="text-ellipsis
           {columnFontWeight}
           {isDimensionTable
-            ? 'text-center break-words line-clamp-2'
+            ? 'text-left break-words line-clamp-2'
             : 'overflow-hidden whitespace-nowrap'}
           "
         >
@@ -127,17 +127,17 @@
         </TooltipShortcutContainer>
       </TooltipContent>
     </Tooltip>
-    {#if isSelected}
-      {#if isSortingDesc}
-        <div in:fly={{ duration: 200, y: -8 }}>
-          <ArrowDown size="16px" />
-        </div>
-      {:else}
-        <div in:fly={{ duration: 200, y: 8 }}>
-          <ArrowDown transform="scale(1 -1)" size="16px" />
-        </div>
-      {/if}
+
+    {#if isSortingDesc}
+      <div in:fly={{ duration: 200, y: -8 }} style:opacity={isSelected ? 1 : 0}>
+        <ArrowDown size="16px" />
+      </div>
+    {:else}
+      <div in:fly={{ duration: 200, y: 8 }} style:opacity={isSelected ? 1 : 0}>
+        <ArrowDown transform="scale(1 -1)" size="16px" />
+      </div>
     {/if}
+
     {#if !noPin && showMore}
       <Tooltip location="top" alignment="middle" distance={16}>
         <button

--- a/web-local/src/lib/components/virtualized-table/core/ColumnHeader.svelte
+++ b/web-local/src/lib/components/virtualized-table/core/ColumnHeader.svelte
@@ -79,15 +79,15 @@
            justify-stretch
            select-none
            over
-           gap-x-2
+           {isDimensionTable ? 'gap-x-1' : 'gap-x-2'}
            "
   >
     <Tooltip location="top" alignment="middle" distance={16}>
       <div
         class="
         grid
-        items-center cursor-pointer
-        {isSelected ? '' : 'w-full gap-x-2'}
+        items-center cursor-pointer w-full
+        {isSelected ? '' : 'gap-x-2'}
         "
         style:grid-template-columns={isDimensionTable
           ? ""
@@ -97,8 +97,11 @@
           <DataTypeIcon suppressTooltip color={"text-gray-500"} {type} />
         {/if}
         <span
-          class="text-ellipsis overflow-hidden whitespace-nowrap
-          {columnFontWeight} {isDimensionTable ? 'text-center' : ''}
+          class="text-ellipsis
+          {columnFontWeight}
+          {isDimensionTable
+            ? 'text-center break-words line-clamp-2'
+            : 'overflow-hidden whitespace-nowrap'}
           "
         >
           {name}

--- a/web-local/src/lib/components/virtualized-table/core/StickyHeader.svelte
+++ b/web-local/src/lib/components/virtualized-table/core/StickyHeader.svelte
@@ -32,8 +32,8 @@
     : "border-b border-b-4 border-r border-r-1";
 
   const borderClassesInnerDiv = isDimensionTable
-    ? "border-b"
-    : "border border-gray-200 border-t-0 border-l-0 bg-gray-100";
+    ? ""
+    : "whitespace-nowrap border border-gray-200 border-t-0 border-l-0 bg-gray-100";
 
   const paddingVerticalTop = config.columnHeaderHeight <= 28 ? "py-1" : "py-2";
   const paddingVerticalLeft = config.rowHeight <= 28 ? "py-0.5" : "py-2";
@@ -63,7 +63,7 @@
 >
   <div
     class="
-    text-ellipsis overflow-hidden whitespace-nowrap
+    text-ellipsis overflow-hidden
     px-4
   {borderClassesInnerDiv}
   {position === 'top' && `${paddingVerticalTop} text-left`}

--- a/web-local/src/lib/components/virtualized-table/core/StickyHeader.svelte
+++ b/web-local/src/lib/components/virtualized-table/core/StickyHeader.svelte
@@ -7,6 +7,7 @@
   import type { VirtualizedTableConfig } from "../types";
 
   const config: VirtualizedTableConfig = getContext("config");
+  const isDimensionTable = config.table === "DimensionTable";
 
   const dispatch = createEventDispatcher();
   export let header;
@@ -25,6 +26,14 @@
       positionClasses = "sticky left-0 top-0 z-40  font-bold";
     }
   }
+
+  const borderClassesOuterDiv = isDimensionTable
+    ? "border-b"
+    : "border-b border-b-4 border-r border-r-1";
+
+  const borderClassesInnerDiv = isDimensionTable
+    ? "border-b"
+    : "border border-gray-200 border-t-0 border-l-0 bg-gray-100";
 
   const paddingVerticalTop = config.columnHeaderHeight <= 28 ? "py-1" : "py-2";
   const paddingVerticalLeft = config.rowHeight <= 28 ? "py-0.5" : "py-2";
@@ -50,17 +59,13 @@
     ? config.rowHeight
     : config.columnHeaderHeight}px"
   class="{positionClasses}
-   bg-white text-left border-b border-b-4 border-r border-r-1"
+   bg-white text-left {borderClassesOuterDiv}"
 >
   <div
     class="
     text-ellipsis overflow-hidden whitespace-nowrap
-  px-4
-  border
-  border-gray-200
-  border-t-0
-  border-l-0
-  bg-gray-100
+    px-4
+  {borderClassesInnerDiv}
   {position === 'top' && `${paddingVerticalTop} text-left`}
   {position === 'left' && paddingVerticalLeft}
   {position === 'top-left' && `${paddingVerticalTop} text-center`}

--- a/web-local/src/lib/components/workspace/explore/leaderboards/DimensionDisplay.svelte
+++ b/web-local/src/lib/components/workspace/explore/leaderboards/DimensionDisplay.svelte
@@ -199,7 +199,7 @@
   <DimensionContainer>
     <DimensionHeader {metricsDefId} isFetching={$topListQuery?.isFetching} />
 
-    {#if values}
+    {#if values && columns.length}
       <DimensionTable
         on:select-item={(event) => onSelectItem(event)}
         on:sort={(event) => onSortByColumn(event)}


### PR DESCRIPTION
The UI of the dimension table is now closer to the mock - 

<img width="1256" alt="Screenshot 2022-09-27 at 4 51 04 PM" src="https://user-images.githubusercontent.com/4402679/192513650-ae53d5db-6e11-4cbd-b074-571a0dd90193.png">
