### PR TITLE
Fixing tooltips in preview table not showing after scrolling

### DIFF
--- a/web-local/src/lib/components/virtualized-table/sections/TableCells.svelte
+++ b/web-local/src/lib/components/virtualized-table/sections/TableCells.svelte
@@ -21,7 +21,6 @@
       formattedValue:
         rows[row.index]["__formatted_" + columns[column.index]?.name],
       type: columns[column.index]?.type,
-      suppressTooltip: scrolling,
       barValue: columns[column.index]?.total
         ? value / columns[column.index]?.total
         : 0,
@@ -40,6 +39,7 @@
         {atLeastOneSelected}
         {excludeMode}
         {rowActive}
+        suppressTooltip={scrolling}
         {...getCellProps(row, column)}
         on:inspect
         on:select-item


### PR DESCRIPTION
closes #1151

@magorlick I tried a few times and this PR seem to have fixed tooltip in preview table not showing after scrolling. Lemme know if you find any edge cases.
@ericpgreen2 Please take a look at the code