### PR TITLE
demo: paste URL to create source and import

### DIFF
--- a/web-local/src/lib/components/CmdVSource.svelte
+++ b/web-local/src/lib/components/CmdVSource.svelte
@@ -16,6 +16,7 @@
     compileCreateSourceYAML,
     inferSourceName,
   } from "./navigation/sources/sourceUtils";
+  import notificationStore from "./notifications/notificationStore";
 
   const createSourceMutation = useRuntimeServicePutFileAndReconcile();
   const queryClient = useQueryClient();
@@ -61,6 +62,10 @@
           $sourceNames.data,
           false
         );
+        notificationStore.send({
+          message: error.message,
+          type: "error",
+        });
       }
     } catch (err) {
       // no-op

--- a/web-local/src/lib/components/CmdVSource.svelte
+++ b/web-local/src/lib/components/CmdVSource.svelte
@@ -1,0 +1,97 @@
+<script lang="ts">
+  import {
+    useRuntimeServiceDeleteFileAndReconcile,
+    useRuntimeServiceListConnectors,
+    useRuntimeServicePutFileAndReconcile,
+  } from "@rilldata/web-common/runtime-client";
+  import { EntityType } from "@rilldata/web-local/common/data-modeler-state-service/entity-state-service/EntityStateService";
+  import { appStore } from "@rilldata/web-local/lib/application-state-stores/app-store";
+  import { useQueryClient } from "@sveltestack/svelte-query";
+  import { runtimeStore } from "../application-state-stores/application-store";
+  import { overlay } from "../application-state-stores/overlay-store";
+  import { deleteFileArtifact } from "../svelte-query/actions";
+  import { useSourceNames } from "../svelte-query/sources";
+  import { createSource } from "./navigation/sources/createSource";
+  import {
+    compileCreateSourceYAML,
+    inferSourceName,
+  } from "./navigation/sources/sourceUtils";
+
+  const createSourceMutation = useRuntimeServicePutFileAndReconcile();
+  const queryClient = useQueryClient();
+  const listConnectors = useRuntimeServiceListConnectors();
+  const deleteSource = useRuntimeServiceDeleteFileAndReconcile();
+  $: sourceNames = useSourceNames($runtimeStore?.instanceId);
+
+  $: connectors = $listConnectors?.data?.connectors;
+  let waitingOnSourceImport = false;
+  const onRefreshClick = async (connectorType: string, url: string) => {
+    const connector = connectors.find(
+      (connector) => connector.name === connectorType
+    );
+    const tableName = inferSourceName(connector, url);
+    const yaml = compileCreateSourceYAML(
+      { type: connectorType, path: url },
+      connector.name
+    );
+    console.log(tableName, yaml);
+    waitingOnSourceImport = true;
+    let error;
+    try {
+      overlay.set({ title: `Importing ${tableName} from ${url}` });
+      const errors = await createSource(
+        queryClient,
+        $runtimeStore.instanceId,
+        tableName,
+        yaml,
+        $createSourceMutation
+      );
+      error = errors[0];
+      if (!error) {
+        // no-op
+        //dispatch("close");
+      } else {
+        await deleteFileArtifact(
+          queryClient,
+          $runtimeStore?.instanceId,
+          tableName,
+          EntityType.Table,
+          $deleteSource,
+          $appStore.activeEntity,
+          $sourceNames.data,
+          false
+        );
+      }
+    } catch (err) {
+      // no-op
+    }
+    waitingOnSourceImport = false;
+    overlay.set(null);
+  };
+
+  async function handleCmdV(event: KeyboardEvent) {
+    if (document.activeElement !== document.body) {
+      console.log("something focused?", document.activeElement);
+      return;
+    }
+    if (event.metaKey && event.key === "v") {
+      event.preventDefault();
+      console.log("huh");
+      const text = await navigator.clipboard.readText();
+      console.log("Pasted text: ", text);
+      // check if a url
+      if (text.startsWith("https://")) {
+        // treat as remote file
+        await onRefreshClick("https", text);
+      } else if (text.startsWith("gs://")) {
+        // treat as remote file
+        await onRefreshClick("gcs", text);
+      } else if (text.startsWith("s3://")) {
+        // treat as remote file
+        await onRefreshClick("s3", text);
+      }
+    }
+  }
+</script>
+
+<svelte:window on:keydown={handleCmdV} />

--- a/web-local/src/lib/components/layouts/RillDeveloperApplicationLayout.svelte
+++ b/web-local/src/lib/components/layouts/RillDeveloperApplicationLayout.svelte
@@ -20,6 +20,7 @@
   import { createQueryClient } from "@rilldata/web-local/lib/svelte-query/globalQueryClient";
   import { QueryClientProvider } from "@sveltestack/svelte-query";
   import { onMount } from "svelte";
+  import CmdVSource from "../CmdVSource.svelte";
   import BlockingOverlayContainer from "../overlay/BlockingOverlayContainer.svelte";
   import BasicLayout from "./BasicLayout.svelte";
 
@@ -62,6 +63,8 @@
 </script>
 
 <QueryClientProvider client={queryClient}>
+  <CmdVSource />
+
   <div class="body">
     {#if $importOverlayVisible}
       <PreparingImport />


### PR DESCRIPTION
This proof of concept shows a feature where pasting a URL into Rill Developer automatically adds it as a source and imports it. Works natively with https, gcs, and s3.

short demo of the branch. Note that I'm copying and pasting the URL to the dataset.

https://user-images.githubusercontent.com/95735/206879650-d060e9f7-7951-4a2d-b587-d9fdc4475020.mp4

