### PR TITLE
Adding dimension search API

### DIFF
--- a/web-local/src/common/database-service/DatabaseTimeSeriesActions.ts
+++ b/web-local/src/common/database-service/DatabaseTimeSeriesActions.ts
@@ -1,3 +1,4 @@
+import type { MetricsViewRequestFilter } from "@rilldata/web-local/common/rill-developer-service/MetricsViewActions";
 import type { BasicMeasureDefinition } from "../data-modeler-state-service/entity-state-service/MeasureDefinitionStateService";
 import { DatabaseActions } from "./DatabaseActions";
 import type { RollupInterval } from "./DatabaseColumnActions";
@@ -6,11 +7,10 @@ import type { DatabaseMetadata } from "./DatabaseMetadata";
 import {
   getCoalesceStatementsMeasures,
   getExpressionColumnsFromMeasures,
-  getFilterFromFilters,
+  getFilterFromMetricsViewFilters,
   normaliseMeasures,
 } from "./utils";
 import { PreviewRollupInterval } from "@rilldata/web-local/lib/duckdb-data-types";
-import type { ActiveValues } from "@rilldata/web-local/lib/application-state-stores/explorer-stores";
 
 export type TimeSeriesValue = {
   ts: string;
@@ -113,7 +113,7 @@ export class DatabaseTimeSeriesActions extends DatabaseActions {
       measures?: Array<BasicMeasureDefinition>;
       timestampColumn: string;
       timeRange?: TimeSeriesTimeRange;
-      filters?: ActiveValues;
+      filters?: MetricsViewRequestFilter;
       pixels?: number;
       sampleSize?: number;
     }
@@ -134,10 +134,8 @@ export class DatabaseTimeSeriesActions extends DatabaseActions {
       timeGranularity = "week";
     }
 
-    const filter =
-      filters && Object.keys(filters).length > 0
-        ? " WHERE " + getFilterFromFilters(filters)
-        : "";
+    const filterCondition = getFilterFromMetricsViewFilters(filters);
+    const filter = filterCondition ? ` WHERE ${filterCondition}` : "";
 
     /**
      * Generate the rolled up time series as a temporary table and

--- a/web-local/src/common/database-service/DatabaseTimeSeriesActions.ts
+++ b/web-local/src/common/database-service/DatabaseTimeSeriesActions.ts
@@ -134,7 +134,9 @@ export class DatabaseTimeSeriesActions extends DatabaseActions {
       timeGranularity = "week";
     }
 
-    const filterCondition = getFilterFromMetricsViewFilters(filters);
+    const filterCondition = filters
+      ? getFilterFromMetricsViewFilters(filters)
+      : "";
     const filter = filterCondition ? ` WHERE ${filterCondition}` : "";
 
     /**

--- a/web-local/src/common/rill-developer-service/MetricsViewActions.ts
+++ b/web-local/src/common/rill-developer-service/MetricsViewActions.ts
@@ -1,4 +1,3 @@
-import type { ActiveValues } from "@rilldata/web-local/lib/application-state-stores/explorer-stores";
 import { ActionResponseFactory } from "../data-modeler-service/response/ActionResponseFactory";
 import type { DimensionDefinitionEntity } from "../data-modeler-state-service/entity-state-service/DimensionDefinitionStateService";
 import {
@@ -47,7 +46,8 @@ export interface MetricsViewRequestTimeRange {
 }
 export interface MetricsViewDimensionValue {
   name: string;
-  values: Array<unknown>;
+  in: Array<unknown>;
+  like?: Array<unknown>;
 }
 export type MetricsViewDimensionValues = Array<MetricsViewDimensionValue>;
 export interface MetricsViewRequestFilter {
@@ -91,23 +91,6 @@ export interface MetricsViewTotalsRequest {
 export interface MetricsViewTotalsResponse {
   meta: Array<{ name: string; type: string }>;
   data: Record<string, number>;
-}
-
-function convertToActiveValues(
-  filters: MetricsViewRequestFilter
-): ActiveValues {
-  if (!filters) return {};
-  const activeValues: ActiveValues = {};
-  filters.include.forEach((value) => {
-    activeValues[value.name] = value.values.map((val) => [val, true]);
-  });
-  filters.exclude.forEach((value) => {
-    activeValues[value.name] ??= [];
-    activeValues[value.name].push(
-      ...(value.values.map((val) => [val, false]) as Array<[unknown, boolean]>)
-    );
-  });
-  return activeValues;
 }
 
 /**
@@ -187,7 +170,7 @@ export class MetricsViewActions extends RillDeveloperActions {
             rillRequestContext.record,
             request.measures
           ),
-          filters: convertToActiveValues(request.filter),
+          filters: request.filter,
           timeRange: {
             ...request.time,
             interval: request.time.granularity,

--- a/web-local/src/lib/application-state-stores/explorer-stores.ts
+++ b/web-local/src/lib/application-state-stores/explorer-stores.ts
@@ -124,30 +124,30 @@ const metricViewReducers = {
       if (existingDimensionIndex === -1) {
         metricsExplorer.filters.include.push({
           name: dimensionId,
-          values: [dimensionValue],
+          in: [dimensionValue],
         });
         return;
       }
 
       const existingIncludeIndex =
-        metricsExplorer.filters.include[existingDimensionIndex].values.indexOf(
+        metricsExplorer.filters.include[existingDimensionIndex].in.indexOf(
           dimensionValue
         ) ?? -1;
 
       // add the value if it doesn't exist, remove the value if it does exist
       if (existingIncludeIndex === -1) {
-        metricsExplorer.filters.include[existingDimensionIndex].values.push(
+        metricsExplorer.filters.include[existingDimensionIndex].in.push(
           dimensionValue
         );
       } else {
-        metricsExplorer.filters.include[existingDimensionIndex].values.splice(
+        metricsExplorer.filters.include[existingDimensionIndex].in.splice(
           existingIncludeIndex,
           1
         );
         // remove the entry for dimension if no values are selected.
         if (
-          metricsExplorer.filters.include[existingDimensionIndex].values
-            .length === 0
+          metricsExplorer.filters.include[existingDimensionIndex].in.length ===
+          0
         ) {
           metricsExplorer.filters.include.splice(existingDimensionIndex, 1);
         }

--- a/web-local/src/lib/components/workspace/explore/filters/Filters.svelte
+++ b/web-local/src/lib/components/workspace/explore/filters/Filters.svelte
@@ -60,7 +60,7 @@ The main feature-set component for dashboard filters
     currentDimensionFilters = values.map((dimensionValues) => ({
       name: getDisplayName(dimensionIdMap.get(dimensionValues.name)),
       dimensionId: dimensionValues.name,
-      selectedValues: dimensionValues.values,
+      selectedValues: dimensionValues.in,
     }));
   }
 

--- a/web-local/src/lib/components/workspace/explore/leaderboards/DimensionDisplay.svelte
+++ b/web-local/src/lib/components/workspace/explore/leaderboards/DimensionDisplay.svelte
@@ -63,7 +63,7 @@
   let activeValues: Array<unknown>;
   $: activeValues =
     metricsExplorer?.filters.include.find((d) => d.name === dimension?.id)
-      ?.values ?? [];
+      ?.in ?? [];
 
   let topListQuery;
 

--- a/web-local/src/lib/components/workspace/explore/leaderboards/Leaderboard.svelte
+++ b/web-local/src/lib/components/workspace/explore/leaderboards/Leaderboard.svelte
@@ -90,7 +90,7 @@
   let activeValues: Array<unknown>;
   $: activeValues =
     metricsExplorer?.filters.include.find((d) => d.name === dimension?.id)
-      ?.values ?? [];
+      ?.in ?? [];
   $: atLeastOneActive = !!activeValues?.length;
 
   function setLeaderboardValues(values) {

--- a/web-local/src/lib/svelte-query/queries/metrics-views/metadata.ts
+++ b/web-local/src/lib/svelte-query/queries/metrics-views/metadata.ts
@@ -95,11 +95,11 @@ export const useMetaMappedFilters = (
     return {
       include: filters.include.map((dimensionValues) => ({
         name: dimensionIdMap.get(dimensionValues.name).dimensionColumn,
-        values: dimensionValues.values,
+        in: dimensionValues.in,
       })),
       exclude: filters.exclude.map((dimensionValues) => ({
         name: dimensionIdMap.get(dimensionValues.name).dimensionColumn,
-        values: dimensionValues.values,
+        in: dimensionValues.in,
       })),
     };
   });

--- a/web-local/test/data/MetricsExplorer.data.ts
+++ b/web-local/test/data/MetricsExplorer.data.ts
@@ -1,8 +1,8 @@
 import type { TimeSeriesTimeRange } from "@rilldata/web-local/common/database-service/DatabaseTimeSeriesActions";
 import type { MetricsViewRequestFilter } from "@rilldata/web-local/common/rill-developer-service/MetricsViewActions";
 import { PreviewRollupInterval } from "@rilldata/web-local/lib/duckdb-data-types";
+import { getTimeRange } from "../utils/time-series-helpers";
 import type { TimeSeriesMeasureRange } from "../utils/time-series-helpers";
-// import { getTimeRange } from "../utils/time-series-helpers";
 
 export interface MetricsExplorerTestDataType {
   title: string;
@@ -68,135 +68,263 @@ export const MetricsExplorerTestData: Array<MetricsExplorerTestDataType> = [
     ],
     bigNumber: { impressions: [50000, 50000], bid_price: [2.75, 3.25] },
   },
-  // {
-  //   title: "request by month",
-  //   timeRange: getTimeRange(PreviewRollupInterval.month),
-  //   previewRollupInterval: PreviewRollupInterval.month,
-  //   leaderboards: [
-  //     DefaultPublisherLeaderboard,
-  //     DefaultDomainLeaderboard,
-  //     DefaultCityLeaderboard,
-  //     ["country", ["India", "USA", "Ireland", "UK"]],
-  //   ],
-  //   bigNumber: { impressions: [50000, 50000], bid_price: [2.75, 3.25] },
-  // },
-  // {
-  //   title: "request with filters",
-  //   timeRange: getTimeRange(PreviewRollupInterval.month),
-  //   previewRollupInterval: PreviewRollupInterval.month,
-  //   filters: {
-  //     include: [
-  //       {
-  //         name: "domain",
-  //         values: ["sports.yahoo.com"],
-  //       },
-  //     ],
-  //     exclude: [],
-  //   },
-  //   measureRanges: [
-  //     { impressions: [3500, 4500], bid_price: [3, 4] },
-  //     { impressions: [750, 1250], bid_price: [1, 2] },
-  //     { impressions: [750, 1250], bid_price: [1, 2] },
-  //   ],
-  //   leaderboards: [
-  //     ["publisher", ["Yahoo", null]],
-  //     DefaultDomainLeaderboard,
-  //     DefaultCityLeaderboard,
-  //     ["country", ["India", "USA", "Ireland", "UK"]],
-  //   ],
-  //   bigNumber: { impressions: [6000, 7000], bid_price: [2.5, 3] },
-  // },
-  // {
-  //   title: "request with filters and time range and single measure",
-  //   timeRange: getTimeRange(PreviewRollupInterval.month, "2022-02-01"),
-  //   previewRollupInterval: PreviewRollupInterval.month,
-  //   filters: {
-  //     include: [],
-  //     exclude: [
-  //       {
-  //         name: "publisher",
-  //         values: ["Yahoo"],
-  //       },
-  //     ],
-  //   },
-  //   measures: [1],
-  //   measureRanges: [{ bid_price: [2.5, 3] }, { bid_price: [3, 3.5] }],
-  //   leaderboards: [
-  //     ["publisher", ["Microsoft", "Facebook", "Google", "Yahoo", null]],
-  //     [
-  //       "domain",
-  //       [
-  //         "facebook.com",
-  //         "google.com",
-  //         "msn.com",
-  //         "instagram.com",
-  //         "news.google.com",
-  //       ],
-  //     ],
-  //     ["city", [...DefaultCityLeaderboard[1].slice(1), null]],
-  //     ["country", ["India", "Ireland", "UK", "USA"]],
-  //   ],
-  //   bigNumber: { bid_price: [2.75, 3.25] },
-  // },
-  // {
-  //   title: "request with missing start time",
-  //   timeRange: getTimeRange(
-  //     PreviewRollupInterval.month,
-  //     "2021-11-01",
-  //     "2022-02-28"
-  //   ),
-  //   previewRollupInterval: PreviewRollupInterval.month,
-  //   measures: [1],
-  //   measureRanges: [
-  //     { bid_price: [0, 0] },
-  //     { bid_price: [0, 0] },
-  //     { bid_price: [2.75, 3.25] },
-  //     { bid_price: [2.75, 3.25] },
-  //   ],
-  //   leaderboards: [
-  //     ["publisher", ["Google", "Yahoo", null, "Facebook", "Microsoft"]],
-  //     [
-  //       "domain",
-  //       [
-  //         "google.com",
-  //         "instagram.com",
-  //         "news.google.com",
-  //         "news.yahoo.com",
-  //         "sports.yahoo.com",
-  //         "facebook.com",
-  //         "msn.com",
-  //       ],
-  //     ],
-  //     ["city", [...DefaultCityLeaderboard[1].slice(1), null]],
-  //     ["country", ["India", "Ireland", "UK", "USA"]],
-  //   ],
-  //   bigNumber: { bid_price: [2.75, 3.25] },
-  // },
-  // {
-  //   title: "request with non standard time range",
-  //   timeRange: {
-  //     interval: PreviewRollupInterval.month,
-  //     start: new Date(`2022-02-01 UTC`).toString(),
-  //     end: new Date(`2022-03-01 UTC`).toString(),
-  //   },
-  //   previewRollupInterval: PreviewRollupInterval.month,
-  //   leaderboards: [
-  //     ["publisher", [null, "Google", "Yahoo", "Facebook", "Microsoft"]],
-  //     [
-  //       "domain",
-  //       [
-  //         "google.com",
-  //         "news.yahoo.com",
-  //         "facebook.com",
-  //         "instagram.com",
-  //         "msn.com",
-  //         "news.google.com",
-  //         "sports.yahoo.com",
-  //       ],
-  //     ],
-  //     DefaultCityLeaderboard,
-  //     ["country", ["India", "USA", "Ireland", "UK"]],
-  //   ],
-  //   bigNumber: { impressions: [15000, 16000], bid_price: [2.75, 3.25] },
-  // },
+  {
+    title: "request by month",
+    timeRange: getTimeRange(PreviewRollupInterval.month),
+    previewRollupInterval: PreviewRollupInterval.month,
+    leaderboards: [
+      DefaultPublisherLeaderboard,
+      DefaultDomainLeaderboard,
+      DefaultCityLeaderboard,
+      ["country", ["India", "USA", "Ireland", "UK"]],
+    ],
+    bigNumber: { impressions: [50000, 50000], bid_price: [2.75, 3.25] },
+  },
+  {
+    title: "request with filters",
+    timeRange: getTimeRange(PreviewRollupInterval.month),
+    previewRollupInterval: PreviewRollupInterval.month,
+    filters: {
+      include: [
+        {
+          name: "domain",
+          in: ["sports.yahoo.com"],
+        },
+      ],
+      exclude: [],
+    },
+    measureRanges: [
+      { impressions: [3500, 4500], bid_price: [3, 4] },
+      { impressions: [750, 1250], bid_price: [1, 2] },
+      { impressions: [750, 1250], bid_price: [1, 2] },
+    ],
+    leaderboards: [
+      ["publisher", ["Yahoo", null]],
+      DefaultDomainLeaderboard,
+      DefaultCityLeaderboard,
+      ["country", ["India", "USA", "Ireland", "UK"]],
+    ],
+    bigNumber: { impressions: [6000, 7000], bid_price: [2.5, 3] },
+  },
+  {
+    title: "request with filters and time range and single measure",
+    timeRange: getTimeRange(PreviewRollupInterval.month, "2022-02-01"),
+    previewRollupInterval: PreviewRollupInterval.month,
+    filters: {
+      include: [],
+      exclude: [
+        {
+          name: "publisher",
+          in: ["Yahoo"],
+        },
+      ],
+    },
+    measures: [1],
+    measureRanges: [{ bid_price: [2.5, 3] }, { bid_price: [3, 3.5] }],
+    leaderboards: [
+      ["publisher", ["Microsoft", "Facebook", "Google", "Yahoo", null]],
+      [
+        "domain",
+        [
+          "facebook.com",
+          "google.com",
+          "msn.com",
+          "instagram.com",
+          "news.google.com",
+        ],
+      ],
+      ["city", [...DefaultCityLeaderboard[1].slice(1), null]],
+      ["country", ["India", "Ireland", "UK", "USA"]],
+    ],
+    bigNumber: { bid_price: [2.75, 3.25] },
+  },
+  {
+    title: "request with ilike filters",
+    timeRange: getTimeRange(PreviewRollupInterval.month),
+    previewRollupInterval: PreviewRollupInterval.month,
+    filters: {
+      include: [
+        {
+          name: "publisher",
+          in: [],
+          like: ["%oo%"],
+        },
+      ],
+      exclude: [],
+    },
+    measureRanges: [
+      { impressions: [3500, 4500], bid_price: [3, 4] },
+      { impressions: [750, 1250], bid_price: [1, 2] },
+      { impressions: [750, 1250], bid_price: [1, 2] },
+    ],
+    leaderboards: [
+      DefaultPublisherLeaderboard,
+      [
+        "domain",
+        [
+          "facebook.com",
+          "google.com",
+          "news.yahoo.com",
+          "instagram.com",
+          "news.google.com",
+          "sports.yahoo.com",
+        ],
+      ],
+      DefaultCityLeaderboard,
+      ["country", ["India", "USA", "Ireland", "UK"]],
+    ],
+    bigNumber: { impressions: [6000, 7000], bid_price: [2.5, 3] },
+  },
+  {
+    title: "request with ilike and exact filters",
+    timeRange: getTimeRange(PreviewRollupInterval.month),
+    previewRollupInterval: PreviewRollupInterval.month,
+    filters: {
+      include: [
+        {
+          name: "publisher",
+          in: ["Yahoo", "Google"],
+          like: ["%oo%"],
+        },
+      ],
+      exclude: [],
+    },
+    measureRanges: [
+      { impressions: [3500, 4500], bid_price: [3, 4] },
+      { impressions: [750, 1250], bid_price: [1, 2] },
+      { impressions: [750, 1250], bid_price: [1, 2] },
+    ],
+    leaderboards: [
+      DefaultPublisherLeaderboard,
+      [
+        "domain",
+        [
+          "facebook.com",
+          "google.com",
+          "news.yahoo.com",
+          "instagram.com",
+          "news.google.com",
+          "sports.yahoo.com",
+        ],
+      ],
+      DefaultCityLeaderboard,
+      ["country", ["India", "USA", "Ireland", "UK"]],
+    ],
+    bigNumber: { impressions: [6000, 7000], bid_price: [2.5, 3] },
+  },
+  {
+    title: "request with exclude ilike filters",
+    timeRange: getTimeRange(PreviewRollupInterval.month),
+    previewRollupInterval: PreviewRollupInterval.month,
+    filters: {
+      include: [],
+      exclude: [
+        {
+          name: "publisher",
+          in: [],
+          like: ["%oo%"],
+        },
+      ],
+    },
+    measureRanges: [
+      { impressions: [3500, 4500], bid_price: [3, 4] },
+      { impressions: [750, 1250], bid_price: [1, 2] },
+      { impressions: [750, 1250], bid_price: [1, 2] },
+    ],
+    leaderboards: [
+      DefaultPublisherLeaderboard,
+      ["domain", ["msn.com"]],
+      DefaultCityLeaderboard,
+      ["country", ["India", "USA", "Ireland", "UK"]],
+    ],
+    bigNumber: { impressions: [6000, 7000], bid_price: [2.5, 3] },
+  },
+  {
+    title: "request with exclude ilike and exact filters",
+    timeRange: getTimeRange(PreviewRollupInterval.month),
+    previewRollupInterval: PreviewRollupInterval.month,
+    filters: {
+      include: [],
+      exclude: [
+        {
+          name: "publisher",
+          in: ["Yahoo", "Google"],
+          like: ["%oo%"],
+        },
+      ],
+    },
+    measureRanges: [
+      { impressions: [3500, 4500], bid_price: [3, 4] },
+      { impressions: [750, 1250], bid_price: [1, 2] },
+      { impressions: [750, 1250], bid_price: [1, 2] },
+    ],
+    leaderboards: [
+      DefaultPublisherLeaderboard,
+      ["domain", ["msn.com"]],
+      DefaultCityLeaderboard,
+      ["country", ["India", "USA", "Ireland", "UK"]],
+    ],
+    bigNumber: { impressions: [6000, 7000], bid_price: [2.5, 3] },
+  },
+  {
+    title: "request with missing start time",
+    timeRange: getTimeRange(
+      PreviewRollupInterval.month,
+      "2021-11-01",
+      "2022-02-28"
+    ),
+    previewRollupInterval: PreviewRollupInterval.month,
+    measures: [1],
+    measureRanges: [
+      { bid_price: [0, 0] },
+      { bid_price: [0, 0] },
+      { bid_price: [2.75, 3.25] },
+      { bid_price: [2.75, 3.25] },
+    ],
+    leaderboards: [
+      ["publisher", ["Google", "Yahoo", null, "Facebook", "Microsoft"]],
+      [
+        "domain",
+        [
+          "google.com",
+          "news.google.com",
+          "news.yahoo.com",
+          "sports.yahoo.com",
+          "instagram.com",
+          "facebook.com",
+          "msn.com",
+        ],
+      ],
+      ["city", [...DefaultCityLeaderboard[1].slice(1), null]],
+      ["country", ["India", "Ireland", "UK", "USA"]],
+    ],
+    bigNumber: { bid_price: [2.75, 3.25] },
+  },
+  {
+    title: "request with non standard time range",
+    timeRange: {
+      interval: PreviewRollupInterval.month,
+      start: new Date(`2022-02-01 UTC`).toString(),
+      end: new Date(`2022-03-01 UTC`).toString(),
+    },
+    previewRollupInterval: PreviewRollupInterval.month,
+    leaderboards: [
+      ["publisher", [null, "Google", "Yahoo", "Facebook", "Microsoft"]],
+      [
+        "domain",
+        [
+          "google.com",
+          "news.yahoo.com",
+          "facebook.com",
+          "instagram.com",
+          "msn.com",
+          "news.google.com",
+          "sports.yahoo.com",
+        ],
+      ],
+      DefaultCityLeaderboard,
+      ["country", ["India", "USA", "Ireland", "UK"]],
+    ],
+    bigNumber: { impressions: [15000, 16000], bid_price: [2.75, 3.25] },
+  },
 ];

--- a/web-local/test/functional/metrics-view.spec.ts
+++ b/web-local/test/functional/metrics-view.spec.ts
@@ -71,7 +71,7 @@ describe("Metric View", () => {
     }
   });
 
-  it.skip("Top list with multiple measures and sorting", async () => {
+  it("Top list with multiple measures and sorting", async () => {
     const dimension = dimensions[2];
     const request: MetricsViewTopListRequest = {
       measures: measures.map((measure) => measure.sqlName),


### PR DESCRIPTION
Adding `like` param to filters. `values` key is changed to `in`. This is how the filter will look like,
```
filters: {
  include: [
    {
      name: "publisher",
      in: ["Yahoo", "Google"],
      like: ["%oo%"],
    },
  ],
  exclude: [
    {
      name: "domain",
      in: [],
      like: ["%oo%"],
    },
  ],
}
```

@hamilton @djbarnwal Lemme know if this satisfies all use cases needed in the UI.