### PR TITLE
for integer, reduce to integer; for floating points, utilize `justEnoughPrecision`

### DIFF
--- a/web-local/src/lib/components/column-profile/column-types/NumericProfile.svelte
+++ b/web-local/src/lib/components/column-profile/column-types/NumericProfile.svelte
@@ -79,6 +79,7 @@
   />
   <div slot="details" class="pl-10 pr-4 py-4">
     <NumericPlot
+      {type}
       data={$numericHistogram}
       rug={$rug}
       summary={$summary}

--- a/web-local/src/lib/components/column-profile/column-types/details/NumericPlot.svelte
+++ b/web-local/src/lib/components/column-profile/column-types/details/NumericPlot.svelte
@@ -17,6 +17,7 @@
   export let summary;
   export let topK;
   export let totalRows;
+  export let type;
 
   let summaryMode: "summary" | "topk" = "summary";
 
@@ -136,6 +137,7 @@
               q25={summary?.q25}
               q50={summary?.q50}
               q75={summary?.q75}
+              {type}
             />
           </div>
         {:else if summaryMode === "topk"}

--- a/web-local/src/lib/components/column-profile/column-types/details/SummaryNumberPlot.svelte
+++ b/web-local/src/lib/components/column-profile/column-types/details/SummaryNumberPlot.svelte
@@ -4,6 +4,7 @@
     SimpleDataGraphic,
   } from "$lib/components/data-graphic/elements";
   import { INTEGERS } from "@rilldata/web-local/lib/duckdb-data-types";
+  import { justEnoughPrecision } from "@rilldata/web-local/lib/util/formatters";
   import { format } from "d3-format";
   import { DynamicallyPlacedLabel } from "../../../data-graphic/guides";
   export let min;
@@ -15,7 +16,7 @@
   export let rowHeight = 24;
   export let type: string;
 
-  $: formatter = INTEGERS.has(type) ? format(".0r") : format(".4f");
+  $: formatter = INTEGERS.has(type) ? format(".0r") : justEnoughPrecision;
   $: values = [
     { label: "min", value: min, format: formatter },
     { label: "max", value: max, format: formatter },
@@ -29,7 +30,7 @@
     {
       label: "mean",
       value: mean,
-      format: INTEGERS.has(type) ? format(".2f") : format(".4f"),
+      format: justEnoughPrecision,
     },
   ].reverse();
 </script>

--- a/web-local/src/lib/components/column-profile/column-types/details/SummaryNumberPlot.svelte
+++ b/web-local/src/lib/components/column-profile/column-types/details/SummaryNumberPlot.svelte
@@ -3,6 +3,7 @@
     GraphicContext,
     SimpleDataGraphic,
   } from "$lib/components/data-graphic/elements";
+  import { INTEGERS } from "@rilldata/web-local/lib/duckdb-data-types";
   import { format } from "d3-format";
   import { DynamicallyPlacedLabel } from "../../../data-graphic/guides";
   export let min;
@@ -12,14 +13,20 @@
   export let q75;
   export let mean;
   export let rowHeight = 24;
+  export let type: string;
 
+  const formatter = INTEGERS.has(type) ? format(".0r") : format(".4f");
   $: values = [
-    { label: "min", value: min },
-    { label: "max", value: max },
-    { label: "q25", value: q25 },
-    { label: "q50", value: q50 },
-    { label: "q75", value: q75 },
-    { label: "mean", value: mean, format: format(".2f") },
+    { label: "min", value: min, format: formatter },
+    { label: "max", value: max, format: formatter },
+    { label: "q25", value: q25, format: formatter },
+    { label: "q50", value: q50, format: formatter },
+    {
+      label: "q75",
+      value: q75,
+      format: formatter,
+    },
+    { label: "mean", value: mean, format: format(".4f") },
   ].reverse();
 </script>
 

--- a/web-local/src/lib/components/column-profile/column-types/details/SummaryNumberPlot.svelte
+++ b/web-local/src/lib/components/column-profile/column-types/details/SummaryNumberPlot.svelte
@@ -26,7 +26,11 @@
       value: q75,
       format: formatter,
     },
-    { label: "mean", value: mean, format: format(".4f") },
+    {
+      label: "mean",
+      value: mean,
+      format: INTEGERS.has(type) ? format(".2f") : format(".4f"),
+    },
   ].reverse();
 </script>
 

--- a/web-local/src/lib/components/column-profile/column-types/details/SummaryNumberPlot.svelte
+++ b/web-local/src/lib/components/column-profile/column-types/details/SummaryNumberPlot.svelte
@@ -15,7 +15,7 @@
   export let rowHeight = 24;
   export let type: string;
 
