### PR TITLE
Fix dashboard routing

### DIFF
--- a/web-local/src/lib/errors/messages.ts
+++ b/web-local/src/lib/errors/messages.ts
@@ -1,0 +1,1 @@
+export const CATALOG_ENTRY_NOT_FOUND = "entry not found";

--- a/web-local/src/routes/(application)/dashboard/[name]/+page.svelte
+++ b/web-local/src/routes/(application)/dashboard/[name]/+page.svelte
@@ -6,7 +6,6 @@
 </script>
 
 <svelte:head>
-  <!-- TODO: add the dashboard name to the title -->
   <title>Rill Developer | {metricViewName}</title>
 </svelte:head>
 

--- a/web-local/src/routes/(application)/dashboard/[name]/+page.ts
+++ b/web-local/src/routes/(application)/dashboard/[name]/+page.ts
@@ -1,6 +1,8 @@
-import { runtimeServiceGetCatalogEntry } from "@rilldata/web-common/runtime-client";
+import {
+  runtimeServiceGetCatalogEntry,
+  runtimeServiceGetFile,
+} from "@rilldata/web-common/runtime-client";
 import { runtimeServiceGetConfig } from "@rilldata/web-common/runtime-client/manual-clients";
-import { ExplorerMetricsDefinitionDoesntExist } from "@rilldata/web-local/common/errors/ErrorMessages";
 import { error, redirect } from "@sveltejs/kit";
 
 export const ssr = false;
@@ -10,28 +12,26 @@ export async function load({ params }) {
   const localConfig = await runtimeServiceGetConfig();
 
   try {
-    const dashboardMeta = await runtimeServiceGetCatalogEntry(
+    await runtimeServiceGetFile(
       localConfig.instance_id,
-      params.name
+      `dashboards/${params.name}.yaml`
     );
-
-    const dashboardYAML = dashboardMeta?.entry?.metricsView;
-
-    // check if metrics definition is defined
-    if (dashboardYAML) {
-      return {
-        metricViewName: params.name,
-      };
-    }
   } catch (err) {
-    if (
-      ExplorerMetricsDefinitionDoesntExist.includes(err.message) ||
-      err.message.includes(ExplorerMetricsDefinitionDoesntExist)
-    ) {
+    if (err.response?.data?.message.includes("entry not found")) {
       throw error(404, "Dashboard not found");
-    } else {
-      throw redirect(307, `/dashboard/${params.name}/edit`);
     }
+
+    throw error(err.response?.status || 500, err.message);
   }
-  throw redirect(307, `/dashboard/${params.name}/edit`);
+
+  try {
+    await runtimeServiceGetCatalogEntry(localConfig.instance_id, params.name);
+
+    return {
+      metricViewName: params.name,
+    };
+  } catch (err) {
+    // If the catalog entry doesn't exist, the dashboard config is invalid, so we redirect to the dashboard editor
+    throw redirect(307, `/dashboard/${params.name}/edit`);
+  }
 }

--- a/web-local/src/routes/(application)/dashboard/[name]/+page.ts
+++ b/web-local/src/routes/(application)/dashboard/[name]/+page.ts
@@ -4,6 +4,7 @@ import {
 } from "@rilldata/web-common/runtime-client";
 import { runtimeServiceGetConfig } from "@rilldata/web-common/runtime-client/manual-clients";
 import { error, redirect } from "@sveltejs/kit";
+import { CATALOG_ENTRY_NOT_FOUND } from "../../../../lib/errors/messages";
 
 export const ssr = false;
 
@@ -17,7 +18,7 @@ export async function load({ params }) {
       `dashboards/${params.name}.yaml`
     );
   } catch (err) {
-    if (err.response?.data?.message.includes("entry not found")) {
+    if (err.response?.data?.message.includes(CATALOG_ENTRY_NOT_FOUND)) {
       throw error(404, "Dashboard not found");
     }
 

--- a/web-local/src/routes/(application)/dashboard/[name]/edit/+page.svelte
+++ b/web-local/src/routes/(application)/dashboard/[name]/edit/+page.svelte
@@ -20,8 +20,7 @@
 </script>
 
 <svelte:head>
-  <!-- TODO: add the dashboard name to the title -->
-  <title>Rill Developer</title>
+  <title>Rill Developer | {metricsDefName}</title>
 </svelte:head>
 
 {#if yaml}

--- a/web-local/src/routes/(application)/dashboard/[name]/edit/+page.ts
+++ b/web-local/src/routes/(application)/dashboard/[name]/edit/+page.ts
@@ -4,6 +4,7 @@ import {
 } from "@rilldata/web-common/runtime-client";
 import { runtimeServiceGetConfig } from "@rilldata/web-common/runtime-client/manual-clients";
 import { error } from "@sveltejs/kit";
+import { CATALOG_ENTRY_NOT_FOUND } from "../../../../../lib/errors/messages";
 
 /** @type {import('./$types').PageLoad} */
 export async function load({ params }) {
@@ -15,7 +16,7 @@ export async function load({ params }) {
       `dashboards/${params.name}.yaml`
     );
   } catch (err) {
-    if (err.response?.data?.message.includes("entry not found")) {
+    if (err.response?.data?.message.includes(CATALOG_ENTRY_NOT_FOUND)) {
       throw error(404, "Dashboard not found");
     }
 
@@ -31,7 +32,7 @@ export async function load({ params }) {
   } catch (err) {
     // If the catalog entry doesn't exist, the dashboard config is invalid
     // The component should render the specific error
-    if (err.response?.data?.message.includes("entry not found")) {
+    if (err.response?.data?.message.includes(CATALOG_ENTRY_NOT_FOUND)) {
       return {
         metricsDefName: params.name,
         error: err.message,


### PR DESCRIPTION
Before this PR: navigating to a dashboard with an invalid config would result in a 500 error.

After this PR: navigating to a dashboard with an invalid config redirects to the dashboard configuration page.