### PR TITLE
fix olap test

### DIFF
--- a/runtime/drivers/drivers.go
+++ b/runtime/drivers/drivers.go
@@ -8,9 +8,6 @@ import (
 	"go.uber.org/zap"
 )
 
-// ErrClosed indicates the connection is closed.
-var ErrClosed = errors.New("driver: connection is closed")
-
 // ErrNotFound indicates the resource wasn't found.
 var ErrNotFound = errors.New("driver: not found")
 

--- a/runtime/drivers/duckdb/olap_test.go
+++ b/runtime/drivers/duckdb/olap_test.go
@@ -2,6 +2,7 @@ package duckdb
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -186,7 +187,7 @@ func TestClose(t *testing.T) {
 	})
 
 	err := g.Wait()
-	require.Equal(t, drivers.ErrClosed, err)
+	require.Equal(t, errors.New("sql: database is closed"), err)
 
 	x := <-results
 	require.Greater(t, x, 0)


### PR DESCRIPTION
Since we are using built in connection pool now. duckdb olap tests does not run in short mode, should we start running them always.