### PR TITLE
more from `r` to `f` for integer formatting in summary numbers

### DIFF
--- a/web-local/src/lib/components/column-profile/column-types/details/SummaryNumberPlot.svelte
+++ b/web-local/src/lib/components/column-profile/column-types/details/SummaryNumberPlot.svelte
@@ -17,7 +17,7 @@
   export let rowHeight = 24;
   export let type: string;
 
-  $: formatter = INTEGERS.has(type) ? format(".0r") : justEnoughPrecision;
+  $: formatter = INTEGERS.has(type) ? format(".0f") : justEnoughPrecision;
   $: values = [
     { label: "min", value: min, format: formatter },
     { label: "q25", value: q25, format: formatter },


### PR DESCRIPTION
This was causing quite the bug in integer histograms.