### PR TITLE
Handle requests to non-existent metrics definitions

### DIFF
--- a/web-local/src/common/errors/ErrorMessages.ts
+++ b/web-local/src/common/errors/ErrorMessages.ts
@@ -4,6 +4,8 @@ import { SourceModelValidationStatus } from "../data-modeler-state-service/entit
 // Unified location for error messages
 // TODO: move all errors here.
 
+export const ExplorerMetricsDefinitionDoesntExist =
+  "Metrics definition doesn't exist";
 export const ExplorerSourceModelDoesntExist =
   "Previously selected source model does not exist.";
 export const ExplorerSourceModelIsInvalid = "Model query has errors.";


### PR DESCRIPTION
When manually inputting an invalid UUID to the `dashboard/` route, the application falls back to the `dashboard/[UUID]/edit` page. This PR ensures a 404 "dashboard not found" message is displayed instead.