### PR TITLE
Filter out empty statement error for models

### DIFF
--- a/web-local/src/lib/application-state-stores/file-artifacts-store.ts
+++ b/web-local/src/lib/application-state-stores/file-artifacts-store.ts
@@ -45,6 +45,14 @@ const fileArtifactsEntitiesReducers = {
     errors.forEach((error) => {
       const filePath = correctFilePath(error.filePath);
 
+      // empty models should not show error
+      if (
+        filePath.endsWith(".sql") &&
+        error.message.endsWith("No statement to prepare!")
+      ) {
+        return;
+      }
+
       if (!errorsForPaths.has(filePath)) {
         errorsForPaths.set(filePath, []);
       }


### PR DESCRIPTION
Empty statement is technically an error in duckdb. But we need not show it in the UI. So filtering it out in the UI before adding to the store.