### PR TITLE
adds back in nonexisting import to `TimestampDetail.svelte`

### DIFF
--- a/web-common/src/components/data-graphic/compositions/timestamp-profile/TimestampDetail.svelte
+++ b/web-common/src/components/data-graphic/compositions/timestamp-profile/TimestampDetail.svelte
@@ -15,6 +15,7 @@
    */
   import { notifications } from "@rilldata/web-common/components/notifications";
   import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
+  import { createShiftClickAction } from "@rilldata/web-common/lib/actions/shift-click-action";
   import type { Interval } from "@rilldata/web-common/lib/duckdb-data-types";
   import { removeTimezoneOffset } from "@rilldata/web-common/lib/formatters";
   import { guidGenerator } from "@rilldata/web-common/lib/guid";


### PR DESCRIPTION
This should be a quick review + merge once CI is complete. For some reason failing imports due to the code migration don't seem to be triggering CI.