### PR TITLE
Remove unneeded slot fragment 2

### DIFF
--- a/web-local/src/lib/components/assets/MetricsDefinitionAssets.svelte
+++ b/web-local/src/lib/components/assets/MetricsDefinitionAssets.svelte
@@ -179,9 +179,7 @@
             disabled={hasSourceError}
             on:select={() => editModel(metricsDef.sourceModelId)}
           >
-            <svelte:fragment slot="icon">
-              <Model />
-            </svelte:fragment>
+            <Model slot="icon" />
             edit model
             <svelte:fragment slot="description">
               {#if hasSourceError}
@@ -194,9 +192,7 @@
             disabled={hasSourceError}
             on:select={() => editMetrics(metricsDef.id)}
           >
-            <svelte:fragment slot="icon">
-              <MetricsIcon />
-            </svelte:fragment>
+            <MetricsIcon slot="icon" />
             edit metrics
           </MenuItem>
           <Divider />
@@ -208,15 +204,11 @@
                 metricsDef.metricDefLabel
               )}
           >
-            <svelte:fragment slot="icon">
-              <EditIcon />
-            </svelte:fragment>
+            <EditIcon slot="icon" />
             rename...</MenuItem
           >
           <MenuItem icon on:select={() => deleteMetricsDef(metricsDef.id)}>
-            <svelte:fragment slot="icon">
-              <Cancel />
-            </svelte:fragment>
+            <Cancel slot="icon" />
             delete</MenuItem
           >
         </svelte:fragment>

--- a/web-local/src/lib/components/assets/ModelAssets.svelte
+++ b/web-local/src/lib/components/assets/ModelAssets.svelte
@@ -178,23 +178,23 @@
         sizeInBytes={tableSummaryProps.sizeInBytes}
         active={tableSummaryProps.active}
       >
-        <svelte:fragment slot="summary" let:containerWidth>
-          <ColumnProfileNavEntry
-            indentLevel={1}
-            {containerWidth}
-            cardinality={tableSummaryProps.cardinality}
-            profile={tableSummaryProps.profile}
-            head={tableSummaryProps.head}
-            entityId={id}
-          />
-        </svelte:fragment>
+        <ColumnProfileNavEntry
+          let:containerWidth
+          slot="summary"
+          indentLevel={1}
+          {containerWidth}
+          cardinality={tableSummaryProps.cardinality}
+          profile={tableSummaryProps.profile}
+          head={tableSummaryProps.head}
+          entityId={id}
+        />
         <svelte:fragment slot="menu-items">
           <MenuItem
             disabled={!derivedProfileEntityHasTimestampColumn(derivedModel)}
             icon
             on:select={() => quickStartMetrics(derivedModel)}
           >
-            <svelte:fragment slot="icon"><Explore /></svelte:fragment>
+            <Explore slot="icon" />
             autogenerate dashboard
             <svelte:fragment slot="description">
               {#if !derivedProfileEntityHasTimestampColumn(derivedModel)}
@@ -204,17 +204,13 @@
           </MenuItem>
           <Divider />
           <MenuItem icon on:select={() => openRenameModelModal(id, modelName)}>
-            <svelte:fragment slot="icon">
-              <EditIcon />
-            </svelte:fragment>
-            rename...</MenuItem
-          >
+            <EditIcon slot="icon" />
+            rename...
+          </MenuItem>
           <MenuItem icon on:select={() => deleteModel(id)}>
-            <svelte:fragment slot="icon">
-              <Cancel />
-            </svelte:fragment>
-            delete</MenuItem
-          >
+            <Cancel slot="icon" />
+            delete
+          </MenuItem>
         </svelte:fragment>
       </CollapsibleTableSummary>
     {/each}

--- a/web-local/src/lib/components/assets/TableAssets.svelte
+++ b/web-local/src/lib/components/assets/TableAssets.svelte
@@ -178,21 +178,19 @@
             sizeInBytes={derivedTable?.sizeInBytes ?? 0}
             active={entityIsActive}
           >
-            <svelte:fragment slot="summary" let:containerWidth>
-              <ColumnProfileNavEntry
-                indentLevel={1}
-                {containerWidth}
-                cardinality={derivedTable?.cardinality ?? 0}
-                profile={derivedTable?.profile ?? []}
-                head={derivedTable?.preview ?? []}
-                entityId={id}
-              />
-            </svelte:fragment>
+            <ColumnProfileNavEntry
+              slot="summary"
+              let:containerWidth
+              indentLevel={1}
+              {containerWidth}
+              cardinality={derivedTable?.cardinality ?? 0}
+              profile={derivedTable?.profile ?? []}
+              head={derivedTable?.preview ?? []}
+              entityId={id}
+            />
             <svelte:fragment slot="menu-items" let:toggleMenu>
               <MenuItem icon on:select={() => createModel(tableName)}>
-                <svelte:fragment slot="icon">
-                  <Model />
-                </svelte:fragment>
+                <Model slot="icon" />
                 create new model
               </MenuItem>
 
@@ -201,7 +199,7 @@
                 icon
                 on:select={() => quickStartMetrics(id, tableName)}
               >
-                <svelte:fragment slot="icon"><Explore /></svelte:fragment>
+                <Explore slot="icon" />
                 autogenerate dashboard
                 <svelte:fragment slot="description">
                   {#if !derivedProfileEntityHasTimestampColumn(derivedTable)}
@@ -217,16 +215,13 @@
                   openRenameTableModal(id, tableName);
                 }}
               >
