### PR TITLE
Ensure `enter` submits form rather than opens docs

### DIFF
--- a/web-local/src/lib/components/forms/InformationalField.svelte
+++ b/web-local/src/lib/components/forms/InformationalField.svelte
@@ -14,16 +14,14 @@
   </div>
   {#if hint}
     <Tooltip location="bottom" alignment="middle" distance={8}>
-      <button
-        class="text-gray-500"
+      <a
+        class="text-gray-500 hover:cursor-pointer"
         style="transform:translateY(-.5px)"
-        type="button"
-        on:click|preventDefault={() => {
-          window.open(href, "_blank");
-        }}
+        {href}
+        target="_blank"
       >
         <InfoCircle size="13px" />
-      </button>
+      </a>
       <TooltipContent slot="tooltip-content">
         {@html hint}
       </TooltipContent>

--- a/web-local/src/lib/components/forms/InformationalField.svelte
+++ b/web-local/src/lib/components/forms/InformationalField.svelte
@@ -17,6 +17,7 @@
       <button
         class="text-gray-500"
         style="transform:translateY(-.5px)"
+        type="button"
         on:click|preventDefault={() => {
           window.open(href, "_blank");
         }}


### PR DESCRIPTION
Currently, in the GCS & S3 connector forms, pressing the `enter` key opens up the documentation pages, rather than submitting the form. This PR fixes that.