### PR TITLE
Upgrade runtime

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -143,3 +143,5 @@ require (
 	google.golang.org/genproto v0.0.0-20220616135557-88e70c0c3a90
 	google.golang.org/protobuf v1.28.1
 )
+
+replace github.com/marcboeker/go-duckdb v1.0.3 => github.com/begelundmuller/go-duckdb v0.0.0-20221017134940-ad5d464b6a1a

--- a/go.sum
+++ b/go.sum
@@ -143,6 +143,8 @@ github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQ
 github.com/aws/aws-sdk-go v1.15.11/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
 github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
+github.com/begelundmuller/go-duckdb v0.0.0-20221017134940-ad5d464b6a1a h1:oL4DeWYfevEd//XJDGB7nOJhqB2+HYUPZl9fgvPK+YI=
+github.com/begelundmuller/go-duckdb v0.0.0-20221017134940-ad5d464b6a1a/go.mod h1:wm91jO2GNKa6iO9NTcjXIRsW+/ykPoJbQcHSXhdAl28=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -831,8 +833,6 @@ github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7
 github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
-github.com/marcboeker/go-duckdb v1.0.3 h1:mUkVsGdfyTM5KutZaCA6ytH7yKvxg9TF+kTfH9e/4g0=
-github.com/marcboeker/go-duckdb v1.0.3/go.mod h1:wm91jO2GNKa6iO9NTcjXIRsW+/ykPoJbQcHSXhdAl28=
 github.com/marstr/guid v1.1.0/go.mod h1:74gB1z2wpxxInTG6yaqA7KrtM0NZ+RbrcqDvYHefzho=
 github.com/matryer/moq v0.2.7/go.mod h1:kITsx543GOENm48TUAQyJ9+SAvFSr7iGQXPoth/VUBk=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=