-                <svelte:fragment slot="icon">
-                  <EditIcon />
-                </svelte:fragment>
+                <EditIcon slot="icon" />
+
                 rename...
               </MenuItem>
               <!-- FIXME: this should pop up an "are you sure?" modal -->
               <MenuItem icon on:select={() => deleteSource(tableName, id)}>
-                <svelte:fragment slot="icon">
-                  <Cancel />
-                </svelte:fragment>
+                <Cancel slot="icon" />
                 delete</MenuItem
               >
             </svelte:fragment>

--- a/web-local/src/lib/components/inspector/SourceInspector.svelte
+++ b/web-local/src/lib/components/inspector/SourceInspector.svelte
@@ -245,16 +245,16 @@
             cardinality={currentDerivedTable?.cardinality ?? 0}
             active={currentTable?.id === activeEntityID}
           >
-            <svelte:fragment slot="summary" let:containerWidth>
-              <ColumnProfileNavEntry
-                entityId={currentTable.id}
-                indentLevel={0}
-                {containerWidth}
-                cardinality={currentDerivedTable?.cardinality ?? 0}
-                profile={currentDerivedTable?.profile ?? []}
-                head={currentDerivedTable?.preview ?? []}
-              />
-            </svelte:fragment>
+            <ColumnProfileNavEntry
+              slot="summary"
+              let:containerWidth
+              entityId={currentTable.id}
+              indentLevel={0}
+              {containerWidth}
+              cardinality={currentDerivedTable?.cardinality ?? 0}
+              profile={currentDerivedTable?.profile ?? []}
+              head={currentDerivedTable?.preview ?? []}
+            />
           </CollapsibleTableSummary>
         </div>
       {/if}

--- a/web-local/src/lib/components/inspector/model/ModelInspectorModelProfile.svelte
+++ b/web-local/src/lib/components/inspector/model/ModelInspectorModelProfile.svelte
@@ -173,16 +173,16 @@
             cardinality={currentDerivedModel?.cardinality ?? 0}
             active={currentModel?.id === $store?.activeEntity?.id}
           >
-            <svelte:fragment slot="summary" let:containerWidth>
-              <ColumnProfileNavEntry
-                indentLevel={0}
-                {containerWidth}
-                cardinality={currentDerivedModel?.cardinality ?? 0}
-                profile={currentDerivedModel?.profile ?? []}
-                head={currentDerivedModel?.preview ?? []}
-                entityId={activeEntityID}
-              />
-            </svelte:fragment>
+            <ColumnProfileNavEntry
+              slot="summary"
+              let:containerWidth
+              indentLevel={0}
+              {containerWidth}
+              cardinality={currentDerivedModel?.cardinality ?? 0}
+              profile={currentDerivedModel?.profile ?? []}
+              head={currentDerivedModel?.preview ?? []}
+              entityId={activeEntityID}
+            />
           </CollapsibleTableSummary>
         </div>
       {/if}

