### PR TITLE
Make `rill init` When Passed Arguments (Probably By Accident)

### DIFF
--- a/cli/cmd/initialize/init.go
+++ b/cli/cmd/initialize/init.go
@@ -76,6 +76,7 @@ func InitCmd(ver version.Version) *cobra.Command {
 
 			return nil
 		},
+		Args: cobra.ExactArgs(0),
 	}
 
 	initCmd.Flags().SortFlags = false


### PR DESCRIPTION
Make `rill init --example <example>` fail instead of quietly using the "default" example project when used instead of `--example=example`.

The latter form is required due to a bug in cobra.  See https://github.com/rilldata/rill-developer/pull/1398#issuecomment-1370228827