### PR TITLE
Making query invalidations non blocking

### DIFF
--- a/web-local/src/lib/components/navigation/models/createModel.ts
+++ b/web-local/src/lib/components/navigation/models/createModel.ts
@@ -28,6 +28,7 @@ export async function createModel(
     },
   });
   fileArtifactsStore.setErrors(resp.affectedPaths, resp.errors);
+  goto(`/model/${newModelName}`);
   invalidateAfterReconcile(queryClient, instanceId, resp);
   if (resp.errors?.length && sql !== "") {
     resp.errors.forEach((error) => {
@@ -36,7 +37,6 @@ export async function createModel(
     throw new Error(resp.errors[0].filePath);
   }
   if (!setAsActive) return;
-  goto(`/model/${newModelName}`);
 }
 
 export async function createModelFromSource(

--- a/web-local/src/lib/components/navigation/sources/createSource.ts
+++ b/web-local/src/lib/components/navigation/sources/createSource.ts
@@ -28,13 +28,13 @@ export async function createSource(
       strict: true,
     },
   });
+  goto(`/source/${tableName}`);
   invalidateAfterReconcile(queryClient, instanceId, resp);
   fileArtifactsStore.setErrors(resp.affectedPaths, resp.errors);
   if (resp.errors.length) {
     // TODO: make sure to get the right error
     return resp.errors;
   }
-  goto(`/source/${tableName}`);
   notifications.send({ message: `Created source ${tableName}` });
   return [];
 }

--- a/web-local/src/lib/svelte-query/actions.ts
+++ b/web-local/src/lib/svelte-query/actions.ts
@@ -43,16 +43,16 @@ export async function renameFileArtifact(
     },
   });
   fileArtifactsStore.setErrors(resp.affectedPaths, resp.errors);
-  goto(getRouteFromName(toName, type), {
-    replaceState: true,
-  });
 
   httpRequestQueue.removeByName(fromName);
   notifications.send({
     message: `Renamed ${getLabel(type)} ${fromName} to ${toName}`,
   });
 
-  return invalidateAfterReconcile(queryClient, instanceId, resp);
+  invalidateAfterReconcile(queryClient, instanceId, resp);
+  goto(getRouteFromName(toName, type), {
+    replaceState: true,
+  });
 }
 
 export async function deleteFileArtifact(
@@ -72,14 +72,14 @@ export async function deleteFileArtifact(
       },
     });
     fileArtifactsStore.setErrors(resp.affectedPaths, resp.errors);
-    if (activeEntity?.name === name) {
-      goto(getRouteFromName(getNextEntityName(names, name), type));
-    }
 
     httpRequestQueue.removeByName(name);
     notifications.send({ message: `Deleted ${getLabel(type)} ${name}` });
 
-    return invalidateAfterReconcile(queryClient, instanceId, resp);
+    invalidateAfterReconcile(queryClient, instanceId, resp);
+    if (activeEntity?.name === name) {
+      goto(getRouteFromName(getNextEntityName(names, name), type));
+    }
   } catch (err) {
     console.error(err);
   }


### PR DESCRIPTION
A few actions post mutations need not wait for query invalidations to finish. This is most apparent when renaming a heavy model.