### PR TITLE
increases visual weight of filter icons in filter pill menu

### DIFF
--- a/web-common/src/components/chip/removable-list-chip/RemovableListMenu.svelte
+++ b/web-common/src/components/chip/removable-list-chip/RemovableListMenu.svelte
@@ -77,9 +77,9 @@
         >
           <svelte:fragment slot="icon">
             {#if selectedValues.includes(value) && !excludeMode}
-              <Check size="20px" />
+              <Check size="20px" color="#15141A" />
             {:else if selectedValues.includes(value) && excludeMode}
-              <Cancel size="20px" />
+              <Cancel size="20px" color="#15141A" />
             {:else}
               <Spacer size="20px" />
             {/if}


### PR DESCRIPTION
fixes #1261 by darkening the icons in the filter pill

Note: this is a bit of a hack -- it hard codes the color because `currentColor` was not actually being set correctly by the upstream styles. There are a lot of layers of cascading in play here, so I thought this was an expedient solution to get us the look we want until we overhaul our approach to styling

this branch:
![image](https://user-images.githubusercontent.com/2380975/209024238-4623df93-261e-4363-8951-3052225ec96f.png)

main (note lighter gray icons in filter pill menus_:
![image](https://user-images.githubusercontent.com/2380975/209024592-2a9fba3b-c2f9-4879-b353-27f28be3a672.png)
