### PR TITLE
Remove notes about not supporting gzipped files

### DIFF
--- a/docs/docs/import-data.md
+++ b/docs/docs/import-data.md
@@ -73,7 +73,6 @@ Private S3 files available to this account can now be pulled into Rill.
 
 Today, a few constraints apply to the data sources you can import:
 - Only Parquet and CSV files are supported.
-- gzipped files are not yet supported.
 - You can only import a single file at a time.
 
 ## Request a new connector

--- a/runtime/connectors/gcs/gcs.go
+++ b/runtime/connectors/gcs/gcs.go
@@ -27,7 +27,7 @@ var spec = connectors.Spec{
 			Placeholder: "gs://bucket-name/path/to/file.csv",
 			Type:        connectors.StringPropertyType,
 			Required:    true,
-			Hint:        "Note that gzipped files & glob patterns aren't yet supported",
+			Hint:        "Note that glob patterns aren't yet supported",
 		},
 		{
 			Key:         "gcp.credentials",

--- a/runtime/connectors/s3/s3.go
+++ b/runtime/connectors/s3/s3.go
@@ -30,7 +30,7 @@ var spec = connectors.Spec{
 			Placeholder: "s3://bucket-name/path/to/file.csv",
 			Type:        connectors.StringPropertyType,
 			Required:    true,
-			Hint:        "Note that gzipped files & glob patterns aren't yet supported",
+			Hint:        "Note that glob patterns aren't yet supported",
 		},
 		{
 			Key:         "aws.region",


### PR DESCRIPTION
There were two places we said we didn't support gzipped files:
- The "Limitations" section of the "Import Data" docs page
- Tooltips over the "Path" field in the connector forms for S3 & GCS