### PR TITLE
Increase leaderboard value limit

### DIFF
--- a/web-local/src/lib/components/workspace/explore/leaderboards/Leaderboard.svelte
+++ b/web-local/src/lib/components/workspace/explore/leaderboards/Leaderboard.svelte
@@ -114,7 +114,7 @@
   ) {
     topListQuery = useTopListQuery(config, metricsDefId, dimensionId, {
       measures: [measure.sqlName],
-      limit: 15,
+      limit: 250,
       offset: 0,
       sort: [
         {


### PR DESCRIPTION
Increase the current limit from 15 to 250. This enables values selected from the dimension table to be have proper values once the use goes back to the leaderboards.