### PR TITLE
Fix timestamp zoom when released outside of svg bounds

### DIFF
--- a/web-local/src/lib/components/data-graphic/actions/scrub-action-factory.ts
+++ b/web-local/src/lib/components/data-graphic/actions/scrub-action-factory.ts
@@ -203,13 +203,13 @@ export function createScrubAction({
 
       node.addEventListener(startEvent, onScrubStart);
       node.addEventListener(moveEvent, onScrub);
-      node.addEventListener(endEvent, onScrubEnd);
+      window.addEventListener(endEvent, onScrubEnd);
       window.addEventListener(endEvent, reset);
       return {
         destroy() {
           node.removeEventListener(startEvent, onScrubStart);
           node.removeEventListener(moveEvent, onScrub);
-          node.removeEventListener(endEvent, onScrubEnd);
+          window.removeEventListener(endEvent, onScrubEnd);
           window.removeEventListener(endEvent, reset);
         },
       };


### PR DESCRIPTION
Right now when you zoom on on a timestamp chart, if you release past the edge of the svg the chart will not zoom

## Bug description
To replicate:
1. start datetime zoom
2. drag past edge of the chart
3. will not actually zoom in 

video of bug: 

https://user-images.githubusercontent.com/13400543/201785378-196f9cc9-d9b1-4d63-af50-e74bb9b6ca4b.mov

## fix
Moving the end event listener to the window rather than the node seems to fix

https://user-images.githubusercontent.com/13400543/201785527-c370aa8d-e097-4416-b3be-8e08a79a0179.mov


I noticed this using your timestamp component in https://github.com/cmudig/AutoProfiler and patched the fix in my repo so thought I would suggest here as well