--- a/web-local/src/lib/components/modal/ExportError.svelte
+++ b/web-local/src/lib/components/modal/ExportError.svelte
@@ -8,7 +8,5 @@
 <Dialog>
   <svelte:fragment slot="title">Export error</svelte:fragment>
   <svelte:fragment slot="body">{exportErrorMessage}</svelte:fragment>
-  <svelte:fragment slot="footer">
-    <Button type="text">close</Button>
-  </svelte:fragment>
+  <Button slot="footer" type="text">close</Button>
 </Dialog>

--- a/web-local/src/lib/components/modal/RenameEntityModal.svelte
+++ b/web-local/src/lib/components/modal/RenameEntityModal.svelte
@@ -79,19 +79,18 @@
   on:primary-action={() => submitHandler(entityId, newAssetName)}
 >
   <svelte:fragment slot="title">Rename</svelte:fragment>
-  <svelte:fragment slot="body">
-    <form
-      autocomplete="off"
-      on:submit|preventDefault={() => submitHandler(entityId, newAssetName)}
-    >
-      <Input
-        claimFocusOnMount
-        id="{entityLabel}-name"
-        label="{entityLabel} name"
-        bind:value={newAssetName}
-        {error}
-      />
-    </form>
-  </svelte:fragment>
+  <form
+    slot="body"
+    autocomplete="off"
+    on:submit|preventDefault={() => submitHandler(entityId, newAssetName)}
+  >
+    <Input
+      claimFocusOnMount
+      id="{entityLabel}-name"
+      label="{entityLabel} name"
+      bind:value={newAssetName}
+      {error}
+    />
+  </form>
   <svelte:fragment slot="primary-action-body">Change Name</svelte:fragment>
 </Dialog>

--- a/web-local/src/lib/components/table-editable/TableRowWithMenu.svelte
+++ b/web-local/src/lib/components/table-editable/TableRowWithMenu.svelte
@@ -81,7 +81,7 @@
               slot="floating-element"
             >
               <MenuItem icon on:select={() => dispatch("delete")}>
-                <svelte:fragment slot="icon"><Cancel /></svelte:fragment>
+                <Cancel slot="icon" />
                 delete row</MenuItem
               >
             </Menu>

--- a/web-local/src/lib/components/virtualized-table/core/Cell.svelte
+++ b/web-local/src/lib/components/virtualized-table/core/Cell.svelte
@@ -140,9 +140,7 @@
   </div>
   <TooltipContent slot="tooltip-content" maxWidth="360px">
     <TooltipTitle>
-      <svelte:fragment slot="name">
-        <FormattedDataType value={tooltipValue} {type} dark />
-      </svelte:fragment>
+      <FormattedDataType slot="name" value={tooltipValue} {type} dark />
     </TooltipTitle>
     <TooltipShortcutContainer>
       <div>

--- a/web-local/src/lib/components/workspace/explore/Explore.svelte
+++ b/web-local/src/lib/components/workspace/explore/Explore.svelte
@@ -17,17 +17,15 @@
 </script>
 
 <ExploreContainer let:columns>
