### PR TITLE
Fixing min max string length query

### DIFF
--- a/web-local/src/common/data-modeler-service/DataModelerService.ts
+++ b/web-local/src/common/data-modeler-service/DataModelerService.ts
@@ -56,6 +56,7 @@ export type DataModelerActionsDefinition = ExtractActionTypeDefinitions<
  * One caveat to note, type definition and actual instances passed might not match.
  */
 export class DataModelerService {
+  public readonly databaseActionQueue: ActionQueueOrchestrator<DatabaseActionsDefinition>;
   /**
    * Map of action to {@link DataModelerActions} instance.
    * This might not have an entry for everything in DataModelerActionsDefinition.
@@ -66,8 +67,6 @@ export class DataModelerService {
     [Action in keyof DataModelerActionsDefinition]?: DataModelerActionsClasses;
   } = {};
   private runningCount = 0;
-
-  public readonly databaseActionQueue: ActionQueueOrchestrator<DatabaseActionsDefinition>;
 
   public constructor(
     protected readonly dataModelerStateService: DataModelerStateService,

--- a/web-local/src/common/data-modeler-service/minMaxStringLength.spec.ts
+++ b/web-local/src/common/data-modeler-service/minMaxStringLength.spec.ts
@@ -1,0 +1,56 @@
+import type { DataProviderData } from "@adityahegde/typescript-test-utils";
+import { expect } from "@jest/globals";
+import { DATA_FOLDER } from "../../../test/data/generator/data-constants";
+import { TwoTableJoinQuery } from "../../../test/data/ModelQuery.data";
+import { FunctionalTestBase } from "../../../test/functional/FunctionalTestBase";
+
+@FunctionalTestBase.Suite
+export class GetMinAndMaxStringLengthsTest extends FunctionalTestBase {
+  @FunctionalTestBase.BeforeSuite()
+  public async setupTables(): Promise<void> {
+    await this.clientDataModelerService.dispatch("addOrUpdateTableFromFile", [
+      `${DATA_FOLDER}/AdBids.csv`,
+    ]);
+    await this.clientDataModelerService.dispatch("addModel", [
+      { name: "model_0", query: "" },
+    ]);
+  }
+
+  public minMaxStringLengthData(): DataProviderData<[string]> {
+    return {
+      subData: [
+        {
+          title: "happy path",
+          args: [TwoTableJoinQuery],
+        },
+        {
+          title: "double quote",
+          args: ["select monthname(timestamp) from AdBids"],
+        },
+        {
+          title: "single quote",
+          args: ["select str_split('hello_world', '_')[1]"],
+        },
+        {
+          title: "mixed quotes",
+          args: ["select str_split(domain, '.')[1] from AdBids"],
+        },
+      ],
+    };
+  }
+
+  @FunctionalTestBase.Test("minMaxStringLengthData")
+  public async testSuccessfulQuery(query: string) {
+    const [model] = this.getModels("tableName", "model_0");
+    await this.clientDataModelerService.dispatch("updateModelQuery", [
+      model.id,
+      query,
+    ]);
+    await this.waitForModels();
+
+    const [, derivedModel] = this.getModels("tableName", "model_0");
+    for (const profile of derivedModel.profile) {
+      expect(profile.largestStringLength).toBeGreaterThan(0);
+    }
+  }
+}

--- a/web-local/src/common/database-service/DatabaseTableActions.ts
+++ b/web-local/src/common/database-service/DatabaseTableActions.ts
@@ -3,8 +3,16 @@ import type { ProfileColumn } from "@rilldata/web-local/lib/types";
 import { guidGenerator } from "@rilldata/web-local/lib/util/guid";
 import { DatabaseActions } from "./DatabaseActions";
 
+const SingleQuoteRegex = /'/g;
+const DoubleQuoteRegex = /"/g;
 function escapeColumn(columnName: string): string {
-  return columnName.replace(/"/g, "'");
+  return `'${columnName.replace(SingleQuoteRegex, '"')}'`;
+}
+
+function escapeColumnAlias(columnName: string): string {
+  return columnName
+    .replace(SingleQuoteRegex, "__")
+    .replace(DoubleQuoteRegex, "__");
 }
 
 export class DatabaseTableActions extends DatabaseActions {
@@ -60,9 +68,9 @@ export class DatabaseTableActions extends DatabaseActions {
       tableName,
       tableDef
     )) as { [key: string]: number };
-    tableDef = tableDef.map((column: ProfileColumn) => {
+    tableDef = tableDef.map((column: ProfileColumn, index) => {
       // get string rep length value to estimate preview table column sizes
-      column.largestStringLength = characterLengths[column.name];
+      column.largestStringLength = characterLengths[`col_${index}`];
       return column;
     });
     try {
@@ -102,33 +110,43 @@ export class DatabaseTableActions extends DatabaseActions {
     columns: ProfileColumn[]
   ) {
     /** get columns */
+    const columnNames = columns
+      .map(
+        (column, index) =>
+          [escapeColumn(column.name), index] as [string, number]
+      )
+      .filter(([columnName]) => columnName !== "");
     // template in the column mins and maxes.
     // treat categoricals a little differently; all they have is length.
-    const minAndMax = columns
-      .map((column) => {
-        const escapedColumn = escapeColumn(column.name);
+    const minAndMax = columnNames
+      .map(([columnName]) => {
+        const columnAlias = escapeColumnAlias(columnName);
         return (
-          `min(length('${column.name}')) as "min_${escapedColumn}",` +
-          `max(length('${column.name}')) as "max_${escapedColumn}"`
+          `min(length(${columnName})) as "min_${columnAlias}",` +
+          `max(length(${columnName})) as "max_${columnAlias}"`
         );
       })
       .join(", ");
-    const largestStrings = columns
-      .map((column) => {
-        const escapedColumn = escapeColumn(column.name);
+    const largestStrings = columnNames
+      .map(([columnName, index]) => {
+        const columnAlias = escapeColumnAlias(columnName);
         return (
-          `CASE WHEN "min_${escapedColumn}" > "max_${escapedColumn}" THEN "min_${escapedColumn}" ` +
-          `ELSE "max_${escapedColumn}" END AS "${escapedColumn}"`
+          `CASE WHEN "min_${columnAlias}" > "max_${columnAlias}" THEN "min_${columnAlias}" ` +
+          `ELSE "max_${columnAlias}" END AS col_${index}`
         );
       })
       .join(",");
-    return (
-      await this.databaseClient.execute(
-        `
+    try {
+      return (
+        await this.databaseClient.execute(
+          `
       WITH strings AS (SELECT ${minAndMax} from "${table}")
       SELECT ${largestStrings} from strings;
     `
-      )
-    )[0];
+        )
+      )[0];
+    } catch (err) {
+      return {};
+    }
   }
 }

--- a/web-local/test/functional/minMaxStringLength.spec.ts
+++ b/web-local/test/functional/minMaxStringLength.spec.ts
@@ -1,8 +1,8 @@
 import type { DataProviderData } from "@adityahegde/typescript-test-utils";
 import { expect } from "@jest/globals";
-import { DATA_FOLDER } from "../../../test/data/generator/data-constants";
-import { TwoTableJoinQuery } from "../../../test/data/ModelQuery.data";
-import { FunctionalTestBase } from "../../../test/functional/FunctionalTestBase";
+import { DATA_FOLDER } from "../data/generator/data-constants";
+import { TwoTableJoinQuery } from "../data/ModelQuery.data";
+import { FunctionalTestBase } from "./FunctionalTestBase";
 
 @FunctionalTestBase.Suite
 export class GetMinAndMaxStringLengthsTest extends FunctionalTestBase {


### PR DESCRIPTION
closes #1037

Added some tests which check for column name with single, double and mixed quotes.
Made the query to be optional. Any failures in it will not cause the modeling to be blocked.