### PR TITLE
Make time range filter inclusive for end part

### DIFF
--- a/runtime/queries/metricsview_timeseries.go
+++ b/runtime/queries/metricsview_timeseries.go
@@ -119,7 +119,7 @@ func (q *MetricsViewTimeSeries) buildMetricsTimeSeriesSQL(mv *runtimev1.MetricsV
 			args = append(args, q.TimeStart.AsTime())
 		}
 		if q.TimeEnd != nil {
-			whereClause += fmt.Sprintf(" AND %s < ?", timestampColumnName)
+			whereClause += fmt.Sprintf(" AND %s <= ?", timestampColumnName)
 			args = append(args, q.TimeEnd.AsTime())
 		}
 	}


### PR DESCRIPTION
Hi,

I like this product, and especially UI, looks very clean.

I noticed that time range filter doesn't include the very end date and filters out last row of data in the dashboard metrics.

See examples in screenshots:

<img width="890" alt="image" src="https://user-images.githubusercontent.com/82666953/210343763-1b6c5c17-1e51-48b4-b91e-f20ebd442c3a.png">

PayOut shows -199.4 and it doesn't include the very last row item, that should substitute another -1000.
Here is the query that shows the correct sum:
<img width="702" alt="image" src="https://user-images.githubusercontent.com/82666953/210344341-55d67972-617c-4bd8-8068-8b21f572b1de.png">


This PR to fix the end date filter to be inclusive.
