### PR TITLE
support date columns for time range summary api

### DIFF
--- a/runtime/server/column_api.go
+++ b/runtime/server/column_api.go
@@ -13,7 +13,7 @@ import (
 	"github.com/rilldata/rill/runtime/drivers"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 const defaultK = 50
@@ -386,7 +386,7 @@ func (s *Server) GetRugHistogram(ctx context.Context, request *runtimev1.GetRugH
 	outlierPseudoBucketSize := 500
 	selectColumn := fmt.Sprintf("%s::DOUBLE", sanitizedColumnName)
 
-	sql := fmt.Sprintf(`WITH data_table AS (
+	rugSql := fmt.Sprintf(`WITH data_table AS (
             SELECT %[1]s as %[2]s
             FROM %[3]s
             WHERE %[2]s IS NOT NULL
@@ -447,7 +447,7 @@ func (s *Server) GetRugHistogram(ctx context.Context, request *runtimev1.GetRugH
           WHERE present=true`, selectColumn, sanitizedColumnName, request.TableName, outlierPseudoBucketSize)
 
 	outlierResults, err := s.query(ctx, request.InstanceId, &drivers.Statement{
-		Query: sql,
+		Query: rugSql,
 	})
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
@@ -494,17 +494,33 @@ func (s *Server) GetTimeRangeSummary(ctx context.Context, request *runtimev1.Get
 		}
 		summary.Min = timestamppb.New(rowMap["min"].(time.Time))
 		summary.Max = timestamppb.New(rowMap["max"].(time.Time))
-		interval := rowMap["interval"].(duckdb.Interval)
-		summary.Interval = new(runtimev1.TimeRangeSummary_Interval)
-		summary.Interval.Days = interval.Days
-		summary.Interval.Months = interval.Months
-		summary.Interval.Micros = interval.Micros
-
+		summary.Interval, err = handleInterval(rowMap["interval"])
+		if err != nil {
+			return nil, err
+		}
 		return &runtimev1.GetTimeRangeSummaryResponse{
 			TimeRangeSummary: summary,
 		}, nil
 	}
 	return nil, status.Error(codes.Internal, "no rows returned")
+}
+
+func handleInterval(interval any) (*runtimev1.TimeRangeSummary_Interval, error) {
+	switch interval.(type) {
+	case duckdb.Interval:
+		duckDbInterval := interval.(duckdb.Interval)
+		var result = new(runtimev1.TimeRangeSummary_Interval)
+		result.Days = duckDbInterval.Days
+		result.Months = duckDbInterval.Months
+		result.Micros = duckDbInterval.Micros
+		return result, nil
+	case int64:
+		days := interval.(int64)
+		var result = new(runtimev1.TimeRangeSummary_Interval)
+		result.Days = int32(days)
+		return result, nil
+	}
+	return nil, fmt.Errorf("cannot handle interval type %T", interval)
 }
 
 func (s *Server) GetCardinalityOfColumn(ctx context.Context, request *runtimev1.GetCardinalityOfColumnRequest) (*runtimev1.GetCardinalityOfColumnResponse, error) {

--- a/runtime/server/column_api.go
+++ b/runtime/server/column_api.go
@@ -515,6 +515,7 @@ func handleInterval(interval any) (*runtimev1.TimeRangeSummary_Interval, error) 
 		result.Micros = duckDbInterval.Micros
 		return result, nil
 	case int64:
+		// for date type column interval is difference in num days for two dates
 		days := interval.(int64)
 		var result = new(runtimev1.TimeRangeSummary_Interval)
 		result.Days = int32(days)

--- a/runtime/server/column_api_test.go
+++ b/runtime/server/column_api_test.go
@@ -148,7 +148,7 @@ func TestServer_GetTimeRangeSummary(t *testing.T) {
 func TestServer_GetTimeRangeSummary_Date_Column(t *testing.T) {
 	server, instanceId := getTestServerWithData(t)
 
-	// Get Time Range Summary works with timestamp columns
+	// Test Get Time Range Summary with Date type column
 	res, err := server.GetTimeRangeSummary(context.Background(), &runtimev1.GetTimeRangeSummaryRequest{InstanceId: instanceId, TableName: "test", ColumnName: "dates"})
 	require.NoError(t, err)
 	require.NotNil(t, res)

--- a/runtime/server/column_api_test.go
+++ b/runtime/server/column_api_test.go
@@ -145,6 +145,20 @@ func TestServer_GetTimeRangeSummary(t *testing.T) {
 	require.Equal(t, int64(0), res.TimeRangeSummary.Interval.Micros)
 }
 
+func TestServer_GetTimeRangeSummary_Date_Column(t *testing.T) {
+	server, instanceId := getTestServerWithData(t)
+
+	// Get Time Range Summary works with timestamp columns
+	res, err := server.GetTimeRangeSummary(context.Background(), &runtimev1.GetTimeRangeSummaryRequest{InstanceId: instanceId, TableName: "test", ColumnName: "dates"})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.Equal(t, parseTime(t, "2007-04-01T00:00:00Z"), res.TimeRangeSummary.Min)
+	require.Equal(t, parseTime(t, "2011-06-30T00:00:00Z"), res.TimeRangeSummary.Max)
+	require.Equal(t, int32(0), res.TimeRangeSummary.Interval.Months)
+	require.Equal(t, int32(1551), res.TimeRangeSummary.Interval.Days)
+	require.Equal(t, int64(0), res.TimeRangeSummary.Interval.Micros)
+}
+
 func parseTime(tst *testing.T, t string) *timestamppb.Timestamp {
 	ts, err := time.Parse(time.RFC3339, t)
 	require.NoError(tst, err)

--- a/runtime/server/server_test.go
+++ b/runtime/server/server_test.go
@@ -40,15 +40,15 @@ func getTestServerWithData(t *testing.T) (*Server, string) {
 	_, err := server.QueryDirect(context.Background(), &runtimev1.QueryDirectRequest{
 		InstanceId: instanceId,
 		Sql: `CREATE TABLE test AS (
-			SELECT 'abc' AS col, 1 AS val, TIMESTAMP '2022-11-01 00:00:00' AS times 
+			SELECT 'abc' AS col, 1 AS val, TIMESTAMP '2022-11-01 00:00:00' AS times, DATE '2007-04-01' AS dates
 			UNION ALL 
-			SELECT 'def' AS col, 5 AS val, TIMESTAMP '2022-11-02 00:00:00' AS times
+			SELECT 'def' AS col, 5 AS val, TIMESTAMP '2022-11-02 00:00:00' AS times, DATE '2009-06-01' AS dates
 			UNION ALL 
-			SELECT 'abc' AS col, 3 AS val, TIMESTAMP '2022-11-03 00:00:00' AS times
+			SELECT 'abc' AS col, 3 AS val, TIMESTAMP '2022-11-03 00:00:00' AS times, DATE '2010-04-11' AS dates
 			UNION ALL 
-			SELECT null AS col, 1 AS val, TIMESTAMP '2022-11-03 00:00:00' AS times
+			SELECT null AS col, 1 AS val, TIMESTAMP '2022-11-03 00:00:00' AS times, DATE '2010-11-21' AS dates
 			UNION ALL 
-			SELECT 12 AS col, 1 AS val, TIMESTAMP '2022-11-03 00:00:00' AS times
+			SELECT 12 AS col, 1 AS val, TIMESTAMP '2022-11-03 00:00:00' AS times, DATE '2011-06-30' AS dates
 			)`,
 		Args: nil,
 	})


### PR DESCRIPTION
Fix error for Date type columns. Difference of two Dates is a BigInt in duckdb 
```
panic caught: interface conversion: interface {} is int64, not duckdb.Interval
```