### PR TITLE
removes the fly transition from the virtualized table header

### DIFF
--- a/web-local/src/lib/components/virtualized-table/core/ColumnHeader.svelte
+++ b/web-local/src/lib/components/virtualized-table/core/ColumnHeader.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { createEventDispatcher, getContext } from "svelte";
   import { fly } from "svelte/transition";
+  import { createShiftClickAction } from "../../../util/shift-click-action";
   import { DataTypeIcon } from "../../data-types";
   import ArrowDown from "../../icons/ArrowDown.svelte";
   import Pin from "../../icons/Pin.svelte";
@@ -11,7 +12,6 @@
   import TooltipContent from "../../tooltip/TooltipContent.svelte";
   import TooltipShortcutContainer from "../../tooltip/TooltipShortcutContainer.svelte";
   import TooltipTitle from "../../tooltip/TooltipTitle.svelte";
-  import { createShiftClickAction } from "../../../util/shift-click-action";
   import type { HeaderPosition, VirtualizedTableConfig } from "../types";
   import StickyHeader from "./StickyHeader.svelte";
 
@@ -97,7 +97,6 @@
           <DataTypeIcon suppressTooltip color={"text-gray-500"} {type} />
         {/if}
         <span
-          in:fly={{ y: 200, duration: 200 }}
           class="text-ellipsis overflow-hidden whitespace-nowrap
           {columnFontWeight} {isDimensionTable ? 'text-center' : ''}
           "


### PR DESCRIPTION
I found this a bit distracting in the modeler. This removes flying.

Example of what the flying in the preview table feels like before this PR. Notice the preview table headers

![Kapture 2022-09-30 at 07 27 33](https://user-images.githubusercontent.com/95735/193292279-3c46a028-b8ff-49a8-9a09-c92e871eefe3.gif)
