### PR TITLE
Edit documentation sequence

### DIFF
--- a/docs/docs/README.md
+++ b/docs/docs/README.md
@@ -45,14 +45,12 @@ You can create and augment your own projects in Rill Developer using the [CLI](h
 rill init
 rill import-source /path/to/data_1.parquet
 rill start
-
 ```
 
 or try our example:
 
 ```
 rill init-example
-
 ```
 
 <!-- (Please note that the command `rill init-example` is temporarily unavailable on Windows.) -->

--- a/docs/docs/sql-dialect.md
+++ b/docs/docs/sql-dialect.md
@@ -1,5 +1,5 @@
 ---
-description: Data transformations in Rill Developer are powered by duckDB and their dialect of SQL.
+description: Data transformations in Rill Developer are powered by DuckDB and their dialect of SQL.
 ---
 
 # DuckSQL

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -29,18 +29,18 @@ const sidebars = {
     },
     {
       type: 'doc',
-      id: 'defining-metrics',
-      label: 'Defining Metrics',
-    },
-    {
-      type: 'category',
-      label: 'SQL Dialects',
-      items: ['sqldialects/duck-sql'],
+      id: 'cli',
+      label: 'CLI Documentation',
     },
     {
       type: 'doc',
-      id: 'cli',
-      label: 'CLI Documentation',
+      id: 'sql-dialect',
+      label: 'SQL Dialect',
+    },
+    {
+      type: 'doc',
+      id: 'defining-metrics',
+      label: 'Defining Metrics',
     },
     {
       type: 'category',


### PR DESCRIPTION
This PR tidies up the docs in a few ways:
- Sequences the docs according to how a user would travel through the product: CLI -> SQL Dialect -> Define metrics. This sequencing will make it more clear where future docs pages (like for importing data!) should go.
- Removes an extra layer of nesting to get to our SQL Dialect page
- Cleans up a couple code snippets