### PR TITLE
fixes text wrapping within "edit metrics" button

### DIFF
--- a/web-local/src/lib/components/workspace/explore/ExploreHeader.svelte
+++ b/web-local/src/lib/components/workspace/explore/ExploreHeader.svelte
@@ -68,11 +68,9 @@
       </div>
     </h1>
     <!-- top right CTAs -->
-    <div>
+    <div style="flex-shrink: 0;">
       <Button type="secondary" on:click={() => viewMetrics(metricsDefId)}>
-        <div class="flex items-center gap-x-2">
-          Edit Metrics <MetricsIcon size="16px" />
-        </div>
+        Edit Metrics <MetricsIcon size="16px" />
       </Button>
     </div>
   </div>

--- a/web-local/src/lib/components/workspace/explore/ExploreHeader.svelte
+++ b/web-local/src/lib/components/workspace/explore/ExploreHeader.svelte
@@ -71,7 +71,7 @@
     <div>
       <Button type="secondary" on:click={() => viewMetrics(metricsDefId)}>
         <div class="flex items-center gap-x-2">
-          Edit Metrics <MetricsIcon />
+          Edit Metrics <MetricsIcon size="16px" />
         </div>
       </Button>
     </div>


### PR DESCRIPTION
also adjusts icon size from 1 rem to 16px to match "go to dashboard" button

addresses part of #1183, but the button can still be pushed off the screen when the window is narrow