### PR TITLE
Move onboarding into `web-common/features/onboarding` directory

### DIFF
--- a/web-common/src/features/onboarding/OnboardingWorkspace.svelte
+++ b/web-common/src/features/onboarding/OnboardingWorkspace.svelte
@@ -3,7 +3,7 @@
   import Metrics from "@rilldata/web-common/components/icons/Metrics.svelte";
   import Model from "@rilldata/web-common/components/icons/Model.svelte";
   import Source from "@rilldata/web-common/components/icons/Source.svelte";
-  import WorkspaceContainer from "../core/WorkspaceContainer.svelte";
+  import WorkspaceContainer from "@rilldata/web-local/lib/components/workspace/core/WorkspaceContainer.svelte";
 
   const steps = [
     {

--- a/web-common/src/features/onboarding/index.ts
+++ b/web-common/src/features/onboarding/index.ts
@@ -1,0 +1,1 @@
+export { default as OnboardingWorkspace } from "./OnboardingWorkspace.svelte";

--- a/web-local/src/lib/components/workspace/index.ts
+++ b/web-local/src/lib/components/workspace/index.ts
@@ -7,5 +7,4 @@ export { default as WorkspaceHeaderStatusSpinner } from "./core/WorkspaceHeaderS
 export { default as DashboardWorkspace } from "./explore/Explore.svelte";
 export { default as MetricsDefinitionWorkspace } from "./metrics-def/MetricsDefWorkspace.svelte";
 export { default as ModelWorkspace } from "./model/ModelWorkspace.svelte";
-export { default as OnboardingWorkspace } from "./onboarding/OnboardingWorkspace.svelte";
 export { default as SourceWorkspace } from "./source/SourceWorkspace.svelte";

--- a/web-local/src/routes/(application)/+page.svelte
+++ b/web-local/src/routes/(application)/+page.svelte
@@ -1,11 +1,5 @@
 <script lang="ts">
-  import { OnboardingWorkspace } from "@rilldata/web-local/lib/components/workspace";
-  // clear any existing active asset
-  // TODO: is this still needed?
-  // $: dataModelerService.dispatch("setActiveAsset", [
-  //   EntityType.Table,
-  //   undefined,
-  // ]);
+  import { OnboardingWorkspace } from "@rilldata/web-common/features/onboarding";
 </script>
 
 <svelte:head>


### PR DESCRIPTION
This PR continues the refactor from #1505. 

The PR creates a `web-common/features/onboarding` directory, which exports the `OnboardingWorkspace` component. This component is imported into the `web-local/routes/(application)/+page.svelte` file.

Assuming our onboarding surface will evolve over time, it will help to have all of its components colocated in this one directory.