### PR TITLE
lighten up leaderboards

### DIFF
--- a/web-local/src/app.css
+++ b/web-local/src/app.css
@@ -35,6 +35,10 @@
     @apply text-gray-600 dark:text-gray-200;
   }
 
+  .ui-copy-strong {
+    @apply text-gray-700 dark:text-white font-semibold;
+  }
+
   .ui-copy-icon {
     @apply ui-copy-muted;
   }
@@ -70,6 +74,10 @@
 
   .ui-measure-bar-included {
     @apply bg-blue-100 dark:bg-blue-700;
+  }
+
+  .ui-measure-bar-included-selected {
+    @apply bg-blue-200 dark:bg-blue-600;
   }
 
   .ui-measure-bar-excluded {

--- a/web-local/src/app.css
+++ b/web-local/src/app.css
@@ -53,7 +53,7 @@
 
   /** a non-acccessible faint version of ui-copy-disabled used in dimension tables */
   .ui-copy-disabled-faint {
-    @apply text-gray-400 dark:text-gray-400;
+    @apply italic text-gray-400 dark:text-gray-400;
   }
 
   .ui-divider {
@@ -66,6 +66,14 @@
 
   .ui-divider-strong {
     @apply border-gray-400 dark:border-gray-500;
+  }
+
+  .ui-measure-bar-included {
+    @apply bg-blue-100 dark:bg-blue-700;
+  }
+
+  .ui-measure-bar-excluded {
+    @apply bg-gray-100 dark:bg-gray-700;
   }
 }
 

--- a/web-local/src/lib/components/chip/removable-list-chip/RemovableListMenu.svelte
+++ b/web-local/src/lib/components/chip/removable-list-chip/RemovableListMenu.svelte
@@ -80,18 +80,23 @@
         >
           <svelte:fragment slot="icon">
             {#if selectedValues.includes(value) && !excludeMode}
-              <Check />
+              <Check size="20px" />
             {:else if selectedValues.includes(value) && excludeMode}
-              <Cancel />
+              <Cancel size="20px" />
             {:else}
-              <Spacer />
+              <Spacer size="20px" />
             {/if}
           </svelte:fragment>
-          {#if value?.length > 240}
-            {value.slice(0, 240)}...
-          {:else}
-            {value}
-          {/if}
+          <span
+            class:ui-copy-disabled={selectedValues.includes(value) &&
+              excludeMode}
+          >
+            {#if value?.length > 240}
+              {value.slice(0, 240)}...
+            {:else}
+              {value}
+            {/if}
+          </span>
         </MenuItem>
       {/each}
     {:else}

--- a/web-local/src/lib/components/virtualized-table/core/Cell.svelte
+++ b/web-local/src/lib/components/virtualized-table/core/Cell.svelte
@@ -80,8 +80,8 @@
     : false;
 
   $: barColor = excluded
-    ? "bg-gray-200 dark:bg-gray-700"
-    : "bg-blue-200 dark:bg-blue-700";
+    ? "ui-measure-bar-excluded"
+    : "ui-measure-bar-included";
 
   $: tooltipValue =
     value && STRING_LIKES.has(type) && value.length >= TOOLTIP_STRING_LIMIT
@@ -138,9 +138,7 @@
         <FormattedDataType
           value={formattedValue || value}
           {type}
-          customStyle={excluded
-            ? "font-normal ui-copy-disabled-faint"
-            : "font-medium ui-copy"}
+          customStyle={excluded ? "ui-copy-disabled-faint" : "ui-copy"}
           inTable
         />
       </button>

--- a/web-local/src/lib/components/virtualized-table/core/Cell.svelte
+++ b/web-local/src/lib/components/virtualized-table/core/Cell.svelte
@@ -80,8 +80,8 @@
     : false;
 
   $: barColor = excluded
-    ? "ui-measure-bar-excluded"
-    : "ui-measure-bar-included";
+    ? "bg-gray-200 dark:bg-gray-700"
+    : "bg-blue-200 dark:bg-blue-700";
 
   $: tooltipValue =
     value && STRING_LIKES.has(type) && value.length >= TOOLTIP_STRING_LIMIT
@@ -138,7 +138,9 @@
         <FormattedDataType
           value={formattedValue || value}
           {type}
-          customStyle={excluded ? "ui-copy-disabled-faint" : "ui-copy"}
+          customStyle={excluded
+            ? "font-normal ui-copy-disabled-faint"
+            : "font-normal ui-copy"}
           inTable
         />
       </button>

--- a/web-local/src/lib/components/virtualized-table/core/Cell.svelte
+++ b/web-local/src/lib/components/virtualized-table/core/Cell.svelte
@@ -80,8 +80,8 @@
     : false;
 
   $: barColor = excluded
-    ? "bg-gray-200 dark:bg-gray-700"
-    : "bg-blue-200 dark:bg-blue-700";
+    ? "ui-measure-bar-excluded"
+    : "ui-measure-bar-included";
 
   $: tooltipValue =
     value && STRING_LIKES.has(type) && value.length >= TOOLTIP_STRING_LIMIT

--- a/web-local/src/lib/components/virtualized-table/core/Cell.svelte
+++ b/web-local/src/lib/components/virtualized-table/core/Cell.svelte
@@ -81,12 +81,20 @@
 
   $: barColor = excluded
     ? "ui-measure-bar-excluded"
+    : rowSelected
+    ? "ui-measure-bar-included-selected"
     : "ui-measure-bar-included";
 
   $: tooltipValue =
     value && STRING_LIKES.has(type) && value.length >= TOOLTIP_STRING_LIMIT
       ? value?.slice(0, TOOLTIP_STRING_LIMIT) + "..."
       : value;
+
+  $: formattedDataTypeStyle = excluded
+    ? "font-normal ui-copy-disabled-faint"
+    : rowSelected
+    ? "font-normal ui-copy-strong"
+    : "font-normal ui-copy";
 </script>
 
 <Tooltip location="top" distance={16} suppress={suppressTooltip}>
@@ -138,9 +146,7 @@
         <FormattedDataType
           value={formattedValue || value}
           {type}
-          customStyle={excluded
-            ? "font-normal ui-copy-disabled-faint"
-            : "font-normal ui-copy"}
+          customStyle={formattedDataTypeStyle}
           inTable
         />
       </button>

--- a/web-local/src/lib/components/workspace/explore/leaderboards/DimensionLeaderboardEntry.svelte
+++ b/web-local/src/lib/components/workspace/explore/leaderboards/DimensionLeaderboardEntry.svelte
@@ -34,6 +34,11 @@
     // if this somehow creates an NaN, let's set it to 0.
     renderedBarValue = !isNaN(renderedBarValue) ? renderedBarValue : 0;
   }
+  $: barColor = excluded
+    ? "ui-measure-bar-excluded"
+    : active
+    ? "ui-measure-bar-included-selected"
+    : "ui-measure-bar-included";
 </script>
 
 <Tooltip location="right">
@@ -42,7 +47,7 @@
     isActive={active}
     {excluded}
     on:click
-    color={excluded ? "ui-measure-bar-excluded" : "ui-measure-bar-included"}
+    color={barColor}
   >
     <!--
       title element
@@ -55,6 +60,7 @@
      -->
     <div
       class:ui-copy={!atLeastOneActive && !loading}
+      class:ui-copy-strong={!excluded && active}
       class:ui-copy-disabled={excluded}
       class="w-full text-ellipsis overflow-hidden whitespace-nowrap"
       slot="title"

--- a/web-local/src/lib/components/workspace/explore/leaderboards/DimensionLeaderboardEntry.svelte
+++ b/web-local/src/lib/components/workspace/explore/leaderboards/DimensionLeaderboardEntry.svelte
@@ -42,9 +42,7 @@
     isActive={active}
     {excluded}
     on:click
-    color={excluded
-      ? "bg-gray-200 dark:bg-gray-600"
-      : "bg-blue-200 dark:bg-blue-700"}
+    color={excluded ? "ui-measure-bar-excluded" : "ui-measure-bar-included"}
   >
     <!--
       title element
@@ -58,20 +56,15 @@
     <div
       class:ui-copy={!atLeastOneActive && !loading}
       class:ui-copy-disabled={excluded}
-      style:font-weight={excluded ? "normal" : "500"}
-      class="leaderboard-list-item-title w-full text-ellipsis overflow-hidden whitespace-nowrap"
+      class="w-full text-ellipsis overflow-hidden whitespace-nowrap"
       slot="title"
     >
       <slot name="label" />
     </div>
     <!-- right-hand metric value -->
-    <div class="leaderboard-list-item-right" slot="right">
+    <div slot="right">
       <!-- {#if !(atLeastOneActive && !active)} -->
-      <div
-        class:ui-copy-disabled={excluded}
-        style:font-weight={excluded ? "normal" : "500"}
-        in:fly={{ duration: 200, y: 4 }}
-      >
+      <div class:ui-copy-disabled={excluded} in:fly={{ duration: 200, y: 4 }}>
         <slot name="right" />
       </div>
       <!-- {/if} -->


### PR DESCRIPTION
@hamilton, here are those adjustments the visual weight of the leaderboards and dimension tables. Subtle changes, but it's a subtle point, and we can push a bit farther on the blue if we want (this is blue-100, but the blue-"75" option is available to try out as well)


- lighten bars
- lighten font weight
- remove refs to undefined styles `leaderboard-list-item-*`
- fix dimension table excluded text -> italic


# leaderboard
after:
![image](https://user-images.githubusercontent.com/2380975/202036285-d801c332-a37c-431a-8983-5362b8379821.png)


before:
![image](https://user-images.githubusercontent.com/2380975/202036373-68580efb-f495-4589-bbac-f43054112868.png)


# dimension table

after:
![image](https://user-images.githubusercontent.com/2380975/202037329-ee69a5f9-05d3-4505-901e-b8d97df01078.png)


before:
![image](https://user-images.githubusercontent.com/2380975/202036728-66064fc4-c797-43d4-a411-79373aa78454.png)


