### PR TITLE
Fix Cancel action on refresh dialog

### DIFF
--- a/web-local/src/lib/components/assets/sources/TableAssets.svelte
+++ b/web-local/src/lib/components/assets/sources/TableAssets.svelte
@@ -174,7 +174,6 @@
   $: getSources = useRuntimeServiceListCatalogObjects(runtimeInstanceId);
 
   const onRefreshSource = async (id: string, tableName: string) => {
-    overlay.set({ title: `Importing ${tableName}` });
     try {
       await refreshSource(
         $getSources.data?.objects.find(

--- a/web-local/src/lib/components/assets/sources/refreshSource.ts
+++ b/web-local/src/lib/components/assets/sources/refreshSource.ts
@@ -1,5 +1,6 @@
 import type { RuntimeState } from "@rilldata/web-local/lib/application-state-stores/application-store";
 import { config } from "@rilldata/web-local/lib/application-state-stores/application-store";
+import { overlay } from "@rilldata/web-local/lib/application-state-stores/layout-store";
 import { compileCreateSourceSql } from "@rilldata/web-local/lib/components/assets/sources/sourceUtils";
 import {
   openFileUploadDialog,
@@ -16,7 +17,9 @@ export async function refreshSource(
 ) {
   if (connector === "file") {
     const files = await openFileUploadDialog(false);
-    if (!files.length) return;
+    if (!files.length) return Promise.reject();
+
+    overlay.set({ title: `Importing ${tableName}` });
     const filePath = await uploadFile(
       `${config.database.runtimeUrl}/v1/repos/${runtimeState.repoId}/objects/file`,
       files[0]

--- a/web-local/src/lib/components/workspace/source/SourceWorkspaceHeader.svelte
+++ b/web-local/src/lib/components/workspace/source/SourceWorkspaceHeader.svelte
@@ -47,7 +47,6 @@
   );
 
   const onRefreshClick = async (tableName: string) => {
-    overlay.set({ title: `Importing ${tableName}` });
     try {
       await refreshSource(
         $getSource.data?.object.source.connector,


### PR DESCRIPTION
Fix #1106 

Also noted that for Firefox, even after cancel the overlay doesn't go away. A focus event is not triggered on the window hence the overlay screen was stuck. To fix that, now overlay is only shown when the upload process actually begins. 