### PR TITLE
Redirect to metric def on dashboard error

### DIFF
--- a/web-local/src/common/errors/ErrorMessages.ts
+++ b/web-local/src/common/errors/ErrorMessages.ts
@@ -12,8 +12,6 @@ export const ExplorerSourceModelIsInvalid = "Model query has errors.";
 export const ExplorerTimeDimensionDoesntExist =
   "Previously selected timestamp column does not exist.";
 export const ExplorerSourceColumnDoesntExist = "not found in FROM clause!"; // the full DuckDB error message is `Binder Error: Referenced column "COLUMN_NAME" not found in FROM clause!`
-export const ExplorerDashboardDoesntExist =
-  "Cannot read properties of undefined (reading 'id')";
 
 export const MetricsSourceSelectionError = (
   metricsDefinition: MetricsDefinitionEntity

--- a/web-local/src/common/errors/ErrorMessages.ts
+++ b/web-local/src/common/errors/ErrorMessages.ts
@@ -12,6 +12,8 @@ export const ExplorerSourceModelIsInvalid = "Model query has errors.";
 export const ExplorerTimeDimensionDoesntExist =
   "Previously selected timestamp column does not exist.";
 export const ExplorerSourceColumnDoesntExist = "not found in FROM clause!"; // the full DuckDB error message is `Binder Error: Referenced column "COLUMN_NAME" not found in FROM clause!`
+export const ExplorerDashboardDoesntExist =
+  "Cannot read properties of undefined (reading 'id')";
 
 export const MetricsSourceSelectionError = (
   metricsDefinition: MetricsDefinitionEntity

--- a/web-local/src/common/rill-developer-service/MetricsViewActions.ts
+++ b/web-local/src/common/rill-developer-service/MetricsViewActions.ts
@@ -104,6 +104,11 @@ export class MetricsViewActions extends RillDeveloperActions {
     rillRequestContext: MetricsDefinitionContext,
     _: string
   ) {
+    if (!rillRequestContext.record) {
+      return ActionResponseFactory.getEntityError(
+        ExplorerMetricsDefinitionDoesntExist
+      );
+    }
     const metricsDef = this.dataModelerStateService
       .getMetricsDefinitionService()
       .getById(rillRequestContext.record.id);

--- a/web-local/src/lib/components/modal/ModalContainer.svelte
+++ b/web-local/src/lib/components/modal/ModalContainer.svelte
@@ -61,10 +61,12 @@
     initiateOnMount(container);
 
   onDestroy(() => {
-    modal.deactivate();
-    unlockBodyScrolling(container);
-    if (typeof originalTrigger?.focus === "function") {
-      setTimeout(() => originalTrigger.focus());
+    if (modal) {
+      modal.deactivate();
+      unlockBodyScrolling(container);
+      if (typeof originalTrigger?.focus === "function") {
+        setTimeout(() => originalTrigger.focus());
+      }
     }
   });
 

--- a/web-local/src/lib/components/modal/ModalContainer.svelte
+++ b/web-local/src/lib/components/modal/ModalContainer.svelte
@@ -61,12 +61,11 @@
     initiateOnMount(container);
 
   onDestroy(() => {
-    if (modal) {
-      modal.deactivate();
-      unlockBodyScrolling(container);
-      if (typeof originalTrigger?.focus === "function") {
-        setTimeout(() => originalTrigger.focus());
-      }
+    if (!modal) return;
+    modal.deactivate();
+    unlockBodyScrolling(container);
+    if (typeof originalTrigger?.focus === "function") {
+      setTimeout(() => originalTrigger.focus());
     }
   });
 

--- a/web-local/src/lib/components/navigation/dashboards/MetricsDefinitionAssets.svelte
+++ b/web-local/src/lib/components/navigation/dashboards/MetricsDefinitionAssets.svelte
@@ -110,17 +110,24 @@
   };
 
   const deleteMetricsDef = (metricsDef: MetricsDefinitionEntity) => {
-    if (
-      $applicationStore.activeEntity.type === EntityType.MetricsDefinition &&
-      $applicationStore.activeEntity.id === metricsDef.id
-    ) {
-      goto(`/model/${metricsDef.sourceModelId}`);
-    }
+    const sourceModelId = metricsDef.sourceModelId;
 
     notificationStore.send({
       message: `Dashboard "${metricsDef.metricDefLabel}" deleted`,
     });
     store.dispatch(deleteMetricsDefsApi(metricsDef.id));
+
+    if (
+      ($applicationStore.activeEntity.type === EntityType.MetricsDefinition ||
+        $applicationStore.activeEntity.type === EntityType.MetricsExplorer) &&
+      $applicationStore.activeEntity.id === metricsDef.id
+    ) {
+      if (sourceModelId) {
+        goto(`/model/${sourceModelId}`);
+      } else {
+        goto("/");
+      }
+    }
   };
 
   onMount(() => {

--- a/web-local/src/lib/components/navigation/dashboards/MetricsDefinitionAssets.svelte
+++ b/web-local/src/lib/components/navigation/dashboards/MetricsDefinitionAssets.svelte
@@ -1,15 +1,19 @@
 <script lang="ts">
   import { goto } from "$app/navigation";
   import { EntityType } from "@rilldata/web-local/common/data-modeler-state-service/entity-state-service/EntityStateService";
-  import { SourceModelValidationStatus } from "@rilldata/web-local/common/data-modeler-state-service/entity-state-service/MetricsDefinitionEntityService";
+  import {
+    MetricsDefinitionEntity,
+    SourceModelValidationStatus,
+  } from "@rilldata/web-local/common/data-modeler-state-service/entity-state-service/MetricsDefinitionEntityService";
   import { MetricsSourceSelectionError } from "@rilldata/web-local/common/errors/ErrorMessages";
   import { BehaviourEventMedium } from "@rilldata/web-local/common/metrics-service/BehaviourEventTypes";
+  import notificationStore from "@rilldata/web-local/lib/components/notifications";
+
   import {
     EntityTypeToScreenMap,
     MetricsEventScreenName,
     MetricsEventSpace,
   } from "@rilldata/web-local/common/metrics-service/MetricsTypes";
-  import { getNextEntityId } from "@rilldata/web-local/common/utils/getNextEntityId";
   import { waitUntil } from "@rilldata/web-local/common/utils/waitUtils";
   import { getContext, onMount } from "svelte";
   import { slide } from "svelte/transition";
@@ -105,21 +109,18 @@
     );
   };
 
-  const deleteMetricsDef = (id: string) => {
+  const deleteMetricsDef = (metricsDef: MetricsDefinitionEntity) => {
     if (
       $applicationStore.activeEntity.type === EntityType.MetricsDefinition &&
-      $applicationStore.activeEntity.id === id
+      $applicationStore.activeEntity.id === metricsDef.id
     ) {
-      const nextMetricsDefId = getNextEntityId($metricsDefinitions, id);
-
-      if (nextMetricsDefId) {
-        goto(`/dashboard/${nextMetricsDefId}`);
-      } else {
-        goto("/");
-      }
+      goto(`/model/${metricsDef.sourceModelId}`);
     }
 
-    store.dispatch(deleteMetricsDefsApi(id));
+    notificationStore.send({
+      message: `Dashboard "${metricsDef.metricDefLabel}" deleted`,
+    });
+    store.dispatch(deleteMetricsDefsApi(metricsDef.id));
   };
 
   onMount(() => {
@@ -213,7 +214,7 @@
             <EditIcon slot="icon" />
             rename...</MenuItem
           >
-          <MenuItem icon on:select={() => deleteMetricsDef(metricsDef.id)}>
+          <MenuItem icon on:select={() => deleteMetricsDef(metricsDef)}>
             <Cancel slot="icon" />
             delete</MenuItem
           >

--- a/web-local/src/lib/components/workspace/metrics-def/MetricsDefWorkspace.svelte
+++ b/web-local/src/lib/components/workspace/metrics-def/MetricsDefWorkspace.svelte
@@ -35,6 +35,7 @@
   import WorkspaceContainer from "../core/WorkspaceContainer.svelte";
   import MetricsDefWorkspaceHeader from "./MetricsDefWorkspaceHeader.svelte";
   export let metricsDefId;
+  export let nonStandardError;
 
   $: measures = getMeasuresByMetricsId(metricsDefId);
   $: dimensions = getDimensionsByMetricsId(metricsDefId);
@@ -113,6 +114,8 @@
 
   $: metricsSourceSelectionError = $selectedMetricsDef
     ? MetricsSourceSelectionError($selectedMetricsDef)
+    : nonStandardError
+    ? nonStandardError
     : "";
 
   onMount(() => {

--- a/web-local/src/lib/redux-store/metrics-definition/metrics-definition-apis.ts
+++ b/web-local/src/lib/redux-store/metrics-definition/metrics-definition-apis.ts
@@ -6,8 +6,6 @@ import type { MeasureDefinitionEntity } from "@rilldata/web-local/common/data-mo
 import type { MetricsDefinitionEntity } from "@rilldata/web-local/common/data-modeler-state-service/entity-state-service/MetricsDefinitionEntityService";
 import { SourceModelValidationStatus } from "@rilldata/web-local/common/data-modeler-state-service/entity-state-service/MetricsDefinitionEntityService";
 import { asyncWait } from "@rilldata/web-local/common/utils/waitUtils";
-import { dataModelerService } from "../../application-state-stores/application-store";
-import { selectApplicationActiveEntity } from "../application/application-selectors";
 import { validateDimensionColumnApi } from "../dimension-definition/dimension-definition-apis";
 import { selectDimensionsByMetricsId } from "../dimension-definition/dimension-definition-selectors";
 import {
@@ -35,29 +33,10 @@ import {
 import { selectDerivedModelById } from "../model/model-selector";
 import { createAsyncThunk } from "../redux-toolkit-wrapper";
 import { selectTimestampColumnFromProfileEntity } from "../source/source-selectors";
-import { RillReduxState, store } from "../store-root";
+import type { RillReduxState } from "../store-root";
 import { generateApis } from "../utils/api-utils";
 import { invalidateExplorer } from "../utils/invalidateExplorerThunk";
 import { streamingFetchWrapper } from "../../util/fetchWrapper";
-
-const handleMetricsDefDelete = async (id: string) => {
-  const activeEntity = selectApplicationActiveEntity(store.getState());
-  if (!activeEntity) return;
-
-  if (
-    activeEntity.id === id &&
-    (activeEntity.type === EntityType.MetricsDefinition ||
-      activeEntity.type === EntityType.MetricsExplorer)
-  ) {
-    const nextId = store.getState().metricsDefinition.ids[0];
-    if (!nextId) {
-      // TODO: refactor to use redux store once we move model and tables there.
-      await dataModelerService.dispatch("setModelAsActiveAsset", []);
-    } else {
-      goto(`/dashboard/${nextId}`);
-    }
-  }
-};
 
 export const {
   fetchManyApi: fetchManyMetricsDefsApi,
@@ -71,7 +50,7 @@ export const {
   [EntityType.MetricsDefinition, "metricsDefinition", "metrics"],
   [addManyMetricsDefs, addOneMetricsDef, updateMetricsDef, removeMetricsDef],
   [],
-  [undefined, handleMetricsDefDelete]
+  [undefined, undefined]
 );
 export const createMetricsDefsAndFocusApi = createAsyncThunk(
   `${EntityType.MetricsDefinition}/fetchManyMetricsDefsAndFocusApi`,

--- a/web-local/src/routes/(application)/dashboard/[id]/+page.ts
+++ b/web-local/src/routes/(application)/dashboard/[id]/+page.ts
@@ -1,7 +1,7 @@
 import { config } from "@rilldata/web-local/lib/application-state-stores/application-store";
 import { getMetricsViewMetadata } from "@rilldata/web-local/lib/svelte-query/queries/metrics-views/metadata";
 import { error, redirect } from "@sveltejs/kit";
-import { ExplorerDashboardDoesntExist } from "@rilldata/web-local/common/errors/ErrorMessages";
+import { ExplorerMetricsDefinitionDoesntExist } from "@rilldata/web-local/common/errors/ErrorMessages";
 
 export const ssr = false;
 
@@ -23,8 +23,8 @@ export async function load({ params }) {
     }
   } catch (err) {
     if (
-      ExplorerDashboardDoesntExist.includes(err.message) ||
-      err.message.includes(ExplorerDashboardDoesntExist)
+      ExplorerMetricsDefinitionDoesntExist.includes(err.message) ||
+      err.message.includes(ExplorerMetricsDefinitionDoesntExist)
     ) {
       throw error(404, "Dashboard not found");
     } else {

--- a/web-local/src/routes/(application)/dashboard/[id]/+page.ts
+++ b/web-local/src/routes/(application)/dashboard/[id]/+page.ts
@@ -1,11 +1,6 @@
-import {
-  ExplorerSourceColumnDoesntExist,
-  ExplorerSourceModelDoesntExist,
-  ExplorerSourceModelIsInvalid,
-} from "@rilldata/web-local/common/errors/ErrorMessages";
 import { config } from "@rilldata/web-local/lib/application-state-stores/application-store";
 import { getMetricsViewMetadata } from "@rilldata/web-local/lib/svelte-query/queries/metrics-views/metadata";
-import { error, redirect } from "@sveltejs/kit";
+import { redirect } from "@sveltejs/kit";
 
 export const ssr = false;
 
@@ -26,21 +21,7 @@ export async function load({ params }) {
       return redirect(307, `/dashboard/${params.id}/edit`);
     }
   } catch (err) {
-    const invalidDashboardErrors = [
-      ExplorerSourceModelDoesntExist,
-      ExplorerSourceModelIsInvalid,
-      ExplorerSourceColumnDoesntExist,
-    ];
-
-    // if dashboard is invalid, redirect to the metrics definition page
-    if (
-      invalidDashboardErrors.some(
-        (errMsg) => errMsg.includes(err.message) || err.message.includes(errMsg)
-      )
-    ) {
-      throw redirect(307, `/dashboard/${params.id}/edit`);
-    }
+    // in case of error redirect to metrics definition page
+    throw redirect(307, `/dashboard/${params.id}/edit`);
   }
-
-  throw error(404, "Dashboard not found");
 }

--- a/web-local/src/routes/(application)/dashboard/[id]/+page.ts
+++ b/web-local/src/routes/(application)/dashboard/[id]/+page.ts
@@ -1,6 +1,7 @@
 import { config } from "@rilldata/web-local/lib/application-state-stores/application-store";
 import { getMetricsViewMetadata } from "@rilldata/web-local/lib/svelte-query/queries/metrics-views/metadata";
-import { redirect } from "@sveltejs/kit";
+import { error, redirect } from "@sveltejs/kit";
+import { ExplorerDashboardDoesntExist } from "@rilldata/web-local/common/errors/ErrorMessages";
 
 export const ssr = false;
 
@@ -21,7 +22,14 @@ export async function load({ params }) {
       return redirect(307, `/dashboard/${params.id}/edit`);
     }
   } catch (err) {
-    // in case of error redirect to metrics definition page
-    throw redirect(307, `/dashboard/${params.id}/edit`);
+    if (
+      ExplorerDashboardDoesntExist.includes(err.message) ||
+      err.message.includes(ExplorerDashboardDoesntExist)
+    ) {
+      throw error(404, "Dashboard not found");
+    } else {
+      throw redirect(307, `/dashboard/${params.id}/edit`);
+    }
   }
+  throw redirect(307, `/dashboard/${params.id}/edit`);
 }

--- a/web-local/src/routes/(application)/dashboard/[id]/edit/+page.svelte
+++ b/web-local/src/routes/(application)/dashboard/[id]/edit/+page.svelte
@@ -2,15 +2,22 @@
   import { EntityType } from "@rilldata/web-local/common/data-modeler-state-service/entity-state-service/EntityStateService";
   import { dataModelerService } from "@rilldata/web-local/lib/application-state-stores/application-store";
   import { MetricsDefinitionWorkspace } from "@rilldata/web-local/lib/components/workspace";
+  import { Button } from "@rilldata/web-local/lib/components/button";
+  import { Dialog } from "@rilldata/web-local/lib/components/modal";
 
   export let data;
 
   $: metricsDefId = data.metricsDefId;
+  $: error = data.error;
 
   $: dataModelerService.dispatch("setActiveAsset", [
     EntityType.MetricsDefinition,
     metricsDefId,
   ]);
+
+  function onCancel() {
+    error = "";
+  }
 </script>
 
 <svelte:head>
@@ -19,3 +26,11 @@
 </svelte:head>
 
 <MetricsDefinitionWorkspace metricsDefId={data.metricsDefId} />
+
+{#if error}
+  <Dialog compact on:cancel={onCancel}>
+    <svelte:fragment slot="title">Unable to display Dashboard</svelte:fragment>
+    <svelte:fragment slot="body">{error}</svelte:fragment>
+    <Button on:click={onCancel} slot="footer" type="text">Close</Button>
+  </Dialog>
+{/if}

--- a/web-local/src/routes/(application)/dashboard/[id]/edit/+page.svelte
+++ b/web-local/src/routes/(application)/dashboard/[id]/edit/+page.svelte
@@ -2,22 +2,16 @@
   import { EntityType } from "@rilldata/web-local/common/data-modeler-state-service/entity-state-service/EntityStateService";
   import { dataModelerService } from "@rilldata/web-local/lib/application-state-stores/application-store";
   import { MetricsDefinitionWorkspace } from "@rilldata/web-local/lib/components/workspace";
-  import { Button } from "@rilldata/web-local/lib/components/button";
-  import { Dialog } from "@rilldata/web-local/lib/components/modal";
 
   export let data;
 
   $: metricsDefId = data.metricsDefId;
-  $: error = data.error;
+  $: nonStandardError = data.error;
 
   $: dataModelerService.dispatch("setActiveAsset", [
     EntityType.MetricsDefinition,
     metricsDefId,
   ]);
-
-  function onCancel() {
-    error = "";
-  }
 </script>
 
 <svelte:head>
@@ -25,12 +19,7 @@
   <title>Rill Developer</title>
 </svelte:head>
 
-<MetricsDefinitionWorkspace metricsDefId={data.metricsDefId} />
-
-{#if error}
-  <Dialog compact on:cancel={onCancel}>
-    <svelte:fragment slot="title">Unable to display Dashboard</svelte:fragment>
-    <svelte:fragment slot="body">{error}</svelte:fragment>
-    <Button on:click={onCancel} slot="footer" type="text">Close</Button>
-  </Dialog>
-{/if}
+<MetricsDefinitionWorkspace
+  metricsDefId={data.metricsDefId}
+  {nonStandardError}
+/>

--- a/web-local/src/routes/(application)/dashboard/[id]/edit/+page.ts
+++ b/web-local/src/routes/(application)/dashboard/[id]/edit/+page.ts
@@ -3,7 +3,7 @@ import {
   ExplorerSourceModelDoesntExist,
   ExplorerSourceModelIsInvalid,
   ExplorerTimeDimensionDoesntExist,
-  ExplorerDashboardDoesntExist,
+  ExplorerMetricsDefinitionDoesntExist,
 } from "@rilldata/web-local/common/errors/ErrorMessages";
 import { config } from "@rilldata/web-local/lib/application-state-stores/application-store";
 import { getMetricsViewMetadata } from "@rilldata/web-local/lib/svelte-query/queries/metrics-views/metadata";
@@ -39,8 +39,8 @@ export async function load({ params }) {
       };
     } else {
       if (
-        ExplorerDashboardDoesntExist.includes(err.message) ||
-        err.message.includes(ExplorerDashboardDoesntExist)
+        ExplorerMetricsDefinitionDoesntExist.includes(err.message) ||
+        err.message.includes(ExplorerMetricsDefinitionDoesntExist)
       ) {
         throw error(404, "Metrics definition  not found");
       }

--- a/web-local/src/routes/(application)/dashboard/[id]/edit/+page.ts
+++ b/web-local/src/routes/(application)/dashboard/[id]/edit/+page.ts
@@ -2,6 +2,8 @@ import {
   ExplorerSourceColumnDoesntExist,
   ExplorerSourceModelDoesntExist,
   ExplorerSourceModelIsInvalid,
+  ExplorerTimeDimensionDoesntExist,
+  ExplorerDashboardDoesntExist,
 } from "@rilldata/web-local/common/errors/ErrorMessages";
 import { config } from "@rilldata/web-local/lib/application-state-stores/application-store";
 import { getMetricsViewMetadata } from "@rilldata/web-local/lib/svelte-query/queries/metrics-views/metadata";
@@ -23,6 +25,7 @@ export async function load({ params }) {
       ExplorerSourceModelDoesntExist,
       ExplorerSourceModelIsInvalid,
       ExplorerSourceColumnDoesntExist,
+      ExplorerTimeDimensionDoesntExist,
     ];
 
     // any invalid dashboard error will be displayed by the component
@@ -35,6 +38,12 @@ export async function load({ params }) {
         metricsDefId: params.id,
       };
     } else {
+      if (
+        ExplorerDashboardDoesntExist.includes(err.message) ||
+        err.message.includes(ExplorerDashboardDoesntExist)
+      ) {
+        throw error(404, "Metrics definition  not found");
+      }
       // Pass non standard error message to be shown in dialog
       return {
         metricsDefId: params.id,

--- a/web-local/src/routes/(application)/dashboard/[id]/edit/+page.ts
+++ b/web-local/src/routes/(application)/dashboard/[id]/edit/+page.ts
@@ -34,6 +34,12 @@ export async function load({ params }) {
       return {
         metricsDefId: params.id,
       };
+    } else {
+      // Pass non standard error message to be shown in dialog
+      return {
+        metricsDefId: params.id,
+        error: err.message,
+      };
     }
   }
 


### PR DESCRIPTION
closes #1144 

404 message on Dashboard has been removed completely. In case of a dashboard error, we redirect to the metrics definition page. If the error is non standard, we show the message in a dialog box (standard message errors are shown in the components themselves).