### PR TITLE
Skip cleanup to find binaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -112,7 +112,7 @@ jobs:
           - rilldata/rill-macos-x64
           - rilldata/rill-linux-x64
           - rilldata/rill-win-x64.exe
-        cleanup: false
+        skip_cleanup: true
         on:
           tags: true
 


### PR DESCRIPTION
to attach to github release