### PR TITLE
Plugging remaining direct file path reference

### DIFF
--- a/web-local/src/lib/components/workspace/source/SourceWorkspace.svelte
+++ b/web-local/src/lib/components/workspace/source/SourceWorkspace.svelte
@@ -10,6 +10,7 @@
   import { appStore } from "@rilldata/web-local/lib/application-state-stores/app-store";
   import { runtimeStore } from "@rilldata/web-local/lib/application-state-stores/application-store";
   import { overlay } from "@rilldata/web-local/lib/application-state-stores/overlay-store";
+  import { getFilePathFromNameAndType } from "@rilldata/web-local/lib/util/entity-mappers";
   import { useQueryClient } from "@sveltestack/svelte-query";
   import { parseDocument } from "yaml";
 
@@ -43,7 +44,7 @@
 
   $: getSource = useRuntimeServiceGetFile(
     $runtimeStore?.instanceId,
-    `sources/${sourceName}.yaml`
+    getFilePathFromNameAndType(sourceName, EntityType.Table)
   );
 
   $: source = parseDocument($getSource?.data?.blob || "{}").toJS();

--- a/web-local/src/lib/svelte-query/actions.ts
+++ b/web-local/src/lib/svelte-query/actions.ts
@@ -144,7 +144,7 @@ export const useCreateDashboardFromSource = <
 
     await runtimeServicePutFileAndReconcile({
       instanceId: data.instanceId,
-      path: `models/${data.newModelName}.sql`,
+      path: getFilePathFromNameAndType(data.newModelName, EntityType.Model),
       blob: `select * from ${data.sourceName}`,
     });
 

--- a/web-local/src/routes/(application)/model/[name]/+page.ts
+++ b/web-local/src/routes/(application)/model/[name]/+page.ts
@@ -1,5 +1,7 @@
 import { runtimeServiceGetFile } from "@rilldata/web-common/runtime-client";
 import { runtimeServiceGetConfig } from "@rilldata/web-common/runtime-client/manual-clients";
+import { EntityType } from "@rilldata/web-local/common/data-modeler-state-service/entity-state-service/EntityStateService";
+import { getFilePathFromNameAndType } from "@rilldata/web-local/lib/util/entity-mappers";
 import { error } from "@sveltejs/kit";
 
 export const ssr = false;
@@ -11,7 +13,7 @@ export async function load({ params }) {
 
     await runtimeServiceGetFile(
       localConfig.instance_id,
-      `models/${params.name}.sql`
+      getFilePathFromNameAndType(params.name, EntityType.Model)
     );
 
     return {

--- a/web-local/src/routes/(application)/source/[name]/+page.ts
+++ b/web-local/src/routes/(application)/source/[name]/+page.ts
@@ -1,5 +1,7 @@
 import { runtimeServiceGetFile } from "@rilldata/web-common/runtime-client";
 import { runtimeServiceGetConfig } from "@rilldata/web-common/runtime-client/manual-clients";
+import { EntityType } from "@rilldata/web-local/common/data-modeler-state-service/entity-state-service/EntityStateService";
+import { getFilePathFromNameAndType } from "@rilldata/web-local/lib/util/entity-mappers";
 import { error } from "@sveltejs/kit";
 
 export const ssr = false;
@@ -11,7 +13,7 @@ export async function load({ params }) {
 
     await runtimeServiceGetFile(
       localConfig.instance_id,
-      `sources/${params.name}.yaml`
+      getFilePathFromNameAndType(params.name, EntityType.Table)
     );
 
     return {


### PR DESCRIPTION
Using `getFilePathFromNameAndType` for remaining references to file name directly.