### PR TITLE
Improve handling of time ranges

### DIFF
--- a/web-local/src/lib/components/workspace/explore/time-controls/time-range-utils.spec.ts
+++ b/web-local/src/lib/components/workspace/explore/time-controls/time-range-utils.spec.ts
@@ -100,13 +100,13 @@ describe("makeTimeRange", () => {
   it("should create a TimeRange object representing the Last Two Weeks", () => {
     expect(
       makeTimeRange(TimeRangeName.Last2Weeks, TimeGrain.OneDay, {
-        start: "2022-01-01",
-        end: "2022-03-31",
+        start: "2022-01-01T11:00:01",
+        end: "2022-03-31T20:00:01",
       })
     ).toEqual({
       name: TimeRangeName.Last2Weeks,
       start: "2022-03-17T00:00:00.000Z",
-      end: "2022-03-30T23:59:59.000Z",
+      end: "2022-04-01T00:00:00.000Z",
       interval: "day",
     });
   });

--- a/web-local/src/lib/components/workspace/explore/time-controls/time-range-utils.ts
+++ b/web-local/src/lib/components/workspace/explore/time-controls/time-range-utils.ts
@@ -135,7 +135,9 @@ export const makeTimeRange = (
     start = new Date(allTimeRange.start);
   } else if (lastXTimeRanges.includes(timeRangeName)) {
     const allTimeEnd = new Date(allTimeRange?.end);
-    start = new Date(allTimeEnd.getTime() - getLastXTimeRangeDuration(timeRangeName));
+    start = new Date(
+      allTimeEnd.getTime() - getLastXTimeRangeDuration(timeRangeName)
+    );
   } else {
     throw new Error(`Unknown time range name: ${timeRangeName}`);
   }
@@ -146,7 +148,7 @@ export const makeTimeRange = (
   // Round end time to start of next grain, since end times are exclusive
   let end = addGrains(new Date(allTimeRange?.end), 1, timeGrain);
   end = floorDate(end, timeGrain);
-  
+
   return {
     name: timeRangeName,
     start: start.toISOString(),
@@ -204,7 +206,7 @@ export const prettyFormatTimeRange = (
 
   const start = new Date(timeRange.start);
   // timeRange.end is exclusive. We subtract one ms to render the last inclusive value.
-  const end = new Date((new Date(timeRange.end)).getTime() - 1);
+  const end = new Date(new Date(timeRange.end).getTime() - 1);
 
   const TIMEZONE = "UTC";
   // const TIMEZONE = Intl.DateTimeFormat().resolvedOptions().timeZone; // the user's local timezone
@@ -233,13 +235,13 @@ export const prettyFormatTimeRange = (
         timeZone: TIMEZONE,
       })
       .replace(/\s/g, "")}-${end
-        .toLocaleString(undefined, {
-          hour12: true,
-          hour: "numeric",
-          minute: "numeric",
-          timeZone: TIMEZONE,
-        })
-        .replace(/\s/g, "")})`;
+      .toLocaleString(undefined, {
+        hour12: true,
+        hour: "numeric",
+        minute: "numeric",
+        timeZone: TIMEZONE,
+      })
+      .replace(/\s/g, "")})`;
   }
 
   // month is the same
@@ -255,13 +257,13 @@ export const prettyFormatTimeRange = (
         timeZone: TIMEZONE,
       })
       .replace(/\s/g, "")}-${end
-        .toLocaleString(undefined, {
-          hour12: true,
-          hour: "numeric",
-          minute: "numeric",
-          timeZone: TIMEZONE,
-        })
-        .replace(/\s/g, "")})`;
+      .toLocaleString(undefined, {
+        hour12: true,
+        hour: "numeric",
+        minute: "numeric",
+        timeZone: TIMEZONE,
+      })
+      .replace(/\s/g, "")})`;
   }
   // year is the same
   if (startYear === endYear) {
@@ -468,7 +470,11 @@ const floorDate = (date: Date | undefined, timeGrain: TimeGrain): Date => {
   }
 };
 
-export const addGrains = (date: Date, units: number, grain: TimeGrain): Date => {
+export const addGrains = (
+  date: Date,
+  units: number,
+  grain: TimeGrain
+): Date => {
   switch (grain) {
     case TimeGrain.OneMinute:
       return new Date(date.getTime() + units * 60 * 1000);
@@ -479,7 +485,9 @@ export const addGrains = (date: Date, units: number, grain: TimeGrain): Date => 
     case TimeGrain.OneWeek:
       return new Date(date.getTime() + units * 7 * 24 * 60 * 60 * 1000);
     case TimeGrain.OneMonth:
-      return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + units, 1));
+      return new Date(
+        Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + units, 1)
+      );
     case TimeGrain.OneYear:
       return new Date(Date.UTC(date.getUTCFullYear() + units, 1, 1));
     default:

--- a/web-local/src/lib/components/workspace/explore/time-series-charts/MetricsTimeSeriesCharts.svelte
+++ b/web-local/src/lib/components/workspace/explore/time-series-charts/MetricsTimeSeriesCharts.svelte
@@ -23,7 +23,10 @@
   } from "../../../../application-state-stores/explorer-stores";
   import { convertTimestampPreview } from "../../../../util/convertTimestampPreview";
   import { NicelyFormattedTypes } from "../../../../util/humanize-numbers";
-  import { formatDateByInterval, addGrains } from "../time-controls/time-range-utils";
+  import {
+    formatDateByInterval,
+    addGrains,
+  } from "../time-controls/time-range-utils";
   import MeasureBigNumber from "./MeasureBigNumber.svelte";
   import TimeSeriesBody from "./TimeSeriesBody.svelte";
   import TimeSeriesChartContainer from "./TimeSeriesChartContainer.svelte";
