### PR TITLE
[Dashboard] Fix jarring rearrange when include/exclude is toggled from filter pills

### DIFF
--- a/web-local/src/lib/application-state-stores/explorer-stores.ts
+++ b/web-local/src/lib/application-state-stores/explorer-stores.ts
@@ -1,6 +1,8 @@
-import type { V1MetricsView } from "@rilldata/web-common/runtime-client";
+import type {
+  V1MetricsView,
+  V1MetricsViewFilter,
+} from "@rilldata/web-common/runtime-client";
 import type { TimeSeriesTimeRange } from "@rilldata/web-local/lib/temp/time-control-types";
-import type { MetricsViewRequestFilter } from "@rilldata/web-local/common/rill-developer-service/MetricsViewActions";
 import { removeIfExists } from "@rilldata/web-local/lib/util/arrayUtils";
 import { Readable, writable } from "svelte/store";
 
@@ -22,7 +24,7 @@ export interface MetricsExplorerEntity {
   selectedMeasureNames: Array<string>;
   // this is used to show leaderboard values
   leaderboardMeasureName: string;
-  filters: MetricsViewRequestFilter;
+  filters: V1MetricsViewFilter;
   // stores whether a dimension is in include/exclude filter mode
   // false/absence = include, true = exclude
   dimensionFilterExcludeMode: Map<string, boolean>;

--- a/web-local/src/lib/components/workspace/explore/filters/Filters.svelte
+++ b/web-local/src/lib/components/workspace/explore/filters/Filters.svelte
@@ -2,17 +2,17 @@
 The main feature-set component for dashboard filters
  -->
 <script lang="ts">
-  import { useRuntimeServiceMetricsViewToplist } from "@rilldata/web-common/runtime-client";
+  import {
+    MetricsViewFilterCond,
+    useRuntimeServiceMetricsViewToplist,
+    V1MetricsViewFilter,
+  } from "@rilldata/web-common/runtime-client";
   import type { MetricsViewDimension } from "@rilldata/web-common/runtime-client";
 
   import { runtimeStore } from "@rilldata/web-local/lib/application-state-stores/application-store";
   import { useMetaQuery } from "@rilldata/web-local/lib/svelte-query/dashboards";
   import { flip } from "svelte/animate";
 
-  import type {
-    MetricsViewDimensionValues,
-    MetricsViewRequestFilter,
-  } from "@rilldata/web-local/common/rill-developer-service/MetricsViewActions";
   import { getMapFromArray } from "@rilldata/web-local/lib/util/arrayUtils";
   import { fly } from "svelte/transition";
   import {
@@ -30,9 +30,9 @@ The main feature-set component for dashboard filters
   let metricsExplorer: MetricsExplorerEntity;
   $: metricsExplorer = $metricsExplorerStore.entities[metricViewName];
 
-  let includeValues: MetricsViewDimensionValues;
+  let includeValues: Array<MetricsViewFilterCond>;
   $: includeValues = metricsExplorer?.filters.include;
-  let excludeValues: MetricsViewDimensionValues;
+  let excludeValues: Array<MetricsViewFilterCond>;
   $: excludeValues = metricsExplorer?.filters.exclude;
 
   $: metaQuery = useMetaQuery($runtimeStore.instanceId, metricViewName);
@@ -47,7 +47,7 @@ The main feature-set component for dashboard filters
     );
   }
 
-  function isFiltered(filters: MetricsViewRequestFilter): boolean {
+  function isFiltered(filters: V1MetricsViewFilter): boolean {
     if (!filters) return false;
     return filters.include.length > 0 || filters.exclude.length > 0;
   }

--- a/web-local/src/lib/components/workspace/explore/filters/Filters.svelte
+++ b/web-local/src/lib/components/workspace/explore/filters/Filters.svelte
@@ -136,6 +136,8 @@ The main feature-set component for dashboard filters
       ...currentDimensionIncludeFilters,
       ...currentDimensionExcludeFilters,
     ];
+    // sort based on name to make sure toggling include/exclude is not jarring
+    currentDimensionFilters.sort((a, b) => (a.name > b.name ? 1 : -1));
   }
 
   function toggleDimensionValue(event, item) {

--- a/web-local/src/lib/components/workspace/explore/leaderboards/DimensionDisplay.svelte
+++ b/web-local/src/lib/components/workspace/explore/leaderboards/DimensionDisplay.svelte
@@ -23,10 +23,9 @@
     humanizeGroupByColumns,
     NicelyFormattedTypes,
   } from "../../../../util/humanize-numbers";
-
-  import type { MetricsViewDimensionValues } from "@rilldata/web-local/common/rill-developer-service/MetricsViewActions";
   import {
     MetricsViewDimension,
+    MetricsViewFilterCond,
     useRuntimeServiceMetricsViewToplist,
     useRuntimeServiceMetricsViewTotals,
   } from "@rilldata/web-common/runtime-client";
@@ -59,7 +58,7 @@
     leaderboardMeasureName
   );
 
-  let excludeValues: MetricsViewDimensionValues;
+  let excludeValues: Array<MetricsViewFilterCond>;
   $: excludeValues = metricsExplorer?.filters.exclude;
 
   $: excludeMode =


### PR DESCRIPTION
closes #1257

- [x] Sort the filters by name to make sure toggling include/exclude is not jarring.
- [x] Code around filters was using older deleted types.