### PR TITLE
Add filter gutter for dimension table

### DIFF
--- a/web-local/src/lib/application-state-stores/explorer-stores.ts
+++ b/web-local/src/lib/application-state-stores/explorer-stores.ts
@@ -215,6 +215,36 @@ const metricViewReducers = {
       }
     });
   },
+
+  /**
+   * Toggle a dimension filter between include/exclude modes
+   */
+  toggleFilterMode(id: string, dimensionId: string) {
+    updateMetricsExplorerById(id, (metricsExplorer) => {
+      const exclude =
+        metricsExplorer.dimensionFilterExcludeMode.get(dimensionId);
+      metricsExplorer.dimensionFilterExcludeMode.set(dimensionId, !exclude);
+
+      const relevantFilterKey = exclude ? "exclude" : "include";
+      const otherFilterKey = exclude ? "include" : "exclude";
+
+      const otherFilterEntryIndex = metricsExplorer.filters[
+        relevantFilterKey
+      ].findIndex((filter) => filter.name === dimensionId);
+      // if relevant filter is not present then return
+      if (otherFilterEntryIndex === -1) return;
+
+      // push relevant filters to other filter
+      metricsExplorer.filters[otherFilterKey].push(
+        metricsExplorer.filters[relevantFilterKey][otherFilterEntryIndex]
+      );
+      // remove entry from relevant filter
+      metricsExplorer.filters[relevantFilterKey].splice(
+        otherFilterEntryIndex,
+        1
+      );
+    });
+  },
 };
 export const metricsExplorerStore: Readable<MetricsExplorerStoreType> &
   typeof metricViewReducers = {

--- a/web-local/src/lib/components/dimension/DimensionFilterGutter.svelte
+++ b/web-local/src/lib/components/dimension/DimensionFilterGutter.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+  import { getContext } from "svelte";
+  import StickyHeader from "../virtualized-table/core/StickyHeader.svelte";
+  import type { VirtualizedTableConfig } from "../virtualized-table/types";
+  import Check from "../icons/Check.svelte";
+  import Cancel from "../icons/Cancel.svelte";
+  import Spacer from "../icons/Spacer.svelte";
+
+  const config: VirtualizedTableConfig = getContext("config");
+  export let totalHeight: number;
+  export let virtualRowItems;
+  export let selectedIndex = [];
+
+  let excluded = false;
+</script>
+
+<div
+  class="sticky left-0 top-0 z-20"
+  style:height="{totalHeight}px"
+  style:width="{config.indexWidth}px"
+>
+  {#each virtualRowItems as row (`row-${row.key}`)}
+    {@const isSelected = selectedIndex.includes(row.index)}
+    <StickyHeader
+      enableResize={false}
+      position="left"
+      header={{ size: config.indexWidth, start: row.start }}
+    >
+      <div class="grid place-items-center">
+        {#if isSelected && !excluded}
+          <Check size="20px" />
+        {:else if isSelected && excluded}
+          <Cancel size="20px" />
+        {:else}
+          <Spacer />
+        {/if}
+      </div>
+    </StickyHeader>
+  {/each}
+</div>

--- a/web-local/src/lib/components/dimension/DimensionFilterGutter.svelte
+++ b/web-local/src/lib/components/dimension/DimensionFilterGutter.svelte
@@ -10,8 +10,7 @@
   export let totalHeight: number;
   export let virtualRowItems;
   export let selectedIndex = [];
-
-  let excluded = false;
+  export let excludeMode = false;
 </script>
 
 <div
@@ -27,9 +26,9 @@
       header={{ size: config.indexWidth, start: row.start }}
     >
       <div class="grid place-items-center">
-        {#if isSelected && !excluded}
+        {#if isSelected && !excludeMode}
           <Check size="20px" />
-        {:else if isSelected && excluded}
+        {:else if isSelected && excludeMode}
           <Cancel size="20px" />
         {:else}
           <Spacer />

--- a/web-local/src/lib/components/dimension/DimensionHeader.svelte
+++ b/web-local/src/lib/components/dimension/DimensionHeader.svelte
@@ -14,6 +14,8 @@
   import { metricsExplorerStore } from "../../application-state-stores/explorer-stores";
   import Spinner from "../Spinner.svelte";
   import Spacer from "../icons/Spacer.svelte";
+  import Check from "../icons/Check.svelte";
+  import Cancel from "../icons/Cancel.svelte";
 
   export let metricsDefId: string;
   export let dimensionId: string;
@@ -52,7 +54,9 @@
 
     <Tooltip location="left" distance={16}>
       <Button type="secondary" on:click={toggleFilterMode} compact>
-        {#if excludeMode}exclude{:else}include{/if}
+        {#if excludeMode}<Check size="20px" /> Include{:else}<Cancel
+            size="20px"
+          /> Exclude{/if}
       </Button>
       <TooltipContent slot="tooltip-content">
         <TooltipTitle>

--- a/web-local/src/lib/components/dimension/DimensionHeader.svelte
+++ b/web-local/src/lib/components/dimension/DimensionHeader.svelte
@@ -2,31 +2,69 @@
   import { slideRight } from "../../transitions";
   import { EntityStatus } from "@rilldata/web-local/common/data-modeler-state-service/entity-state-service/EntityStateService";
 
+  import { Button } from "../button";
+
+  import Tooltip from "../tooltip/Tooltip.svelte";
+  import TooltipContent from "../tooltip/TooltipContent.svelte";
+  import TooltipTitle from "../tooltip/TooltipTitle.svelte";
+  import TooltipShortcutContainer from "../tooltip/TooltipShortcutContainer.svelte";
+  import Shortcut from "../tooltip/Shortcut.svelte";
+
   import Back from "../icons/Back.svelte";
   import { metricsExplorerStore } from "../../application-state-stores/explorer-stores";
   import Spinner from "../Spinner.svelte";
+  import Spacer from "../icons/Spacer.svelte";
 
   export let metricsDefId: string;
+  export let dimensionId: string;
   export let isFetching: boolean;
+  export let excludeMode = false;
+
+  $: filterKey = excludeMode ? "exclude" : "include";
+  $: otherFilterKey = excludeMode ? "include" : "exclude";
 
   const goBackToLeaderboard = () => {
     metricsExplorerStore.setMetricDimensionId(metricsDefId, null);
   };
+  function toggleFilterMode() {
+    metricsExplorerStore.toggleFilterMode(metricsDefId, dimensionId);
+  }
 </script>
 
-<div class="grid grid-auto-cols justify-start grid-flow-col items-end p-1 pb-3">
-  <button
-    on:click={() => goBackToLeaderboard()}
-    class="flex flex-row items-center mb-4"
-    style:grid-column-gap=".4rem"
-  >
+<div
+  class="grid justify-start items-center pb-3"
+  style:grid-template-columns="24px calc(100% - 24px)"
+>
+  <div transition:slideRight|local={{ leftOffset: 8 }}>
     {#if isFetching}
-      <div transition:slideRight|local={{ leftOffset: 8 }}>
-        <Spinner size="16px" status={EntityStatus.Running} />
-      </div>
+      <Spinner size="16px" status={EntityStatus.Running} />
     {:else}
-      <Back size="16px" />
-      <span> All Dimensions </span>
+      <Spacer size="16px" />
     {/if}
-  </button>
+  </div>
+  <div
+    class="grid justify-between items-center"
+    style:grid-template-columns="auto max-content"
+  >
+    <Button type="secondary" on:click={goBackToLeaderboard} compact>
+      <Back size="16px" />All Dimensions
+    </Button>
+
+    <Tooltip location="left" distance={16}>
+      <Button type="secondary" on:click={toggleFilterMode} compact>
+        {#if excludeMode}exclude{:else}include{/if}
+      </Button>
+      <TooltipContent slot="tooltip-content">
+        <TooltipTitle>
+          <svelte:fragment slot="name">
+            Output {filterKey}s selected values
+          </svelte:fragment>
+        </TooltipTitle>
+        <TooltipShortcutContainer>
+          <div>toggle to {otherFilterKey} values</div>
+          <Shortcut>Click</Shortcut>
+        </TooltipShortcutContainer>
+      </TooltipContent>
+    </Tooltip>
+  </div>
 </div>

--- a/web-local/src/lib/components/dimension/DimensionTable.svelte
+++ b/web-local/src/lib/components/dimension/DimensionTable.svelte
@@ -18,8 +18,9 @@ TableCells – the cell contents.
 
   export let rows;
   export let columns: VirtualizedTableColumns[];
-  export let activeValues: Array<unknown> = [];
+  export let selectedValues: Array<unknown> = [];
   export let sortByColumn: string;
+  export let excludeMode = false;
 
   /** the overscan values tell us how much to render off-screen. These may be set by the consumer
    * in certain circumstances. The tradeoff: the higher the overscan amount, the more DOM elements we have
@@ -48,7 +49,7 @@ TableCells – the cell contents.
   const FILTER_COLUMN_WIDTH = DimensionTableConfig.indexWidth;
 
   $: dimensionName = columns[0]?.name;
-  $: selectedIndex = activeValues
+  $: selectedIndex = selectedValues
     .map((label) => {
       return rows.findIndex((row) => row[dimensionName] === label);
     })
@@ -244,6 +245,7 @@ TableCells – the cell contents.
           virtualRowItems={virtualRows}
           totalHeight={virtualHeight}
           {selectedIndex}
+          {excludeMode}
         />
 
         <!-- VirtualTableBody -->
@@ -255,6 +257,7 @@ TableCells – the cell contents.
           {activeIndex}
           {selectedIndex}
           {scrolling}
+          {excludeMode}
           on:select-item={(event) => onSelectItem(event)}
           on:inspect={setActiveIndex}
         />

--- a/web-local/src/lib/components/dimension/DimensionTable.svelte
+++ b/web-local/src/lib/components/dimension/DimensionTable.svelte
@@ -12,6 +12,7 @@ TableCells – the cell contents.
   import { DimensionTableConfig } from "./DimensionTableConfig";
   import ColumnHeaders from "../virtualized-table/sections/ColumnHeaders.svelte";
   import TableCells from "../virtualized-table/sections/TableCells.svelte";
+  import DimensionFilterGutter from "./DimensionFilterGutter.svelte";
 
   const dispatch = createEventDispatcher();
 
@@ -44,6 +45,7 @@ TableCells – the cell contents.
   const HEADER_X_PAD = CHARACTER_X_PAD;
   const HEADER_FLEX_SPACING = 14;
   const CHARACTER_LIMIT_FOR_WRAPPING = 9;
+  const FILTER_COLUMN_WIDTH = DimensionTableConfig.indexWidth;
 
   $: dimensionName = columns[0]?.name;
   $: selectedIndex = activeValues
@@ -142,7 +144,7 @@ TableCells – the cell contents.
 
     /* Dimension column should expand to cover whole container */
     estimateColumnSize[0] = Math.max(
-      containerWidth - measureColumnSizeSum,
+      containerWidth - measureColumnSizeSum - FILTER_COLUMN_WIDTH,
       estimateColumnSize[0]
     );
 
@@ -155,6 +157,7 @@ TableCells – the cell contents.
         return estimateColumnSize[index];
       },
       overscan: columnOverscanAmount,
+      paddingStart: FILTER_COLUMN_WIDTH,
       initialOffset: colScrollOffset,
     });
   }
@@ -230,11 +233,19 @@ TableCells – the cell contents.
         <!-- ColumnHeaders -->
         <ColumnHeaders
           virtualColumnItems={virtualColumns}
-          {columns}
           noPin={true}
           selectedColumn={sortByColumn}
+          {columns}
           on:click-column={handleColumnHeaderClick}
         />
+
+        <!-- Gutter for Include Exlude Filter -->
+        <DimensionFilterGutter
+          virtualRowItems={virtualRows}
+          totalHeight={virtualHeight}
+          {selectedIndex}
+        />
+
         <!-- VirtualTableBody -->
         <TableCells
           virtualColumnItems={virtualColumns}

--- a/web-local/src/lib/components/dimension/DimensionTableConfig.ts
+++ b/web-local/src/lib/components/dimension/DimensionTableConfig.ts
@@ -7,7 +7,7 @@ export const DimensionTableConfig: VirtualizedTableConfig = {
   minHeaderWidthWhenColumsAreSmall: 160,
   rowHeight: 24,
   columnHeaderHeight: 28,
-  indexWidth: 60,
+  indexWidth: 24,
   columnHeaderFontWeightClass: "font-normal",
   defaultFontWeightClass: "font-normal",
   table: "DimensionTable",

--- a/web-local/src/lib/components/leaderboard/LeaderboardHeader.svelte
+++ b/web-local/src/lib/components/leaderboard/LeaderboardHeader.svelte
@@ -19,10 +19,8 @@
 
   let otherFilterKey: "exclude" | "include";
   $: otherFilterKey = filterKey === "include" ? "exclude" : "include";
-  $: console.log("hovered", hovered);
 
   let optionsMenuActive = false;
-  $: console.log("optionsMenuActive", optionsMenuActive);
 </script>
 
 <div class="flex flex-row  items-center">

--- a/web-local/src/lib/components/leaderboard/LeaderboardOptionsMenu.svelte
+++ b/web-local/src/lib/components/leaderboard/LeaderboardOptionsMenu.svelte
@@ -14,8 +14,6 @@
   export let optionsMenuActive = false;
 
   const optionsButtonId = guidGenerator();
-
-  $: console.log("optionsMenuActive inner", optionsMenuActive);
 </script>
 
 <WithTogglableFloatingElement

--- a/web-local/src/lib/components/virtualized-table/core/Cell.svelte
+++ b/web-local/src/lib/components/virtualized-table/core/Cell.svelte
@@ -31,6 +31,7 @@
   export let suppressTooltip = false;
   export let rowSelected = false;
   export let atLeastOneSelected = false;
+  export let excludeMode = false;
 
   let cellActive = false;
 
@@ -67,11 +68,14 @@
     }
   }
 
-  $: barColor = rowSelected
-    ? "bg-blue-300"
-    : atLeastOneSelected
-    ? "bg-blue-100"
-    : "bg-blue-200";
+  // Super important special case: if there is not at least one "active" (selected) value,
+  // we need to set *all* items to be included, because by default if a user has not
+  // selected any values, we assume they want all values included in all calculations.
+  $: excluded = atLeastOneSelected
+    ? (excludeMode && rowSelected) || (!excludeMode && !rowSelected)
+    : false;
+
+  $: barColor = excluded ? "bg-gray-200" : "bg-blue-200";
 
   let TOOLTIP_STRING_LIMIT = 200;
   $: tooltipValue =
@@ -128,11 +132,9 @@
         <FormattedDataType
           value={formattedValue || value}
           {type}
-          customStyle={rowSelected
-            ? "font-bold text-gray-800"
-            : atLeastOneSelected
+          customStyle={excluded
             ? "font-normal italic text-gray-400"
-            : config.defaultFontWeightClass}
+            : "font-bold text-gray-800"}
           inTable
         />
       </button>

--- a/web-local/src/lib/components/virtualized-table/core/Cell.svelte
+++ b/web-local/src/lib/components/virtualized-table/core/Cell.svelte
@@ -134,7 +134,7 @@
           {type}
           customStyle={excluded
             ? "font-normal italic text-gray-400"
-            : "font-bold text-gray-800"}
+            : "font-semibold text-gray-800"}
           inTable
         />
       </button>

--- a/web-local/src/lib/components/virtualized-table/core/Cell.svelte
+++ b/web-local/src/lib/components/virtualized-table/core/Cell.svelte
@@ -109,7 +109,7 @@
       <button
         class="
           {config.rowHeight <= 28 ? 'py-1' : 'py-2'}
-          {isDimensionTable ? 'px-2' : 'px-4'}
+          {isDimensionTable ? '' : 'px-4'}
           text-left w-full text-ellipsis overflow-x-hidden whitespace-nowrap
           "
         use:shiftClickAction

--- a/web-local/src/lib/components/virtualized-table/core/StickyHeader.svelte
+++ b/web-local/src/lib/components/virtualized-table/core/StickyHeader.svelte
@@ -28,7 +28,9 @@
   }
 
   const borderClassesOuterDiv = isDimensionTable
-    ? "border-b"
+    ? position === "left"
+      ? ""
+      : "border-b"
     : "border-b border-b-4 border-r border-r-1";
 
   const borderClassesInnerDiv = isDimensionTable

--- a/web-local/src/lib/components/virtualized-table/sections/TableCells.svelte
+++ b/web-local/src/lib/components/virtualized-table/sections/TableCells.svelte
@@ -10,6 +10,7 @@
   export let columns: VirtualizedTableColumns[];
   export let scrolling = false;
   export let activeIndex: number;
+  export let excludeMode = false;
 
   $: atLeastOneSelected = !!selectedIndex?.length;
 
@@ -38,6 +39,7 @@
         {row}
         {column}
         {atLeastOneSelected}
+        {excludeMode}
         {...getCellProps(row, column)}
         on:inspect
         on:select-item

--- a/web-local/src/lib/components/workspace/explore/leaderboards/DimensionDisplay.svelte
+++ b/web-local/src/lib/components/workspace/explore/leaderboards/DimensionDisplay.svelte
@@ -198,7 +198,7 @@
   }
 
   $: if (values) {
-    const measureFormatSpec = allMeasures.map((m) => {
+    const measureFormatSpec = allMeasures?.map((m) => {
       return { columnName: m.sqlName, formatPreset: m.formatPreset };
     });
     values = humanizeGroupByColumns(values, measureFormatSpec);

--- a/web-local/src/lib/components/workspace/explore/leaderboards/DimensionDisplay.svelte
+++ b/web-local/src/lib/components/workspace/explore/leaderboards/DimensionDisplay.svelte
@@ -27,6 +27,8 @@
   import { humanizeGroupByColumns } from "../../../../util/humanize-numbers";
   import { getContext } from "svelte";
 
+  import type { MetricsViewDimensionValues } from "@rilldata/web-local/common/rill-developer-service/MetricsViewActions";
+
   export let metricsDefId: string;
   export let dimensionId: string;
 
@@ -48,6 +50,11 @@
   let metricsExplorer: MetricsExplorerEntity;
   $: metricsExplorer = $metricsExplorerStore.entities[metricsDefId];
 
+  let includeValues: MetricsViewDimensionValues;
+  $: includeValues = metricsExplorer?.filters.include;
+  $: dimensionIsIncluded =
+    includeValues.findIndex((v) => v.name === dimensionId) > -1;
+
   $: mappedFiltersQuery = useMetaMappedFilters(
     config,
     metricsDefId,
@@ -60,10 +67,13 @@
     metricsExplorer?.selectedMeasureIds
   );
 
-  let activeValues: Array<unknown>;
-  $: activeValues =
-    metricsExplorer?.filters.include.find((d) => d.name === dimension?.id)
-      ?.values ?? [];
+  let selectedValues: Array<unknown>;
+  $: selectedValues =
+    (dimensionIsIncluded
+      ? metricsExplorer?.filters.include.find((d) => d.name === dimension?.id)
+          ?.values
+      : metricsExplorer?.filters.exclude.find((d) => d.name === dimension?.id)
+          ?.values) ?? [];
 
   let topListQuery;
 
@@ -204,9 +214,10 @@
         on:select-item={(event) => onSelectItem(event)}
         on:sort={(event) => onSortByColumn(event)}
         {columns}
-        {activeValues}
+        {selectedValues}
         rows={values}
         {sortByColumn}
+        excludeMode={!dimensionIsIncluded}
       />
     {/if}
   </DimensionContainer>

--- a/web-local/src/lib/components/workspace/explore/leaderboards/DimensionDisplay.svelte
+++ b/web-local/src/lib/components/workspace/explore/leaderboards/DimensionDisplay.svelte
@@ -50,10 +50,10 @@
   let metricsExplorer: MetricsExplorerEntity;
   $: metricsExplorer = $metricsExplorerStore.entities[metricsDefId];
 
-  let includeValues: MetricsViewDimensionValues;
-  $: includeValues = metricsExplorer?.filters.include;
-  $: dimensionIsIncluded =
-    includeValues.findIndex((v) => v.name === dimensionId) > -1;
+  let excludeValues: MetricsViewDimensionValues;
+  $: excludeValues = metricsExplorer?.filters.exclude;
+  $: console.log("excludeValues", excludeValues);
+  $: excludeMode = excludeValues.findIndex((v) => v.name === dimensionId) > -1;
 
   $: mappedFiltersQuery = useMetaMappedFilters(
     config,
@@ -69,10 +69,10 @@
 
   let selectedValues: Array<unknown>;
   $: selectedValues =
-    (dimensionIsIncluded
-      ? metricsExplorer?.filters.include.find((d) => d.name === dimension?.id)
+    (excludeMode
+      ? metricsExplorer?.filters.exclude.find((d) => d.name === dimension?.id)
           ?.values
-      : metricsExplorer?.filters.exclude.find((d) => d.name === dimension?.id)
+      : metricsExplorer?.filters.include.find((d) => d.name === dimension?.id)
           ?.values) ?? [];
 
   let topListQuery;
@@ -207,7 +207,12 @@
 
 {#if topListQuery}
   <DimensionContainer>
-    <DimensionHeader {metricsDefId} isFetching={$topListQuery?.isFetching} />
+    <DimensionHeader
+      {metricsDefId}
+      {dimensionId}
+      {excludeMode}
+      isFetching={$topListQuery?.isFetching}
+    />
 
     {#if values && columns.length}
       <DimensionTable
@@ -217,7 +222,7 @@
         {selectedValues}
         rows={values}
         {sortByColumn}
-        excludeMode={!dimensionIsIncluded}
+        {excludeMode}
       />
     {/if}
   </DimensionContainer>


### PR DESCRIPTION
@bcolloran This PR creates a new component which adds a row header for each dimension value. This works as is for `include`. For exclude you would have to make the relevant state changes to `DimensionFilterGutter` and `DimensionDisplay`. These components are independent of the `PreviewTable` so you won't have to worry about design conflicts there.