-  <svelte:fragment slot="header">
-    <ExploreHeader {metricsDefId} />
-  </svelte:fragment>
-  <svelte:fragment slot="metrics">
-    <MetricsTimeSeriesCharts {metricsDefId} />
-  </svelte:fragment>
-  <svelte:fragment slot="leaderboards">
-    {#if selectedDimensionId}
-      <DimensionDisplay {metricsDefId} dimensionId={selectedDimensionId} />
-    {:else}
-      <LeaderboardDisplay {metricsDefId} />
-    {/if}
-  </svelte:fragment>
+  <ExploreHeader slot="header" {metricsDefId} />
+  <MetricsTimeSeriesCharts slot="metrics" {metricsDefId} />
+  {#if selectedDimensionId}
+    <DimensionDisplay
+      slot="leaderboards"
+      {metricsDefId}
+      dimensionId={selectedDimensionId}
+    />
+  {:else}
+    <LeaderboardDisplay slot="leaderboards" {metricsDefId} />
+  {/if}
 </ExploreContainer>

--- a/web-local/src/lib/components/workspace/explore/filters/Filters.svelte
+++ b/web-local/src/lib/components/workspace/explore/filters/Filters.svelte
@@ -118,9 +118,7 @@ The main feature-set component for dashboard filters
             ringOffsetColor="ring-offset-gray-400"
             on:click={clearAllFilters}
           >
-            <svelte:fragment slot="icon"
-              ><FilterRemove size="16px" /></svelte:fragment
-            >
+            <FilterRemove slot="icon" size="16px" />
             <svelte:fragment slot="body">clear filters</svelte:fragment>
           </Chip>
         </div>

--- a/web-local/src/lib/components/workspace/metrics-def/MetricsDefWorkspaceHeader.svelte
+++ b/web-local/src/lib/components/workspace/metrics-def/MetricsDefWorkspaceHeader.svelte
@@ -32,9 +32,7 @@
   style:grid-template-columns="auto max-content"
 >
   <WorkspaceHeader {...{ titleInput, onChangeCallback }} showStatus={false}>
-    <svelte:fragment slot="icon">
-      <MetricsIcon />
-    </svelte:fragment>
+    <MetricsIcon slot="icon" />
   </WorkspaceHeader>
 
   {#if !metricsSourceSelectionError}

--- a/web-local/src/lib/components/workspace/source/SourceWorkspaceHeader.svelte
+++ b/web-local/src/lib/components/workspace/source/SourceWorkspaceHeader.svelte
@@ -29,8 +29,6 @@
   style:grid-template-columns="auto max-content"
 >
   <WorkspaceHeader {...{ titleInput, onChangeCallback }} showStatus={false}>
-    <svelte:fragment slot="icon">
-      <Source />
-    </svelte:fragment>
+    <Source slot="icon" />
   </WorkspaceHeader>
 </div>

--- a/web-local/src/routes/(application)/dashboard/[id]/+page.svelte
+++ b/web-local/src/routes/(application)/dashboard/[id]/+page.svelte
@@ -29,12 +29,8 @@
 </svelte:head>
 
 <ExploreContainer let:columns>
-  <svelte:fragment slot="header">
-    <ExploreHeader {metricsDefId} />
-  </svelte:fragment>
-  <svelte:fragment slot="metrics">
-    <MetricsTimeSeriesCharts {metricsDefId} />
-  </svelte:fragment>
+  <ExploreHeader slot="header" {metricsDefId} />
+  <MetricsTimeSeriesCharts slot="metrics" {metricsDefId} />
   <svelte:fragment slot="leaderboards">
     {#if selectedDimensionId}
       <DimensionDisplay {metricsDefId} dimensionId={selectedDimensionId} />

--- a/web-local/src/routes/dev/dialog/index.svelte
+++ b/web-local/src/routes/dev/dialog/index.svelte
@@ -28,14 +28,15 @@
       <svelte:fragment slot="body"
         >This action will replace all existing measures and dimensions.</svelte:fragment
       >
-      <svelte:fragment slot="footer">
-        <div class="flex flex-row gap-x-3 justify-items-end justify-end">
-          <Button on:click={() => (replaceSource = false)} type="text"
-            >cancel</Button
-          >
-          <Button type="primary">Update source</Button>
-        </div>
-      </svelte:fragment>
+      <div
+        slot="footer"
+        class="flex flex-row gap-x-3 justify-items-end justify-end"
+      >
+        <Button on:click={() => (replaceSource = false)} type="text"
+          >cancel</Button
+        >
+        <Button type="primary">Update source</Button>
+      </div>
     </Dialog>
   {/if}
 
@@ -58,14 +59,15 @@
         />
         {changeThingValue}
       </svelte:fragment>
-      <svelte:fragment slot="footer">
-        <div class="flex flex-row gap-x-3 justify-items-end justify-end">
-          <Button on:click={() => (changeThing = false)} type="text"
-            >cancel</Button
-          >
-          <Button type="primary">Update name</Button>
-        </div>
-      </svelte:fragment>
+      <div
+        slot="footer"
+        class="flex flex-row gap-x-3 justify-items-end justify-end"
+      >
+        <Button on:click={() => (changeThing = false)} type="text"
+          >cancel</Button
+        >
+        <Button type="primary">Update name</Button>
+      </div>
     </Dialog>
   {/if}
 </div>

--- a/web-local/src/routes/dev/tooltips.svelte
+++ b/web-local/src/routes/dev/tooltips.svelte
@@ -133,30 +133,29 @@
     >
       drag this one around 🚐
     </div>
-    <svelte:fragment slot="tooltip-content">
-      <!-- <TooltipContent> -->
-      <div
-        style="min-height: 300px; width: 300px;"
-        class="border border-2 border-black p-3 rounded backdrop-blur-md	"
-      >
-        This is a tooltip. It will follow our little 🚐 everywhere it goes.
-        Ignore the design; the <i>positioning semantics</i> are the important
-        part.
 
-        <SummaryAndHistogram
-          min={9508263}
-          qlow={21123818}
-          median={30627455}
-          mean={34851293}
-          qhigh={45410890}
-          max={52802608}
-          width={300}
-          height={65}
-          data={data01}
-          color="black"
-        />
-      </div>
-      <!-- </TooltipContent> -->
-    </svelte:fragment>
+    <!-- <TooltipContent> -->
+    <div
+      slot="tooltip-content"
+      style="min-height: 300px; width: 300px;"
+      class="border border-2 border-black p-3 rounded backdrop-blur-md	"
+    >
+      This is a tooltip. It will follow our little 🚐 everywhere it goes. Ignore
+      the design; the <i>positioning semantics</i> are the important part.
+
+      <SummaryAndHistogram
+        min={9508263}
+        qlow={21123818}
+        median={30627455}
+        mean={34851293}
+        qhigh={45410890}
+        max={52802608}
+        width={300}
+        height={65}
+        data={data01}
+        color="black"
+      />
+    </div>
+    <!-- </TooltipContent> -->
   </Tooltip>
 </div>

--- a/web-local/src/routes/dev/tooltips.svelte
+++ b/web-local/src/routes/dev/tooltips.svelte
@@ -76,16 +76,15 @@
   <div class="mt-24" />
   <Tooltip alignment="left">
     <div style:width="max-content">position</div>
-    <svelte:fragment slot="tooltip-content">
-      <div class="bg-black text-white p-5">another element</div>
-    </svelte:fragment>
+
+    <div slot="tooltip-content" class="bg-black text-white p-5">
+      another element
+    </div>
   </Tooltip>
 
   <Tooltip alignment="left" bind:active={showTooltip} distance={16}>
     <button class="bg-red-500 text-white p-3 rounded">position</button>
-    <svelte:fragment slot="tooltip-content">
-      <TooltipContent>another element</TooltipContent>
-    </svelte:fragment>
+    <TooltipContent slot="tooltip-content">another element</TooltipContent>
   </Tooltip>
 
   <p>
@@ -100,11 +99,12 @@
     treatise on the theory of
     <Tooltip>
       <span class="font-bold"> ethics, </span>
-      <svelte:fragment slot="tooltip-content">
-        <div class="bg-black text-white p-5">another element!</div>
-      </svelte:fragment></Tooltip
-    > very popular during the Renaissance. The first line of Lorem Ipsum, "Lorem
-    ipsum dolor sit amet..", comes from a line in section 1.10.32.
+      <div slot="tooltip-content" class="bg-black text-white p-5">
+        another element!
+      </div>
+    </Tooltip>
+    very popular during the Renaissance. The first line of Lorem Ipsum, "Lorem ipsum
+    dolor sit amet..", comes from a line in section 1.10.32.
   </p>
 
   <div class="m-12">


### PR DESCRIPTION
PSA @hamilton @AdityaHegde @djbarnwal @ericpgreen2  -- this PR removes a bunch of svelte fragments whose only real purpose was to wrap another component in a slot. Just a heads up that this (anti)pattern has appeared a bunch of places in our code, and I think we've all done it (I know I have), but it's only really necessary in some cases -- in many cases, you can attach a slot attribute directly to the component that will occupy that slot and the fragment is not needed. Anyway, keep your eyes open for this -- in many cases it nicely improves readability by removing boilerplate and a layer of nesting! :-)

This should be a quick review, anyone can take it.