### PR TITLE
fixes Distribution chart tune ups #1498

### DIFF
--- a/web-local/src/lib/components/column-profile/column-types/details/SummaryNumberPlot.svelte
+++ b/web-local/src/lib/components/column-profile/column-types/details/SummaryNumberPlot.svelte
@@ -20,7 +20,6 @@
   $: formatter = INTEGERS.has(type) ? format(".0r") : justEnoughPrecision;
   $: values = [
     { label: "min", value: min, format: formatter },
-    { label: "max", value: max, format: formatter },
     { label: "q25", value: q25, format: formatter },
     { label: "q50", value: q50, format: formatter },
     {
@@ -28,6 +27,8 @@
       value: q75,
       format: formatter,
     },
+
+    { label: "max", value: max, format: formatter },
     {
       label: "mean",
       value: mean,
@@ -47,11 +48,16 @@
     {#each values as { label, value, format = undefined }, i}
       <g transform="translate(0 {(values.length - i - 1) * rowHeight})">
         <GraphicContext height={rowHeight}>
-          <circle cx={xScale(value)} cy={rowHeight / 2} r="4" fill="red" />
+          <circle
+            cx={xScale(value)}
+            cy={rowHeight / 2}
+            r="2.5"
+            fill="#ff8282"
+          />
           <line
             x1={xScale(value)}
             x2={xScale(value)}
-            y1={rowHeight / 2 - 8}
+            y1={rowHeight / 2 - 1}
             y2={-(rowHeight * (values.length - i - 1))}
             stroke="red"
             opacity={0.5}
@@ -60,7 +66,7 @@
             dy=".35em"
             x={value}
             ry={rowHeight / 2}
-            buffer={8}
+            buffer={6}
             colorClass="ui-copy-muted"
           >
             <tspan>


### PR DESCRIPTION
another quick bit of polish @magorlick  and @hamilton 

- puts quantile labels in order (min moved to bottom) for better scanability
- reduces size of red dots next to labels and desaturates them so that they perceptually match the color of the vertical lines going up to the chart.

this branch:
![image](https://user-images.githubusercontent.com/2380975/209017492-11e00f38-a408-4b4a-b9b9-00f1db979f60.png)

main:
![image](https://user-images.githubusercontent.com/2380975/209017573-f3d17f38-8dde-4d73-a3cc-86b3cb3d9ea2.png)
