### PR TITLE
Adjust responsiveness of the inspector

### DIFF
--- a/web-local/src/lib/application-config.ts
+++ b/web-local/src/lib/application-config.ts
@@ -10,11 +10,10 @@ export const COLUMN_PROFILE_CONFIG = {
   /** The null percentage should be _just_ big enough to show x 100.0%
    * For MD IO 0.4, this is 74px.
    */
-  nullPercentageWidth: 44,
-  mediumCutoff: 300,
+  nullPercentageWidth: 42,
   compactBreakpoint: 350,
-  hideRight: 325,
-  hideNullPercentage: 399,
+  hideRight: 310,
+  hideNullPercentage: 350,
   summaryVizWidth: { medium: 68, small: 64 },
   exampleWidth: { medium: 204, small: 132 },
   fontSize: 12,

--- a/web-local/src/lib/components/column-profile/ColumnProfile.svelte
+++ b/web-local/src/lib/components/column-profile/ColumnProfile.svelte
@@ -66,13 +66,12 @@
   }
 </script>
 
-<!-- pl-16 -->
 <div
   bind:this={container}
   class="pl-{indentLevel === 1
     ? '10'
     : '4'} pr-5 pb-2 flex justify-between text-gray-500 pt-1"
-  class:flex-col={containerWidth < 325}
+  class:flex-col={containerWidth < COLUMN_PROFILE_CONFIG.hideRight}
 >
   <select bind:value={sortMethod} class={NATIVE_SELECT} style:font-size="11px">
     <option value={sortByOriginalOrder}>show original order</option>
@@ -84,7 +83,7 @@
     style:transform="translateX(4px)"
     bind:value={mode}
     class={NATIVE_SELECT}
-    class:hidden={containerWidth < 325}
+    class:hidden={containerWidth < COLUMN_PROFILE_CONFIG.hideRight}
     style:font-size="11px"
   >
     <option value="summaries">show summary&nbsp;</option>


### PR DESCRIPTION
Possibly addresses #1481 

This PR tightens up the inspector's responsiveness. Now, we wait until a smaller width before hiding the column profile charts.