@@ -122,11 +125,17 @@
   let startValue: Date;
   let endValue: Date;
   $: if (metricsExplorer?.selectedTimeRange) {
-    startValue = removeTimezoneOffset(new Date(metricsExplorer?.selectedTimeRange?.start));
+    startValue = removeTimezoneOffset(
+      new Date(metricsExplorer?.selectedTimeRange?.start)
+    );
     // selectedTimeRange.end is exclusive and rounded to the time grain ("interval").
     // Since values are grouped with DATE_TRUNC, we subtract one grain to get the (inclusive) axis end.
     endValue = new Date(metricsExplorer?.selectedTimeRange?.end);
-    endValue = addGrains(endValue, -1, metricsExplorer?.selectedTimeRange?.interval);
+    endValue = addGrains(
+      endValue,
+      -1,
+      metricsExplorer?.selectedTimeRange?.interval
+    );
     endValue = removeTimezoneOffset(endValue);
   }
 </script>

--- a/web-local/src/lib/components/workspace/explore/time-series-charts/MetricsTimeSeriesCharts.svelte
+++ b/web-local/src/lib/components/workspace/explore/time-series-charts/MetricsTimeSeriesCharts.svelte
@@ -23,7 +23,7 @@
   } from "../../../../application-state-stores/explorer-stores";
   import { convertTimestampPreview } from "../../../../util/convertTimestampPreview";
   import { NicelyFormattedTypes } from "../../../../util/humanize-numbers";
-  import { formatDateByInterval } from "../time-controls/time-range-utils";
+  import { formatDateByInterval, addGrains } from "../time-controls/time-range-utils";
   import MeasureBigNumber from "./MeasureBigNumber.svelte";
   import TimeSeriesBody from "./TimeSeriesBody.svelte";
   import TimeSeriesChartContainer from "./TimeSeriesChartContainer.svelte";
@@ -119,12 +119,16 @@
 
   let mouseoverValue = undefined;
 
-  $: startValue = removeTimezoneOffset(
-    new Date(metricsExplorer?.selectedTimeRange?.start)
-  );
-  $: endValue = removeTimezoneOffset(
-    new Date(metricsExplorer?.selectedTimeRange?.end)
-  );
+  let startValue: Date;
+  let endValue: Date;
+  $: if (metricsExplorer?.selectedTimeRange) {
+    startValue = removeTimezoneOffset(new Date(metricsExplorer?.selectedTimeRange?.start));
+    // selectedTimeRange.end is exclusive and rounded to the time grain ("interval").
+    // Since values are grouped with DATE_TRUNC, we subtract one grain to get the (inclusive) axis end.
+    endValue = new Date(metricsExplorer?.selectedTimeRange?.end);
+    endValue = addGrains(endValue, -1, metricsExplorer?.selectedTimeRange?.interval);
+    endValue = removeTimezoneOffset(endValue);
+  }
 </script>
 
 <WithBisector

--- a/web-local/src/lib/temp/time-control-types.ts
+++ b/web-local/src/lib/temp/time-control-types.ts
@@ -51,9 +51,11 @@ export enum TimeGrain {
   OneMonth = "month",
   OneYear = "year",
 }
+
+// The start and end times are rounded to the time grain (interval) such that start is inclusive and end is exclusive.
 export interface TimeSeriesTimeRange {
   name?: TimeRangeName;
   start?: string;
   end?: string;
-  interval?: string; // TODO: switch this to TimeGrain
+  interval?: TimeGrain; // TODO: switch this to TimeGrain
 }

--- a/web-local/src/lib/temp/time-control-types.ts
+++ b/web-local/src/lib/temp/time-control-types.ts
@@ -57,5 +57,5 @@ export interface TimeSeriesTimeRange {
   name?: TimeRangeName;
   start?: string;
   end?: string;
-  interval?: TimeGrain; // TODO: switch this to TimeGrain
+  interval?: TimeGrain;
 }


### PR DESCRIPTION
This was triggered by https://github.com/rilldata/rill-developer/pull/1553, which shows that we were not handling time ranges correctly. Fixing it on the API-side didn't feel right as it opens some edge cases (I found [this blog post](https://metala.org/posts/api-design-exclusive-vs-inclusive-ranges/) that illustrates one of the problems).

This PR changes how time ranges are calculated and used in the frontend. The rules are:

- Backend
  - The time series metrics APIs accept `[start;end)` ranges. The result is grouped using `DATE_TRUNC` (so the groups are floor timestamps).
  - The `GetTimeRangeSummary` API returns the min and max timestamp values in the column (so both inclusive).
- Frontend
  - The selected time range passed to the API is computed as:
    - For all time: `start = floor(mintime, grain)` and `end = floor(maxtime + 1 grain, grain)`
    - For last X grains: `start = floor(maxtime - X grains, grain)` and `end` is same as for all time
  - The time period selector shows prettified values for `start` and `end - 1 millisecond` (so it appears inclusive – this is misleading for edge cases, but seems more intuitive)
  - The chart axis spans from `start` to `end - 1 grain` (since it is rendering the results of a `DATE_TRUNC`)

Here's a model that was useful for testing:
```sql
select generate_series as t, 'a' as a, 1 as x
from generate_series('2020-01-01T00:00:00Z'::TIMESTAMP, '2021-01-01T00:00:00Z'::TIMESTAMP, INTERVAL 1 DAY)
union all 
select '2021-01-01T02:01:00Z'::TIMESTAMP as t, 'a' as a, 1 as x
union all 
select '2021-01-01T02:59:59.999Z'::TIMESTAMP as t, 'a' as a, 1 as x
```

Not sure if this is better, let me know what you think. 