### PR TITLE
Refresh when local file changes

### DIFF
--- a/runtime/services/catalog/migrations_test.go
+++ b/runtime/services/catalog/migrations_test.go
@@ -15,6 +15,7 @@ import (
 	_ "github.com/rilldata/rill/runtime/drivers/file"
 	_ "github.com/rilldata/rill/runtime/drivers/sqlite"
 	"github.com/rilldata/rill/runtime/services/catalog"
+	"github.com/rilldata/rill/runtime/services/catalog/artifacts"
 	_ "github.com/rilldata/rill/runtime/services/catalog/artifacts/sql"
 	_ "github.com/rilldata/rill/runtime/services/catalog/artifacts/yaml"
 	"github.com/rilldata/rill/runtime/services/catalog/migrator/metrics_views"
@@ -192,13 +193,38 @@ func TestRefreshSource(t *testing.T) {
 
 	for _, tt := range configs {
 		t.Run(tt.title, func(t *testing.T) {
-			s, _ := initBasicService(t)
+			s, dir := initBasicService(t)
+
+			testutils.CopyFileToData(t, dir, AdBidsCsvPath)
+			AdBidsDataPath := "data/AdBids.csv"
 
 			// update with same content
-			testutils.CreateSource(t, s, "AdBids", AdBidsCsvPath, AdBidsRepoPath)
+			err := artifacts.Write(context.Background(), s.Repo, s.InstId, &drivers.CatalogEntry{
+				Name: "AdBids",
+				Type: drivers.ObjectTypeSource,
+				Path: AdBidsRepoPath,
+				Object: &runtimev1.Source{
+					Name:      "AdBids",
+					Connector: "local_file",
+					Properties: testutils.ToProtoStruct(map[string]any{
+						"path": AdBidsDataPath,
+					}),
+				},
+			})
+			require.NoError(t, err)
 			result, err := s.Reconcile(context.Background(), tt.config)
 			require.NoError(t, err)
 			// ForcedPaths updates all dependant items
+			testutils.AssertMigration(t, result, 0, 0, 3, 0, AdBidsAffectedPaths)
+
+			// update the uploaded file directly
+			time.Sleep(10 * time.Millisecond)
+			err = os.Chtimes(path.Join(dir, AdBidsDataPath), time.Now(), time.Now())
+			require.NoError(t, err)
+			result, err = s.Reconcile(context.Background(), catalog.ReconcileConfig{
+				ChangedPaths: tt.config.ChangedPaths,
+			})
+			require.NoError(t, err)
 			testutils.AssertMigration(t, result, 0, 0, 3, 0, AdBidsAffectedPaths)
 		})
 	}

--- a/runtime/services/catalog/migrator/migrator.go
+++ b/runtime/services/catalog/migrator/migrator.go
@@ -3,6 +3,7 @@ package migrator
 import (
 	"context"
 	"fmt"
+	"time"
 
 	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
 	"github.com/rilldata/rill/runtime/drivers"
@@ -136,6 +137,19 @@ func SetSchema(ctx context.Context, olap drivers.OLAPStore, catalog *drivers.Cat
 	}
 
 	return nil
+}
+
+func LastUpdated(ctx context.Context, instID string, repo drivers.RepoStore, catalog *drivers.CatalogEntry) (time.Time, error) {
+	// TODO: do we need to push this to individual implementations to handle just local_file source?
+	if catalog.Type != drivers.ObjectTypeSource || catalog.GetSource().Connector != "local_file" {
+		// return a very old time
+		return time.Time{}, nil
+	}
+	stat, err := repo.Stat(ctx, instID, catalog.GetSource().Properties.Fields["path"].GetStringValue())
+	if err != nil {
+		return time.Time{}, err
+	}
+	return stat.LastUpdated, nil
 }
 
 func CreateValidationError(filePath string, message string) []*runtimev1.ReconcileError {

--- a/web-local/src/lib/components/navigation/sources/createSource.ts
+++ b/web-local/src/lib/components/navigation/sources/createSource.ts
@@ -23,7 +23,9 @@ export async function createSource(
       path: getFilePathFromNameAndType(tableName, EntityType.Table),
       blob: yaml,
       create: true,
-      createOnly: true,
+      // create source is used to upload and replace.
+      // so we cannot send createOnly=true until we refactor it to use refresh source
+      createOnly: false,
       strict: true,
     },
   });


### PR DESCRIPTION
closes #1447

Adding a feature where if the local file changes in `data` folder we re-ingest the source. This does not apply to remote sources since we want the user to explicitly refresh it.