### PR TITLE
When a model query is blank, hide the table & inspector

### DIFF
--- a/web-common/src/features/models/utils/model-is-empty/index.ts
+++ b/web-common/src/features/models/utils/model-is-empty/index.ts
@@ -1,0 +1,11 @@
+import { useRuntimeServiceGetFile } from "@rilldata/web-common/runtime-client";
+
+export function modelIsEmpty(instanceId, modelName) {
+  return useRuntimeServiceGetFile(instanceId, `/models/${modelName}.sql`, {
+    query: {
+      select(data) {
+        return data?.blob?.length === 0;
+      },
+    },
+  });
+}

--- a/web-common/src/features/models/workspace/ModelBody.svelte
+++ b/web-common/src/features/models/workspace/ModelBody.svelte
@@ -22,6 +22,7 @@
   import { getContext } from "svelte";
   import type { Writable } from "svelte/store";
   import { slide } from "svelte/transition";
+  import { modelIsEmpty } from "../utils/model-is-empty";
   import { sanitizeQuery } from "../utils/sanitize-query";
   import Editor from "./Editor.svelte";
 
@@ -42,6 +43,8 @@
   $: modelPath = getFilePathFromNameAndType(modelName, EntityType.Model);
   $: modelError = $fileArtifactsStore.entities[modelPath]?.errors[0]?.message;
   $: modelSqlQuery = useRuntimeServiceGetFile(runtimeInstanceId, modelPath);
+
+  $: modelEmpty = modelIsEmpty(runtimeInstanceId, modelName);
 
   $: modelSql = $modelSqlQuery?.data?.blob;
   $: hasModelSql = typeof modelSql === "string";
@@ -171,7 +174,9 @@
           "
           class="relative h-full"
         >
-          <ConnectedPreviewTable objectName={modelName} />
+          {#if !$modelEmpty?.data}
+            <ConnectedPreviewTable objectName={modelName} />
+          {/if}
         </div>
         <!--TODO {:else}-->
         <!--  <div-->

--- a/web-common/src/features/models/workspace/inspector/ModelInspector.svelte
+++ b/web-common/src/features/models/workspace/inspector/ModelInspector.svelte
@@ -1,10 +1,7 @@
 <script lang="ts">
   import { createResizeListenerActionFactory } from "@rilldata/web-common/lib/actions/create-resize-listener-factory";
-  import {
-    useRuntimeServiceGetCatalogEntry,
-    useRuntimeServiceGetFile,
-  } from "@rilldata/web-common/runtime-client";
   import { runtimeStore } from "@rilldata/web-local/lib/application-state-stores/application-store";
+  import { modelIsEmpty } from "../../utils/model-is-empty";
   import ModelInspectorHeader from "./ModelInspectorHeader.svelte";
   import ModelInspectorModelProfile from "./ModelInspectorModelProfile.svelte";
 
@@ -13,24 +10,12 @@
   const { observedNode, listenToNodeResize } =
     createResizeListenerActionFactory();
 
-  $: getModel = useRuntimeServiceGetCatalogEntry(
-    $runtimeStore?.instanceId,
-    modelName
-  );
-
-  $: getFile = useRuntimeServiceGetFile(
-    $runtimeStore?.instanceId,
-    `/models/${modelName}.sql`
-  );
-
-  // $: emptyModel = modelIsEmpty($runtimeStore?.instanceId, modelName);
-
-  $: fileHasSQL = !$getModel?.isError && $getFile?.data?.blob?.length > 0;
+  $: emptyModel = modelIsEmpty($runtimeStore?.instanceId, modelName);
 </script>
 
-{#if fileHasSQL === true}
+{#if !$emptyModel?.data}
   <div>
-    {#key modelName + fileHasSQL}
+    {#key modelName}
       <div use:listenToNodeResize>
         <ModelInspectorHeader
           {modelName}

--- a/web-common/src/features/models/workspace/inspector/ModelInspector.svelte
+++ b/web-common/src/features/models/workspace/inspector/ModelInspector.svelte
@@ -27,5 +27,7 @@
     {/key}
   </div>
 {:else}
-  <div class="px-4 py-2">Model is empty.</div>
+  <div class="px-4 py-24 italic ui-copy-disabled text-center">
+    Model is empty.
+  </div>
 {/if}

--- a/web-local/src/lib/components/column-profile/ColumnProfileIcon.svelte
+++ b/web-local/src/lib/components/column-profile/ColumnProfileIcon.svelte
@@ -14,7 +14,7 @@
     {#key isFetching}
       <div
         class="absolute m-auto grid place-items-center"
-        transition:fade={{ duration: LIST_SLIDE_DURATION }}
+        transition:fade|local={{ duration: LIST_SLIDE_DURATION }}
         style:width="16px"
         style:height="16px"
       >

--- a/web-local/src/lib/components/column-profile/column-types/sparks/NumericSpark.svelte
+++ b/web-local/src/lib/components/column-profile/column-types/sparks/NumericSpark.svelte
@@ -51,13 +51,6 @@
         />
       </g>
     </SimpleDataGraphic>
-    <!-- <Histogram
-      {data}
-      width={summaryWidthSize}
-      height={18}
-      fillColor={DATA_TYPE_COLORS["DOUBLE"].vizFillClass}
-      baselineStrokeColor={DATA_TYPE_COLORS["DOUBLE"].vizStrokeClass}
-    /> -->
     <TooltipContent slot="tooltip-content">
       the distribution of the values of this column
     </TooltipContent>

--- a/web-local/src/lib/components/column-profile/column-types/sparks/TimestampSpark.svelte
+++ b/web-local/src/lib/components/column-profile/column-types/sparks/TimestampSpark.svelte
@@ -93,33 +93,6 @@
         y2={config.plotBottom}
         stroke="black"
       />
-      <!-- {#if zoomPreviewWidth}
-  <g transition:fade={{ duration: 100 }}>
-    <rect
-      x={zoomPreviewX}
-      y={plotTop}
-      width={zoomPreviewWidth}
-      {height}
-      fill={zoomWindowColor}
-      opacity=".9"
-      style:mix-blend-mode="lighten"
-    />
-    <line
-      x1={zoomPreviewX}
-      x2={zoomPreviewX}
-      y1={plotTop}
-      y2={plotBottom}
-      stroke={zoomWindowBoundaryColor}
-    />
-    <line
-      x1={zoomPreviewX + zoomPreviewWidth}
-      x2={zoomPreviewX + zoomPreviewWidth}
-      y1={plotTop}
-      y2={plotBottom}
-      stroke={zoomWindowBoundaryColor}
-    />
-  </g>
-{/if} -->
     </SimpleDataGraphic>
   </WithParentClientRect>
 {/if}


### PR DESCRIPTION
This has been bothering me for a while, so I decided to fix this.

We should not be surfacing the preview table / inspector information if a model query is blank. It's better to hide any information from the user. This is distinct from the case where the query has an error; here, we actually preserve the representations in those surfaces.