### PR TITLE
Metrics view support  dashboards with no timestamp

### DIFF
--- a/runtime/queries/metricsview_timeseries.go
+++ b/runtime/queries/metricsview_timeseries.go
@@ -69,6 +69,10 @@ func (q *MetricsViewTimeSeries) Resolve(ctx context.Context, rt *runtime.Runtime
 		return err
 	}
 
+	if mv.TimeDimension == "" {
+		return fmt.Errorf("metrics view '%s' does not have a time dimension", q.MetricsViewName)
+	}
+
 	// Build query
 	sql, args, err := q.buildMetricsTimeSeriesSQL(mv)
 	if err != nil {

--- a/runtime/queries/metricsview_toplist.go
+++ b/runtime/queries/metricsview_toplist.go
@@ -68,7 +68,7 @@ func (q *MetricsViewToplist) Resolve(ctx context.Context, rt *runtime.Runtime, i
 		return err
 	}
 
-	if mv.TimeDimension == "" {
+	if mv.TimeDimension == "" && (q.TimeStart != nil || q.TimeEnd != nil) {
 		return fmt.Errorf("metrics view '%s' does not have a time dimension", q.MetricsViewName)
 	}
 

--- a/runtime/queries/metricsview_toplist.go
+++ b/runtime/queries/metricsview_toplist.go
@@ -68,6 +68,10 @@ func (q *MetricsViewToplist) Resolve(ctx context.Context, rt *runtime.Runtime, i
 		return err
 	}
 
+	if mv.TimeDimension == "" {
+		return fmt.Errorf("metrics view '%s' does not have a time dimension", q.MetricsViewName)
+	}
+
 	// Build query
 	sql, args, err := q.buildMetricsTopListSQL(mv)
 	if err != nil {

--- a/runtime/queries/metricsview_totals.go
+++ b/runtime/queries/metricsview_totals.go
@@ -66,7 +66,7 @@ func (q *MetricsViewTotals) Resolve(ctx context.Context, rt *runtime.Runtime, in
 		return err
 	}
 
-	if mv.TimeDimension == "" {
+	if mv.TimeDimension == "" && (q.TimeStart != nil || q.TimeEnd != nil) {
 		return fmt.Errorf("metrics view '%s' does not have a time dimension", q.MetricsViewName)
 	}
 

--- a/runtime/queries/metricsview_totals.go
+++ b/runtime/queries/metricsview_totals.go
@@ -66,6 +66,10 @@ func (q *MetricsViewTotals) Resolve(ctx context.Context, rt *runtime.Runtime, in
 		return err
 	}
 
+	if mv.TimeDimension == "" {
+		return fmt.Errorf("metrics view '%s' does not have a time dimension", q.MetricsViewName)
+	}
+
 	ql, args, err := q.buildMetricsTotalsSQL(mv)
 	if err != nil {
 		return fmt.Errorf("error building query: %w", err)


### PR DESCRIPTION
>  Audit/adapt the analytical APIs to support metrics views without a time dimension (just return an error if a metrics timeseries API is queried)