--- a/package-lock.json
+++ b/package-lock.json
@@ -19274,6 +19274,7 @@
       }
     },
     "runtime": {
+      "name": "@rilldata/runtime",
       "version": "0.0.1"
     },
     "web-cloud": {
@@ -19373,7 +19374,7 @@
     },
     "web-local": {
       "name": "@rilldata/rill",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "hasInstallScript": true,
       "dependencies": {
         "@codemirror/autocomplete": "^0.20.0",

--- a/runtime/cmd/main.go
+++ b/runtime/cmd/main.go
@@ -27,7 +27,7 @@ type Config struct {
 	GRPCPort       int           `default:"9090" split_words:"true"`
 	LogLevel       zapcore.Level `default:"info" split_words:"true"`
 	DatabaseDriver string        `default:"sqlite"`
-	DatabaseURL    string        `default:":memory:" split_words:"true"`
+	DatabaseURL    string        `default:"file:rill?mode=memory&cache=shared" split_words:"true"`
 }
 
 func main() {

--- a/runtime/server/queries.go
+++ b/runtime/server/queries.go
@@ -2,9 +2,13 @@ package server
 
 import (
 	"context"
-	"encoding/json"
+	"fmt"
+	"math/big"
+	"time"
+	"unicode/utf8"
 
 	"github.com/jmoiron/sqlx"
+	"github.com/marcboeker/go-duckdb"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -110,16 +114,7 @@ func rowsToData(rows *sqlx.Rows) ([]*structpb.Struct, error) {
 			return nil, err
 		}
 
-		// Note: structpb only supports JSON types (e.g. not time.Time)
-		// For now, we're doing a JSON round-trip for convenience (not great for performance)
-
-		json, err := json.Marshal(rowMap)
-		if err != nil {
-			return nil, err
-		}
-
-		rowStruct := &structpb.Struct{}
-		err = rowStruct.UnmarshalJSON(json)
+		rowStruct, err := mapToPB(rowMap)
 		if err != nil {
 			return nil, err
 		}
@@ -133,4 +128,87 @@ func rowsToData(rows *sqlx.Rows) ([]*structpb.Struct, error) {
 	}
 
 	return data, nil
+}
+
+// valToPB converts any value to a google.protobuf.Value. It's similar to
+// structpb.NewValue, but adds support for a few extra primitive types.
+func valToPB(v any) (*structpb.Value, error) {
+	switch v := v.(type) {
+	// In addition to the extra supported types, we also override handling for
+	// maps and lists since we need to use valToPB on nested fields.
+	case map[string]interface{}:
+		v2, err := mapToPB(v)
+		if err != nil {
+			return nil, err
+		}
+		return structpb.NewStructValue(v2), nil
+	case []interface{}:
+		v2, err := sliceToPB(v)
+		if err != nil {
+			return nil, err
+		}
+		return structpb.NewListValue(v2), nil
+	// Handle types not handled by structpb.NewValue
+	case int8:
+		return structpb.NewNumberValue(float64(v)), nil
+	case int16:
+		return structpb.NewNumberValue(float64(v)), nil
+	case uint8:
+		return structpb.NewNumberValue(float64(v)), nil
+	case uint16:
+		return structpb.NewNumberValue(float64(v)), nil
+	case time.Time:
+		s := v.Format(time.RFC3339Nano)
+		return structpb.NewStringValue(s), nil
+	case *big.Int:
+		// Evil cast to float until frontend can deal with bigs:
+		v2, _ := new(big.Float).SetInt(v).Float64()
+		return structpb.NewNumberValue(v2), nil
+		// This is what we should do when frontend supports it:
+		// s := v.String()
+		// return structpb.NewStringValue(s), nil
+	case duckdb.Interval:
+		m := map[string]any{"months": v.Months, "days": v.Days, "micros": v.Micros}
+		v2, err := mapToPB(m)
+		if err != nil {
+			return nil, err
+		}
+		return structpb.NewStructValue(v2), nil
+	default:
+		// Default handling for basic types (ints, string, etc.)
+		return structpb.NewValue(v)
+	}
+}
+
+// mapToPB converts a map to a google.protobuf.Struct. It's similar to
+// structpb.NewStruct(), but it recurses on valToPB instead of structpb.NewValue
+// to add support for more types.
+func mapToPB(v map[string]any) (*structpb.Struct, error) {
+	x := &structpb.Struct{Fields: make(map[string]*structpb.Value, len(v))}
+	for k, v := range v {
+		if !utf8.ValidString(k) {
+			return nil, fmt.Errorf("invalid UTF-8 in string: %q", k)
+		}
+		var err error
+		x.Fields[k], err = valToPB(v)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return x, nil
+}
+
+// sliceToPB converts a map to a google.protobuf.List. It's similar to
+// structpb.NewList(), but it recurses on valToPB instead of structpb.NewList
+// to add support for more types.
+func sliceToPB(v []interface{}) (*structpb.ListValue, error) {
+	x := &structpb.ListValue{Values: make([]*structpb.Value, len(v))}
+	for i, v := range v {
+		var err error
+		x.Values[i], err = valToPB(v)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return x, nil
 }

--- a/web-local/build-tools/postinstall_runtime.sh
+++ b/web-local/build-tools/postinstall_runtime.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Hardcoded runtime version to install
-RUNTIME_VERSION="d660dfbf3fcd46ff737280cea83d7f64eac6095a"
+RUNTIME_VERSION="9512d3c2c0ad54e37291562add08a54fd77bf999"
 
 # Targets dist/runtime as the output directory
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )

--- a/web-local/build-tools/postinstall_runtime.sh
+++ b/web-local/build-tools/postinstall_runtime.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Hardcoded runtime version to install
-RUNTIME_VERSION="9512d3c2c0ad54e37291562add08a54fd77bf999"
+RUNTIME_VERSION="8ecbb53536149002b5f7dacaed4838501f407d20"
 
 # Targets dist/runtime as the output directory
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )


### PR DESCRIPTION
- Fixes bug around big number serialization (just coerces to float)
- Sets the default in-memory sqlite registry to use shared memory (otherwise, it doesn't work on many concurrent requests where new threads are spawned)
- Updates runtime version in `web-local` to incorporate the above