### PR TITLE
custom error to code handler

### DIFF
--- a/runtime/drivers/registry.go
+++ b/runtime/drivers/registry.go
@@ -7,8 +7,8 @@ import (
 
 // RegistryStore is implemented by drivers capable of storing and looking up instances and repos
 type RegistryStore interface {
-	FindInstances(ctx context.Context) []*Instance
-	FindInstance(ctx context.Context, id string) (*Instance, bool)
+	FindInstances(ctx context.Context) ([]*Instance, error)
+	FindInstance(ctx context.Context, id string) (*Instance, bool, error)
 	CreateInstance(ctx context.Context, instance *Instance) error
 	DeleteInstance(ctx context.Context, id string) error
 }

--- a/runtime/drivers/registry.go
+++ b/runtime/drivers/registry.go
@@ -8,7 +8,7 @@ import (
 // RegistryStore is implemented by drivers capable of storing and looking up instances and repos
 type RegistryStore interface {
 	FindInstances(ctx context.Context) ([]*Instance, error)
-	FindInstance(ctx context.Context, id string) (*Instance, bool, error)
+	FindInstance(ctx context.Context, id string) (*Instance, error)
 	CreateInstance(ctx context.Context, instance *Instance) error
 	DeleteInstance(ctx context.Context, id string) error
 }

--- a/runtime/drivers/registry_test.go
+++ b/runtime/drivers/registry_test.go
@@ -32,8 +32,8 @@ func testRegistry(t *testing.T, reg drivers.RegistryStore) {
 	require.Greater(t, time.Minute, time.Since(inst.CreatedOn))
 	require.Greater(t, time.Minute, time.Since(inst.UpdatedOn))
 
-	res, found, err := reg.FindInstance(ctx, inst.ID)
-	require.True(t, found)
+	res, err := reg.FindInstance(ctx, inst.ID)
+	require.NoError(t, err)
 	require.Equal(t, inst.OLAPDriver, res.OLAPDriver)
 	require.Equal(t, inst.OLAPDSN, res.OLAPDSN)
 	require.Equal(t, inst.RepoDriver, res.RepoDriver)
@@ -49,8 +49,8 @@ func testRegistry(t *testing.T, reg drivers.RegistryStore) {
 	err = reg.DeleteInstance(ctx, inst.ID)
 	require.NoError(t, err)
 
-	_, found, err = reg.FindInstance(ctx, inst.ID)
-	require.False(t, found)
+	_, err = reg.FindInstance(ctx, inst.ID)
+	require.EqualError(t, err, drivers.ErrNotFound.Error())
 
 	insts, err = reg.FindInstances(ctx)
 	require.Equal(t, 1, len(insts))

--- a/runtime/drivers/registry_test.go
+++ b/runtime/drivers/registry_test.go
@@ -32,7 +32,7 @@ func testRegistry(t *testing.T, reg drivers.RegistryStore) {
 	require.Greater(t, time.Minute, time.Since(inst.CreatedOn))
 	require.Greater(t, time.Minute, time.Since(inst.UpdatedOn))
 
-	res, found := reg.FindInstance(ctx, inst.ID)
+	res, found, err := reg.FindInstance(ctx, inst.ID)
 	require.True(t, found)
 	require.Equal(t, inst.OLAPDriver, res.OLAPDriver)
 	require.Equal(t, inst.OLAPDSN, res.OLAPDSN)
@@ -43,15 +43,15 @@ func testRegistry(t *testing.T, reg drivers.RegistryStore) {
 	err = reg.CreateInstance(ctx, &drivers.Instance{OLAPDriver: "druid"})
 	require.NoError(t, err)
 
-	insts := reg.FindInstances(ctx)
+	insts, err := reg.FindInstances(ctx)
 	require.Equal(t, 2, len(insts))
 
 	err = reg.DeleteInstance(ctx, inst.ID)
 	require.NoError(t, err)
 
-	_, found = reg.FindInstance(ctx, inst.ID)
+	_, found, err = reg.FindInstance(ctx, inst.ID)
 	require.False(t, found)
 
-	insts = reg.FindInstances(ctx)
+	insts, err = reg.FindInstances(ctx)
 	require.Equal(t, 1, len(insts))
 }

--- a/runtime/drivers/sqlite/registry.go
+++ b/runtime/drivers/sqlite/registry.go
@@ -15,15 +15,15 @@ func (c *connection) FindInstances(ctx context.Context) ([]*drivers.Instance, er
 }
 
 // FindInstance implements drivers.RegistryStore
-func (c *connection) FindInstance(ctx context.Context, id string) (*drivers.Instance, bool, error) {
+func (c *connection) FindInstance(ctx context.Context, id string) (*drivers.Instance, error) {
 	is, err := c.findInstances(ctx, "WHERE id = $1", id)
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
 	if len(is) == 0 {
-		return nil, false, nil
+		return nil, drivers.ErrNotFound
 	}
-	return is[0], true, nil
+	return is[0], nil
 }
 
 func (c *connection) findInstances(ctx context.Context, whereClause string, args ...any) ([]*drivers.Instance, error) {

--- a/runtime/server/catalog.go
+++ b/runtime/server/catalog.go
@@ -46,12 +46,12 @@ func (s *Server) GetCatalogEntry(ctx context.Context, req *runtimev1.GetCatalogE
 // TriggerRefresh implements RuntimeService
 func (s *Server) TriggerRefresh(ctx context.Context, req *runtimev1.TriggerRefreshRequest) (*runtimev1.TriggerRefreshResponse, error) {
 	registry, _ := s.metastore.RegistryStore()
-	inst, found, err := registry.FindInstance(ctx, req.InstanceId)
+	inst, err := registry.FindInstance(ctx, req.InstanceId)
 	if err != nil {
+		if err == drivers.ErrNotFound {
+			return nil, status.Error(codes.InvalidArgument, "instance not found")
+		}
 		return nil, err
-	}
-	if !found {
-		return nil, status.Error(codes.InvalidArgument, "instance not found")
 	}
 
 	catalog, err := s.openCatalog(ctx, inst)
@@ -114,12 +114,12 @@ func (s *Server) TriggerSync(ctx context.Context, req *runtimev1.TriggerSyncRequ
 	// TODO: move to using reconcile
 	// Get instance
 	registry, _ := s.metastore.RegistryStore()
-	inst, found, err := registry.FindInstance(ctx, req.InstanceId)
+	inst, err := registry.FindInstance(ctx, req.InstanceId)
 	if err != nil {
+		if err == drivers.ErrNotFound {
+			return nil, status.Error(codes.InvalidArgument, "instance not found")
+		}
 		return nil, err
-	}
-	if !found {
-		return nil, status.Error(codes.InvalidArgument, "instance not found")
 	}
 
 	// Get OLAP

--- a/runtime/server/catalog.go
+++ b/runtime/server/catalog.go
@@ -46,7 +46,10 @@ func (s *Server) GetCatalogEntry(ctx context.Context, req *runtimev1.GetCatalogE
 // TriggerRefresh implements RuntimeService
 func (s *Server) TriggerRefresh(ctx context.Context, req *runtimev1.TriggerRefreshRequest) (*runtimev1.TriggerRefreshResponse, error) {
 	registry, _ := s.metastore.RegistryStore()
-	inst, found := registry.FindInstance(ctx, req.InstanceId)
+	inst, found, err := registry.FindInstance(ctx, req.InstanceId)
+	if err != nil {
+		return nil, err
+	}
 	if !found {
 		return nil, status.Error(codes.InvalidArgument, "instance not found")
 	}
@@ -111,7 +114,10 @@ func (s *Server) TriggerSync(ctx context.Context, req *runtimev1.TriggerSyncRequ
 	// TODO: move to using reconcile
 	// Get instance
 	registry, _ := s.metastore.RegistryStore()
-	inst, found := registry.FindInstance(ctx, req.InstanceId)
+	inst, found, err := registry.FindInstance(ctx, req.InstanceId)
+	if err != nil {
+		return nil, err
+	}
 	if !found {
 		return nil, status.Error(codes.InvalidArgument, "instance not found")
 	}

--- a/runtime/server/column_api.go
+++ b/runtime/server/column_api.go
@@ -39,7 +39,7 @@ func (s *Server) GetTopK(ctx context.Context, topKRequest *runtimev1.GetTopKRequ
 		Query: topKSql,
 	})
 	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, err
 	}
 	defer rows.Close()
 
@@ -51,7 +51,7 @@ func (s *Server) GetTopK(ctx context.Context, topKRequest *runtimev1.GetTopKRequ
 		var value sql.NullString
 		err = rows.Scan(&value, &topKEntry.Count)
 		if err != nil {
-			return nil, status.Error(codes.Internal, err.Error())
+			return nil, err
 		}
 		if value.Valid {
 			topKEntry.Value = structpb.NewStringValue(value.String)
@@ -79,7 +79,7 @@ func (s *Server) GetNullCount(ctx context.Context, nullCountRequest *runtimev1.G
 		Query: nullCountSql,
 	})
 	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, err
 	}
 	defer rows.Close()
 
@@ -87,7 +87,7 @@ func (s *Server) GetNullCount(ctx context.Context, nullCountRequest *runtimev1.G
 	for rows.Next() {
 		err = rows.Scan(&count)
 		if err != nil {
-			return nil, status.Error(codes.Internal, err.Error())
+			return nil, err
 		}
 	}
 
@@ -112,7 +112,7 @@ func (s *Server) GetDescriptiveStatistics(ctx context.Context, request *runtimev
 		Query: descriptiveStatisticsSql,
 	})
 	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, err
 	}
 	defer rows.Close()
 
@@ -120,7 +120,7 @@ func (s *Server) GetDescriptiveStatistics(ctx context.Context, request *runtimev
 	for rows.Next() {
 		err = rows.Scan(&stats.Min, &stats.Q25, &stats.Q50, &stats.Q75, &stats.Max, &stats.Mean, &stats.Sd)
 		if err != nil {
-			return nil, status.Error(codes.Internal, err.Error())
+			return nil, err
 		}
 	}
 	resp := &runtimev1.NumericSummary{
@@ -165,13 +165,13 @@ func (s *Server) EstimateSmallestTimeGrain(ctx context.Context, request *runtime
 		Query: fmt.Sprintf("SELECT count(*) as c FROM %s", request.TableName),
 	})
 	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, err
 	}
 	var totalRows int64
 	for rows.Next() {
 		err := rows.Scan(&totalRows)
 		if err != nil {
-			return nil, status.Error(codes.Internal, err.Error())
+			return nil, err
 		}
 	}
 	rows.Close()
@@ -223,7 +223,7 @@ func (s *Server) EstimateSmallestTimeGrain(ctx context.Context, request *runtime
 		Query: estimateSql,
 	})
 	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, err
 	}
 	defer rows.Close()
 
@@ -231,7 +231,7 @@ func (s *Server) EstimateSmallestTimeGrain(ctx context.Context, request *runtime
 	for rows.Next() {
 		err := rows.Scan(&timeGrainString)
 		if err != nil {
-			return nil, status.Error(codes.Internal, err.Error())
+			return nil, err
 		}
 	}
 	var timeGrain *runtimev1.EstimateSmallestTimeGrainResponse
@@ -280,14 +280,14 @@ func (s *Server) GetNumericHistogram(ctx context.Context, request *runtimev1.Get
 		Query: sql,
 	})
 	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, err
 	}
 	defer rows.Close()
 	var iqr, count, rangeVal float64
 	for rows.Next() {
 		err = rows.Scan(&iqr, &count, &rangeVal)
 		if err != nil {
-			return nil, status.Error(codes.Internal, err.Error())
+			return nil, err
 		}
 	}
 	var bucketSize float64
@@ -358,7 +358,7 @@ func (s *Server) GetNumericHistogram(ctx context.Context, request *runtimev1.Get
 		Query: histogramSql,
 	})
 	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, err
 	}
 	defer histogramRows.Close()
 	histogramBins := make([]*runtimev1.NumericHistogramBins_Bin, 0)
@@ -366,7 +366,7 @@ func (s *Server) GetNumericHistogram(ctx context.Context, request *runtimev1.Get
 		bin := &runtimev1.NumericHistogramBins_Bin{}
 		err = histogramRows.Scan(&bin.Bucket, &bin.Low, &bin.High, &bin.Count)
 		if err != nil {
-			return nil, status.Error(codes.Internal, err.Error())
+			return nil, err
 		}
 		histogramBins = append(histogramBins, bin)
 	}
@@ -450,7 +450,7 @@ func (s *Server) GetRugHistogram(ctx context.Context, request *runtimev1.GetRugH
 		Query: rugSql,
 	})
 	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, err
 	}
 	defer outlierResults.Close()
 
@@ -459,7 +459,7 @@ func (s *Server) GetRugHistogram(ctx context.Context, request *runtimev1.GetRugH
 		outlier := &runtimev1.NumericOutliers_Outlier{}
 		err = outlierResults.Scan(&outlier.Bucket, &outlier.Low, &outlier.High, &outlier.Present)
 		if err != nil {
-			return nil, status.Error(codes.Internal, err.Error())
+			return nil, err
 		}
 		outlierBins = append(outlierBins, outlier)
 	}
@@ -482,7 +482,7 @@ func (s *Server) GetTimeRangeSummary(ctx context.Context, request *runtimev1.Get
 			sanitizedColumnName, request.TableName),
 	})
 	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, err
 	}
 	defer rows.Close()
 	if rows.Next() {
@@ -530,14 +530,14 @@ func (s *Server) GetCardinalityOfColumn(ctx context.Context, request *runtimev1.
 		Query: fmt.Sprintf("SELECT approx_count_distinct(%s) as count from %s", sanitizedColumnName, request.TableName),
 	})
 	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, err
 	}
 	defer rows.Close()
 	var count float64
 	for rows.Next() {
 		err = rows.Scan(&count)
 		if err != nil {
-			return nil, status.Error(codes.Internal, err.Error())
+			return nil, err
 		}
 		return &runtimev1.GetCardinalityOfColumnResponse{
 			CategoricalSummary: &runtimev1.CategoricalSummary{

--- a/runtime/server/instances.go
+++ b/runtime/server/instances.go
@@ -12,7 +12,10 @@ import (
 // ListInstances implements RuntimeService
 func (s *Server) ListInstances(ctx context.Context, req *runtimev1.ListInstancesRequest) (*runtimev1.ListInstancesResponse, error) {
 	registry, _ := s.metastore.RegistryStore()
-	instances := registry.FindInstances(ctx)
+	instances, err := registry.FindInstances(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	pbs := make([]*runtimev1.Instance, len(instances))
 	for i, inst := range instances {
@@ -25,7 +28,10 @@ func (s *Server) ListInstances(ctx context.Context, req *runtimev1.ListInstances
 // GetInstance implements RuntimeService
 func (s *Server) GetInstance(ctx context.Context, req *runtimev1.GetInstanceRequest) (*runtimev1.GetInstanceResponse, error) {
 	registry, _ := s.metastore.RegistryStore()
-	inst, found := registry.FindInstance(ctx, req.InstanceId)
+	inst, found, err := registry.FindInstance(ctx, req.InstanceId)
+	if err != nil {
+		return nil, err
+	}
 	if !found {
 		return nil, status.Error(codes.NotFound, "instance not found")
 	}

--- a/runtime/server/instances.go
+++ b/runtime/server/instances.go
@@ -28,12 +28,12 @@ func (s *Server) ListInstances(ctx context.Context, req *runtimev1.ListInstances
 // GetInstance implements RuntimeService
 func (s *Server) GetInstance(ctx context.Context, req *runtimev1.GetInstanceRequest) (*runtimev1.GetInstanceResponse, error) {
 	registry, _ := s.metastore.RegistryStore()
-	inst, found, err := registry.FindInstance(ctx, req.InstanceId)
+	inst, err := registry.FindInstance(ctx, req.InstanceId)
 	if err != nil {
+		if err == drivers.ErrNotFound {
+			return nil, status.Error(codes.InvalidArgument, "instance not found")
+		}
 		return nil, err
-	}
-	if !found {
-		return nil, status.Error(codes.NotFound, "instance not found")
 	}
 
 	return &runtimev1.GetInstanceResponse{

--- a/runtime/server/queries.go
+++ b/runtime/server/queries.go
@@ -77,12 +77,12 @@ func (s *Server) QueryDirect(ctx context.Context, req *runtimev1.QueryDirectRequ
 
 func (s *Server) query(ctx context.Context, instanceID string, stmt *drivers.Statement) (*drivers.Result, error) {
 	registry, _ := s.metastore.RegistryStore()
-	inst, found, err := registry.FindInstance(ctx, instanceID)
+	inst, err := registry.FindInstance(ctx, instanceID)
 	if err != nil {
+		if err == drivers.ErrNotFound {
+			return nil, status.Error(codes.InvalidArgument, "instance not found")
+		}
 		return nil, err
-	}
-	if !found {
-		return nil, status.Error(codes.NotFound, "instance not found")
 	}
 
 	conn, err := s.connCache.openAndMigrate(ctx, inst.ID, inst.OLAPDriver, inst.OLAPDSN)

--- a/runtime/server/queries.go
+++ b/runtime/server/queries.go
@@ -77,14 +77,17 @@ func (s *Server) QueryDirect(ctx context.Context, req *runtimev1.QueryDirectRequ
 
 func (s *Server) query(ctx context.Context, instanceID string, stmt *drivers.Statement) (*drivers.Result, error) {
 	registry, _ := s.metastore.RegistryStore()
-	inst, found := registry.FindInstance(ctx, instanceID)
+	inst, found, err := registry.FindInstance(ctx, instanceID)
+	if err != nil {
+		return nil, err
+	}
 	if !found {
 		return nil, status.Error(codes.NotFound, "instance not found")
 	}
 
 	conn, err := s.connCache.openAndMigrate(ctx, inst.ID, inst.OLAPDriver, inst.OLAPDSN)
 	if err != nil {
-		return nil, status.Error(codes.Unknown, err.Error())
+		return nil, err
 	}
 	olap, _ := conn.OLAPStore()
 

--- a/runtime/server/repos.go
+++ b/runtime/server/repos.go
@@ -16,7 +16,10 @@ import (
 // ListFiles implements RuntimeService
 func (s *Server) ListFiles(ctx context.Context, req *runtimev1.ListFilesRequest) (*runtimev1.ListFilesResponse, error) {
 	registry, _ := s.metastore.RegistryStore()
-	inst, found := registry.FindInstance(ctx, req.InstanceId)
+	inst, found, err := registry.FindInstance(ctx, req.InstanceId)
+	if err != nil {
+		return nil, err
+	}
 	if !found {
 		return nil, status.Error(codes.NotFound, "instance not found")
 	}
@@ -43,7 +46,10 @@ func (s *Server) ListFiles(ctx context.Context, req *runtimev1.ListFilesRequest)
 // GetFile implements RuntimeService
 func (s *Server) GetFile(ctx context.Context, req *runtimev1.GetFileRequest) (*runtimev1.GetFileResponse, error) {
 	registry, _ := s.metastore.RegistryStore()
-	inst, found := registry.FindInstance(ctx, req.InstanceId)
+	inst, found, err := registry.FindInstance(ctx, req.InstanceId)
+	if err != nil {
+		return nil, err
+	}
 	if !found {
 		return nil, status.Error(codes.NotFound, "instance not found")
 	}
@@ -71,7 +77,10 @@ func (s *Server) GetFile(ctx context.Context, req *runtimev1.GetFileRequest) (*r
 // PutFile implements RuntimeService
 func (s *Server) PutFile(ctx context.Context, req *runtimev1.PutFileRequest) (*runtimev1.PutFileResponse, error) {
 	registry, _ := s.metastore.RegistryStore()
-	inst, found := registry.FindInstance(ctx, req.InstanceId)
+	inst, found, err := registry.FindInstance(ctx, req.InstanceId)
+	if err != nil {
+		return nil, err
+	}
 	if !found {
 		return nil, status.Error(codes.NotFound, "instance not found")
 	}
@@ -94,7 +103,10 @@ func (s *Server) PutFile(ctx context.Context, req *runtimev1.PutFileRequest) (*r
 // DeleteFile implements RuntimeService
 func (s *Server) DeleteFile(ctx context.Context, req *runtimev1.DeleteFileRequest) (*runtimev1.DeleteFileResponse, error) {
 	registry, _ := s.metastore.RegistryStore()
-	inst, found := registry.FindInstance(ctx, req.InstanceId)
+	inst, found, err := registry.FindInstance(ctx, req.InstanceId)
+	if err != nil {
+		return nil, err
+	}
 	if !found {
 		return nil, status.Error(codes.NotFound, "instance not found")
 	}
@@ -116,7 +128,10 @@ func (s *Server) DeleteFile(ctx context.Context, req *runtimev1.DeleteFileReques
 // RenameFile implements RuntimeService
 func (s *Server) RenameFile(ctx context.Context, req *runtimev1.RenameFileRequest) (*runtimev1.RenameFileResponse, error) {
 	registry, _ := s.metastore.RegistryStore()
-	inst, found := registry.FindInstance(ctx, req.InstanceId)
+	inst, found, err := registry.FindInstance(ctx, req.InstanceId)
+	if err != nil {
+		return nil, err
+	}
 	if !found {
 		return nil, status.Error(codes.NotFound, "instance not found")
 	}
@@ -145,7 +160,11 @@ func (s *Server) UploadMultipartFile(w http.ResponseWriter, req *http.Request, p
 	}
 
 	registry, _ := s.metastore.RegistryStore()
-	inst, found := registry.FindInstance(ctx, pathParams["instance_id"])
+	inst, found, err := registry.FindInstance(ctx, pathParams["instance_id"])
+	if err != nil {
+		http.Error(w, "unexpected error", http.StatusInternalServerError)
+		return
+	}
 	if !found {
 		http.Error(w, "instance not found", http.StatusBadRequest)
 		return

--- a/runtime/server/repos.go
+++ b/runtime/server/repos.go
@@ -16,12 +16,12 @@ import (
 // ListFiles implements RuntimeService
 func (s *Server) ListFiles(ctx context.Context, req *runtimev1.ListFilesRequest) (*runtimev1.ListFilesResponse, error) {
 	registry, _ := s.metastore.RegistryStore()
-	inst, found, err := registry.FindInstance(ctx, req.InstanceId)
+	inst, err := registry.FindInstance(ctx, req.InstanceId)
 	if err != nil {
+		if err == drivers.ErrNotFound {
+			return nil, status.Error(codes.InvalidArgument, "instance not found")
+		}
 		return nil, err
-	}
-	if !found {
-		return nil, status.Error(codes.NotFound, "instance not found")
 	}
 
 	conn, err := drivers.Open(inst.RepoDriver, inst.RepoDSN)
@@ -46,12 +46,12 @@ func (s *Server) ListFiles(ctx context.Context, req *runtimev1.ListFilesRequest)
 // GetFile implements RuntimeService
 func (s *Server) GetFile(ctx context.Context, req *runtimev1.GetFileRequest) (*runtimev1.GetFileResponse, error) {
 	registry, _ := s.metastore.RegistryStore()
-	inst, found, err := registry.FindInstance(ctx, req.InstanceId)
+	inst, err := registry.FindInstance(ctx, req.InstanceId)
 	if err != nil {
+		if err == drivers.ErrNotFound {
+			return nil, status.Error(codes.InvalidArgument, "instance not found")
+		}
 		return nil, err
-	}
-	if !found {
-		return nil, status.Error(codes.NotFound, "instance not found")
 	}
 
 	conn, err := drivers.Open(inst.RepoDriver, inst.RepoDSN)
@@ -77,12 +77,12 @@ func (s *Server) GetFile(ctx context.Context, req *runtimev1.GetFileRequest) (*r
 // PutFile implements RuntimeService
 func (s *Server) PutFile(ctx context.Context, req *runtimev1.PutFileRequest) (*runtimev1.PutFileResponse, error) {
 	registry, _ := s.metastore.RegistryStore()
-	inst, found, err := registry.FindInstance(ctx, req.InstanceId)
+	inst, err := registry.FindInstance(ctx, req.InstanceId)
 	if err != nil {
+		if err == drivers.ErrNotFound {
+			return nil, status.Error(codes.InvalidArgument, "instance not found")
+		}
 		return nil, err
-	}
-	if !found {
-		return nil, status.Error(codes.NotFound, "instance not found")
 	}
 
 	conn, err := drivers.Open(inst.RepoDriver, inst.RepoDSN)
@@ -103,12 +103,12 @@ func (s *Server) PutFile(ctx context.Context, req *runtimev1.PutFileRequest) (*r
 // DeleteFile implements RuntimeService
 func (s *Server) DeleteFile(ctx context.Context, req *runtimev1.DeleteFileRequest) (*runtimev1.DeleteFileResponse, error) {
 	registry, _ := s.metastore.RegistryStore()
-	inst, found, err := registry.FindInstance(ctx, req.InstanceId)
+	inst, err := registry.FindInstance(ctx, req.InstanceId)
 	if err != nil {
+		if err == drivers.ErrNotFound {
+			return nil, status.Error(codes.InvalidArgument, "instance not found")
+		}
 		return nil, err
-	}
-	if !found {
-		return nil, status.Error(codes.NotFound, "instance not found")
 	}
 
 	conn, err := drivers.Open(inst.RepoDriver, inst.RepoDSN)
@@ -128,12 +128,12 @@ func (s *Server) DeleteFile(ctx context.Context, req *runtimev1.DeleteFileReques
 // RenameFile implements RuntimeService
 func (s *Server) RenameFile(ctx context.Context, req *runtimev1.RenameFileRequest) (*runtimev1.RenameFileResponse, error) {
 	registry, _ := s.metastore.RegistryStore()
-	inst, found, err := registry.FindInstance(ctx, req.InstanceId)
+	inst, err := registry.FindInstance(ctx, req.InstanceId)
 	if err != nil {
+		if err == drivers.ErrNotFound {
+			return nil, status.Error(codes.InvalidArgument, "instance not found")
+		}
 		return nil, err
-	}
-	if !found {
-		return nil, status.Error(codes.NotFound, "instance not found")
 	}
 
 	conn, err := drivers.Open(inst.RepoDriver, inst.RepoDSN)
@@ -160,13 +160,13 @@ func (s *Server) UploadMultipartFile(w http.ResponseWriter, req *http.Request, p
 	}
 
 	registry, _ := s.metastore.RegistryStore()
-	inst, found, err := registry.FindInstance(ctx, pathParams["instance_id"])
+	inst, err := registry.FindInstance(ctx, pathParams["instance_id"])
 	if err != nil {
-		http.Error(w, "unexpected error", http.StatusInternalServerError)
-		return
-	}
-	if !found {
-		http.Error(w, "instance not found", http.StatusBadRequest)
+		if err == drivers.ErrNotFound {
+			http.Error(w, "instance not found", http.StatusBadRequest)
+		} else {
+			http.Error(w, "unexpected error", http.StatusInternalServerError)
+		}
 		return
 	}
 

--- a/runtime/server/server.go
+++ b/runtime/server/server.go
@@ -91,6 +91,7 @@ func (s *Server) ServeHTTP(ctx context.Context) error {
 
 // CustomErrorToCode returns the Code of the error if it is a Status error
 // otherwise use status.FromContextError to determine the Code.
+// Log level for error codes is defined in logging.DefaultServerCodeToLevel
 func CustomErrorToCode(err error) codes.Code {
 	if se, ok := err.(interface {
 		GRPCStatus() *status.Status

--- a/runtime/server/server.go
+++ b/runtime/server/server.go
@@ -3,6 +3,8 @@ package server
 import (
 	"context"
 	"fmt"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"net/http"
 	"time"
 
@@ -54,19 +56,19 @@ func NewServer(opts *ServerOptions, metastore drivers.Connection, logger *zap.Lo
 	}, nil
 }
 
-// Starts the gRPC server
+// ServeGRPC Starts the gRPC server
 func (s *Server) ServeGRPC(ctx context.Context) error {
 	server := grpc.NewServer(
 		grpc.ChainStreamInterceptor(
 			tracing.StreamServerInterceptor(opentracing.InterceptorTracer()),
 			metrics.StreamServerInterceptor(metrics.NewServerMetrics()),
-			logging.StreamServerInterceptor(grpczaplog.InterceptorLogger(s.logger)),
+			logging.StreamServerInterceptor(grpczaplog.InterceptorLogger(s.logger), logging.WithCodes(CustomErrorToCode)),
 			recovery.StreamServerInterceptor(),
 		),
 		grpc.ChainUnaryInterceptor(
 			tracing.UnaryServerInterceptor(opentracing.InterceptorTracer()),
 			metrics.UnaryServerInterceptor(metrics.NewServerMetrics()),
-			logging.UnaryServerInterceptor(grpczaplog.InterceptorLogger(s.logger)),
+			logging.UnaryServerInterceptor(grpczaplog.InterceptorLogger(s.logger), logging.WithCodes(CustomErrorToCode)),
 			recovery.UnaryServerInterceptor(),
 		),
 	)
@@ -87,7 +89,19 @@ func (s *Server) ServeHTTP(ctx context.Context) error {
 	return graceful.ServeHTTP(ctx, server, s.opts.HTTPPort)
 }
 
-// HTTP handler serving REST gateway
+// CustomErrorToCode returns the Code of the error if it is a Status error
+// otherwise use status.FromContextError to determine the Code.
+func CustomErrorToCode(err error) codes.Code {
+	if se, ok := err.(interface {
+		GRPCStatus() *status.Status
+	}); ok {
+		return se.GRPCStatus().Code()
+	}
+	contextStatus := status.FromContextError(err)
+	return contextStatus.Code()
+}
+
+// HTTPHandler HTTP handler serving REST gateway
 func (s *Server) HTTPHandler(ctx context.Context) (http.Handler, error) {
 	// Create REST gateway
 	mux := gateway.NewServeMux()

--- a/runtime/server/services.go
+++ b/runtime/server/services.go
@@ -36,12 +36,12 @@ func (c *servicesCache) createCatalogService(ctx context.Context, s *Server, ins
 	}
 
 	registry, _ := s.metastore.RegistryStore()
-	inst, found, err := registry.FindInstance(ctx, instId)
+	inst, err := registry.FindInstance(ctx, instId)
 	if err != nil {
+		if err == drivers.ErrNotFound {
+			return nil, status.Error(codes.InvalidArgument, "instance not found")
+		}
 		return nil, err
-	}
-	if !found {
-		return nil, status.Error(codes.InvalidArgument, "instance not found")
 	}
 
 	olapConn, err := s.connCache.openAndMigrate(ctx, instId, inst.OLAPDriver, inst.OLAPDSN)

--- a/runtime/server/services.go
+++ b/runtime/server/services.go
@@ -36,7 +36,10 @@ func (c *servicesCache) createCatalogService(ctx context.Context, s *Server, ins
 	}
 
 	registry, _ := s.metastore.RegistryStore()
-	inst, found := registry.FindInstance(ctx, instId)
+	inst, found, err := registry.FindInstance(ctx, instId)
+	if err != nil {
+		return nil, err
+	}
 	if !found {
 		return nil, status.Error(codes.InvalidArgument, "instance not found")
 	}


### PR DESCRIPTION
- Context cancelled err mapped to `codes.Canceled` which is logged as Info 
- All status error codes are used as it is and logged as per `DefaultServerCodeToLevel` func in `options.go` file
- Removed `panic` from RegistryStore method implementation to handle context cancelled