### PR TITLE
catches empty histogram cases in the UI

### DIFF
--- a/web-local/src/lib/components/data-graphic/marks/HistogramPrimitive.svelte
+++ b/web-local/src/lib/components/data-graphic/marks/HistogramPrimitive.svelte
@@ -77,7 +77,7 @@ it to do any automatic binning of data, which is done server-side.
   );
 </script>
 
-{#if $xScale && $yScale}
+{#if d?.length && $xScale && $yScale}
   <defs>
     <linearGradient id="gradient-{markID}" x1="0" x2="0" y1="0" y2="1">
       <stop offset="5%" stop-color={color} />

--- a/web-local/src/lib/components/data-graphic/utils.ts
+++ b/web-local/src/lib/components/data-graphic/utils.ts
@@ -109,55 +109,52 @@ export function barplotPolyline(
   inflator = 1
 ) {
   if (!data?.length) return [];
-  const path = data
-    //.filter((d) => d[yAccessor])
-    .reduce((pointsPathString, datum, i) => {
-      const low = datum[xLow];
-      const high = datum[xHigh];
-      const count = datum[yAccessor];
+  const path = data.reduce((pointsPathString, datum, i) => {
+    const low = datum[xLow];
+    const high = datum[xHigh];
+    const count = datum[yAccessor];
 
-      const x = X(low) + separator;
+    const x = X(low) + separator;
 
-      const width = Math.max(0.5, X(high) - X(low) - separator * 2);
-      const y = Y(0) * (1 - inflator) + Y(count) * inflator;
+    const width = Math.max(0.5, X(high) - X(low) - separator * 2);
+    const y = Y(0) * (1 - inflator) + Y(count) * inflator;
 
-      const computedHeight = Math.min(
-        Y(0),
-        Y(0) * inflator - Y(count) * inflator
-      );
-      const height = separator > 0 ? computedHeight : 0;
+    const computedHeight = Math.min(
+      Y(0),
+      Y(0) * inflator - Y(count) * inflator
+    );
+    const height = separator > 0 ? computedHeight : 0;
 
-      // do not add zero values here
-      if (count === 0) {
-        return pointsPathString;
-      }
+    // do not add zero values here
+    if (count === 0) {
+      return pointsPathString;
+    }
 
-      let p1 = "";
+    let p1 = "";
 
-      const nextPointIsZero =
-        i < data.length - 1 && data[i + 1][yAccessor] === 0;
+    const nextPointIsZero = i < data.length - 1 && data[i + 1][yAccessor] === 0;
 
-      const lastPointWasZero = i > 0 && data[i - 1][yAccessor] === 0;
+    const lastPointWasZero = i > 0 && data[i - 1][yAccessor] === 0;
 
-      if (separator === 0 && lastPointWasZero) {
-        // we will need to start this thing at 0?
-        p1 = `M${x},${y + computedHeight}`;
-      } else if (separator > 0 || i === 0) {
-        // standard case.
-        p1 = `${i !== 0 ? "M" : ""}${x},${y + height}`;
-      }
+    if (separator === 0 && lastPointWasZero) {
+      // we will need to start this thing at 0?
+      p1 = `M${x},${y + computedHeight}`;
+    } else if (separator > 0 || i === 0) {
+      // standard case.
+      p1 = `${i !== 0 ? "M" : ""}${x},${y + height}`;
+    }
 
-      const p2 = `${x},${y}`;
-      const p3 = `${x + width},${y}`;
+    const p2 = `${x},${y}`;
+    const p3 = `${x + width},${y}`;
 
-      const p4 =
-        separator > 0 || nextPointIsZero
-          ? `${x + width},${y + (separator > 0 ? height : computedHeight)}`
-          : "";
-      const closedBottom = closeBottom ? `${x},${y + height}` : "";
+    const p4 =
+      separator > 0 || nextPointIsZero
+        ? `${x + width},${y + (separator > 0 ? height : computedHeight)}`
+        : "";
+    const closedBottom = closeBottom ? `${x},${y + height}` : "";
 
-      return pointsPathString + `${p1} ${p2} ${p3} ${p4} ${closedBottom} `;
-    }, " ");
+    return pointsPathString + `${p1} ${p2} ${p3} ${p4} ${closedBottom} `;
+  }, " ");
   return (
     `M${X(data[0][xLow]) + separator},${Y(0)} ` +
     path +

--- a/web-local/src/lib/components/data-graphic/utils.ts
+++ b/web-local/src/lib/components/data-graphic/utils.ts
@@ -108,6 +108,7 @@ export function barplotPolyline(
   closeBottom = false,
   inflator = 1
 ) {
+  if (!data?.length) return [];
   const path = data
     //.filter((d) => d[yAccessor])
     .reduce((pointsPathString, datum, i) => {


### PR DESCRIPTION
This should fix a variety of bugs relating to modeling. The `HistogramPrimitive.svelte` component was not handling empty arrays, which is very common when you filter out all data in a result set.