### PR TITLE
fixes Format dates with Inter monospace #1480

### DIFF
--- a/web-common/src/lib/formatters.ts
+++ b/web-common/src/lib/formatters.ts
@@ -66,19 +66,19 @@ export function removeTimezoneOffset(dt: Date) {
 }
 
 export const standardTimestampFormat = (v, type = "TIMESTAMP") => {
-  let fmt = timeFormat("%b %d, %Y %I:%M:%S");
+  let fmt = timeFormat("%Y-%m-%d %I:%M:%S");
   if (type === "DATE") {
-    fmt = timeFormat("%b %d, %Y");
+    fmt = timeFormat("%Y-%m-%d");
   }
   return fmt(removeTimezoneOffset(new Date(v)));
 };
 
 export const fullTimestampFormat = (v) => {
-  const fmt = timeFormat("%b %d, %Y %I:%M:%S.%L");
+  const fmt = timeFormat("%Y-%m-%d %I:%M:%S.%L");
   return fmt(removeTimezoneOffset(new Date(v)));
 };
 
-export const datePortion = timeFormat("%b %d, %Y");
+export const datePortion = timeFormat("%Y-%m-%d");
 export const timePortion = timeFormat("%I:%M:%S");
 
 export function microsToTimestring(microseconds: number) {

--- a/web-local/src/lib/components/viz/ExploreChart.svelte
+++ b/web-local/src/lib/components/viz/ExploreChart.svelte
@@ -26,7 +26,7 @@
 
   export let hoveredDate;
 
-  const fmt = timeFormat("%b %d, %Y");
+  const fmt = timeFormat("%Y-%m-%d");
   const axisFmt = timeFormat("%b %d");
   const secondaryFmt = timeFormat("%Y");
 


### PR DESCRIPTION
Quick PR to see how the iso date approach to #1480 works. @magorlick and @hamilton, please take a look.


this branch:
![image](https://user-images.githubusercontent.com/2380975/209016074-6d152ae0-1e89-4b1a-b0e5-705b539b4004.png)

main:
![image](https://user-images.githubusercontent.com/2380975/209016128-7072fe8c-cb5a-415a-99de-22f617f85777.png)