-  const formatter = INTEGERS.has(type) ? format(".0r") : format(".4f");
+  $: formatter = INTEGERS.has(type) ? format(".0r") : format(".4f");
   $: values = [
     { label: "min", value: min, format: formatter },
     { label: "max", value: max, format: formatter },

--- a/web-local/src/lib/util/formatters.spec.ts
+++ b/web-local/src/lib/util/formatters.spec.ts
@@ -1,0 +1,84 @@
+import { justEnoughPrecision } from "./formatters";
+
+interface TestCase {
+  input: number;
+  output: string;
+}
+
+const onlyIntegers = [
+  { input: 0, output: "0" },
+  { input: 1, output: "1" },
+  { input: 12, output: "12" },
+  { input: 123, output: "123" },
+  { input: 1234, output: "1234" },
+  { input: 12345, output: "12345" },
+  { input: 123456, output: "123456" },
+];
+
+const zeros = [
+  { input: 0.1, output: "0.1" },
+  { input: 0.12, output: "0.12" },
+  { input: 0.123, output: "0.123" },
+  { input: 0.1234, output: "0.1234" },
+  { input: 0.12345, output: "0.1234" },
+];
+
+const ones = [
+  { input: 1.0, output: "1" },
+  { input: 1.1, output: "1.1" },
+  { input: 1.12, output: "1.12" },
+  { input: 1.123, output: "1.123" },
+  { input: 1.1234, output: "1.1234" },
+  { input: 1.12345, output: "1.1234" },
+];
+
+const twos = [
+  { input: 12.0, output: "12" },
+  { input: 12.1, output: "12.1" },
+  { input: 12.12, output: "12.12" },
+  { input: 12.123, output: "12.123" },
+  { input: 12.1234, output: "12.123" },
+];
+
+const threes = [
+  { input: 123.0, output: "123" },
+  { input: 123.1, output: "123.1" },
+  { input: 123.12, output: "123.12" },
+  { input: 123.123, output: "123.12" },
+];
+
+const fours = [
+  { input: 1234.0, output: "1234" },
+  { input: 1234.1, output: "1234.1" },
+  { input: 1234.12, output: "1234.1" },
+];
+
+// add negative versions of all test cases
+const withNegativesToo = (testCases: TestCase[]) => [
+  ...testCases,
+  ...testCases.map(({ input, output }) => ({
+    input: -input,
+    output: input === 0 ? `${input}` : `-${output}`,
+  })),
+];
+
+const allTestCases = withNegativesToo([
+  ...onlyIntegers,
+  ...zeros,
+  ...ones,
+  ...twos,
+  ...threes,
+  ...fours,
+]);
+
+describe("justEnoughPrecision", () => {
+  it("throws on non-numbers", () => {
+    expect(() => justEnoughPrecision("foo" as any)).toThrow();
+    expect(() => justEnoughPrecision(undefined as any)).toThrow();
+  });
+  it("returns formatted values, removing floating points depending on number of significant digits", () => {
+    allTestCases.forEach(({ input, output }) => {
+      expect(justEnoughPrecision(input)).toBe(output);
+    });
+  });
+});

--- a/web-local/src/lib/util/formatters.ts
+++ b/web-local/src/lib/util/formatters.ts
@@ -10,6 +10,33 @@ import {
   TIMESTAMPS,
 } from "../duckdb-data-types";
 
+/** This heuristic is courtesy Dominik Moritz.
+ * Best used in cases where (1) you have no context for the number, and (2) you
+ * want have "enough resolution to distinguish numbers when they should be distinguishable."
+ */
+export function justEnoughPrecision(n: number) {
+  if (typeof n !== "number") throw Error("argument must be a number");
+  const str = n.toString();
+  // if there are no floating point digits, return the string
+  if (n === ~~n) return str;
+  const [left, right] = str.split(".");
+
+  // count the integer side
+  const leftSideDigits = left
+    .split("")
+    .filter((l) => l !== "-") // remove the negative sign
+    .join("").length;
+
+  // calculate the remaining available precision
+  const remainingPrecision = Math.max(0, 5 - leftSideDigits);
+  // take the remaining precision from the floating point side.
+  const remainingFloatingPoints = right.slice(0, remainingPrecision);
+  // format a new string
+  return `${left}${remainingFloatingPoints.length ? "." : ""}${
+    remainingFloatingPoints || ""
+  }`;
+}
+
 const zeroPad = format("02d");
 const msPad = format("03d");
 export const formatInteger = format(",");


### PR DESCRIPTION
Dominik Moritz suggested that the formatting on the summary plots is way too precise, so we'll go with this approach:
- *look at the number of significant digits,*
- *keep everything before the '.' (the integer portion),*
- *and then at most ~5 digits.*

So you'd get formatted numbers like `12345`, `1234.5`, `123.45`, `12.345`.
