### PR TITLE
Create `readonly` UI

### DIFF
--- a/web-common/src/features/onboarding/OnboardingWorkspace.svelte
+++ b/web-common/src/features/onboarding/OnboardingWorkspace.svelte
@@ -3,9 +3,10 @@
   import Metrics from "@rilldata/web-common/components/icons/Metrics.svelte";
   import Model from "@rilldata/web-common/components/icons/Model.svelte";
   import Source from "@rilldata/web-common/components/icons/Source.svelte";
+  import { runtimeStore } from "@rilldata/web-local/lib/application-state-stores/application-store";
   import WorkspaceContainer from "@rilldata/web-local/lib/components/workspace/core/WorkspaceContainer.svelte";
 
-  const steps = [
+  const dataModelerSteps = [
     {
       heading: "Import your data source",
       description:
@@ -24,6 +25,9 @@
         "Define aggregate metrics and break out dimensions for your modeled data.",
       icon: Metrics,
     },
+  ];
+
+  const dashboardSteps = [
     {
       heading: "Explore your metrics dashboard",
       description:
@@ -31,6 +35,11 @@
       icon: Explore,
     },
   ];
+
+  $: isModelerEnabled = $runtimeStore.readOnly === false;
+  $: steps = isModelerEnabled
+    ? [...dataModelerSteps, ...dashboardSteps]
+    : dashboardSteps;
 </script>
 
 <WorkspaceContainer top="0px" assetID="onboarding" inspector={false}>

--- a/web-common/src/runtime-client/manual-clients.ts
+++ b/web-common/src/runtime-client/manual-clients.ts
@@ -11,6 +11,7 @@ export type V1RuntimeGetConfig = {
   build_commit: string;
   is_dev: boolean;
   analytics_enabled: boolean;
+  readonly: boolean;
 };
 export const runtimeServiceGetConfig =
   async (): Promise<V1RuntimeGetConfig> => {

--- a/web-local/src/lib/application-state-stores/application-store.ts
+++ b/web-local/src/lib/application-state-stores/application-store.ts
@@ -7,7 +7,9 @@ import { writable } from "svelte/store";
 
 export type RuntimeState = {
   instanceId: string;
+  readOnly: boolean;
 };
 export const runtimeStore = writable<RuntimeState>({
   instanceId: null,
+  readOnly: undefined,
 });

--- a/web-local/src/lib/components/layouts/RillDeveloperApplicationLayout.svelte
+++ b/web-local/src/lib/components/layouts/RillDeveloperApplicationLayout.svelte
@@ -27,23 +27,23 @@
 
   const appBuildMetaStore: Writable<ApplicationBuildMetadata> =
     getContext("rill:app:metadata");
-
   onMount(async () => {
-    const localConfig = await runtimeServiceGetConfig();
+    const config = await runtimeServiceGetConfig();
 
     runtimeStore.set({
-      instanceId: localConfig.instance_id,
+      instanceId: config.instance_id,
+      readOnly: config.readonly,
     });
 
     appBuildMetaStore.set({
-      version: localConfig.version,
-      commitHash: localConfig.build_commit,
+      version: config.version,
+      commitHash: config.build_commit,
     });
 
-    const res = await getArtifactErrors(localConfig.instance_id);
+    const res = await getArtifactErrors(config.instance_id);
     fileArtifactsStore.setErrors(res.affectedPaths, res.errors);
 
-    return initMetrics(localConfig);
+    return initMetrics(config);
   });
 
   let dbRunState = "disconnected";

--- a/web-local/src/lib/components/navigation/Navigation.svelte
+++ b/web-local/src/lib/components/navigation/Navigation.svelte
@@ -47,6 +47,8 @@
   );
 
   $: yaml = parseDocument($thing?.data?.blob || "{}")?.toJS();
+
+  $: isModelerEnabled = $runtimeStore.readOnly === false;
 </script>
 
 <div
@@ -132,8 +134,10 @@
             </Tooltip>
           </h1>
         </header>
-        <TableAssets />
-        <ModelAssets />
+        {#if isModelerEnabled}
+          <TableAssets />
+          <ModelAssets />
+        {/if}
         <MetricsDefinitionAssets />
       </div>
       <Footer />

--- a/web-local/src/lib/components/navigation/NavigationHeader.svelte
+++ b/web-local/src/lib/components/navigation/NavigationHeader.svelte
@@ -11,6 +11,7 @@
   export let toggleText = "models";
   /** The CSS ID used for tests for the context button */
   export let contextButtonID: string = undefined;
+  export let canAddAsset = true;
 
   const dispatch = createEventDispatcher();
 </script>
@@ -25,16 +26,18 @@
       <slot />
     </div>
   </CollapsibleSectionTitle>
-  <ContextButton
-    id={contextButtonID}
-    {tooltipText}
-    on:click={() => {
-      dispatch("add");
-    }}
-    width={24}
-    height={24}
-    rounded
-  >
-    <AddIcon />
-  </ContextButton>
+  {#if canAddAsset}
+    <ContextButton
+      id={contextButtonID}
+      {tooltipText}
+      on:click={() => {
+        dispatch("add");
+      }}
+      width={24}
+      height={24}
+      rounded
+    >
+      <AddIcon />
+    </ContextButton>
+  {/if}
 </div>

--- a/web-local/src/lib/components/navigation/dashboards/MetricsDefinitionAssets.svelte
+++ b/web-local/src/lib/components/navigation/dashboards/MetricsDefinitionAssets.svelte
@@ -178,6 +178,8 @@
     );
     return entities[dashboardPath];
   };
+
+  $: canAddDashboard = $runtimeStore.readOnly === false;
 </script>
 
 <NavigationHeader
@@ -185,6 +187,7 @@
   on:add={dispatchAddEmptyMetricsDef}
   tooltipText="Create a new dashboard"
   toggleText="dashboards"
+  canAddAsset={canAddDashboard}
 >
   Dashboards
 </NavigationHeader>

--- a/web-local/src/lib/components/workspace/explore/ExploreHeader.svelte
+++ b/web-local/src/lib/components/workspace/explore/ExploreHeader.svelte
@@ -51,6 +51,8 @@
       MetricsEventScreenName.MetricsDefinition
     );
   };
+
+  $: isEditableDashboard = $runtimeStore.readOnly === false;
 </script>
 
 <section
@@ -72,16 +74,18 @@
       </div>
     </h1>
     <!-- top right CTAs -->
-    <div style="flex-shrink: 0;">
-      <Tooltip distance={8}>
-        <Button on:click={() => viewMetrics(metricViewName)} type="secondary">
-          Edit Metrics <MetricsIcon size="16px" />
-        </Button>
-        <TooltipContent slot="tooltip-content">
-          Edit this dashboard's metrics & settings
-        </TooltipContent>
-      </Tooltip>
-    </div>
+    {#if isEditableDashboard}
+      <div style="flex-shrink: 0;">
+        <Tooltip distance={8}>
+          <Button on:click={() => viewMetrics(metricViewName)} type="secondary">
+            Edit Metrics <MetricsIcon size="16px" />
+          </Button>
+          <TooltipContent slot="tooltip-content">
+            Edit this dashboard's metrics & settings
+          </TooltipContent>
+        </Tooltip>
+      </div>
+    {/if}
   </div>
   <!-- bottom row -->
   <div class="px-2 pt-1">

--- a/web-local/src/routes/(application)/dashboard/[name]/+page.ts
+++ b/web-local/src/routes/(application)/dashboard/[name]/+page.ts
@@ -34,7 +34,11 @@ export async function load({ params }) {
       metricViewName: params.name,
     };
   } catch (err) {
-    // If the catalog entry doesn't exist, the dashboard config is invalid, so we redirect to the dashboard editor
+    // When the catalog entry doesn't exist, the dashboard config is invalid
+    if (config.readonly) {
+      throw error(400, "Invalid dashboard");
+    }
+
     throw redirect(307, `/dashboard/${params.name}/edit`);
   }
 }

--- a/web-local/src/routes/(application)/dashboard/[name]/+page.ts
+++ b/web-local/src/routes/(application)/dashboard/[name]/+page.ts
@@ -12,11 +12,11 @@ export const ssr = false;
 
 /** @type {import('./$types').PageLoad} */
 export async function load({ params }) {
-  const localConfig = await runtimeServiceGetConfig();
+  const config = await runtimeServiceGetConfig();
 
   try {
     await runtimeServiceGetFile(
-      localConfig.instance_id,
+      config.instance_id,
       getFilePathFromNameAndType(params.name, EntityType.MetricsDefinition)
     );
   } catch (err) {
@@ -28,7 +28,7 @@ export async function load({ params }) {
   }
 
   try {
-    await runtimeServiceGetCatalogEntry(localConfig.instance_id, params.name);
+    await runtimeServiceGetCatalogEntry(config.instance_id, params.name);
 
     return {
       metricViewName: params.name,

--- a/web-local/src/routes/(application)/dashboard/[name]/edit/+page.ts
+++ b/web-local/src/routes/(application)/dashboard/[name]/edit/+page.ts
@@ -10,11 +10,14 @@ import { CATALOG_ENTRY_NOT_FOUND } from "../../../../../lib/errors/messages";
 
 /** @type {import('./$types').PageLoad} */
 export async function load({ params }) {
-  const localConfig = await runtimeServiceGetConfig();
+  const config = await runtimeServiceGetConfig();
+  if (config.readonly) {
+    throw error(404, "Page not found");
+  }
 
   try {
     await runtimeServiceGetFile(
-      localConfig.instance_id,
+      config.instance_id,
       getFilePathFromNameAndType(params.name, EntityType.MetricsDefinition)
     );
   } catch (err) {
@@ -26,7 +29,7 @@ export async function load({ params }) {
   }
 
   try {
-    await runtimeServiceGetCatalogEntry(localConfig.instance_id, params.name);
+    await runtimeServiceGetCatalogEntry(config.instance_id, params.name);
 
     return {
       metricsDefName: params.name,

--- a/web-local/src/routes/(application)/model/[name]/+page.ts
+++ b/web-local/src/routes/(application)/model/[name]/+page.ts
@@ -11,10 +11,13 @@ export async function load({ params, url }) {
   /** If ?focus, tell the page to focus the editor as soon as available */
   const focusEditor = url.searchParams.get("focus") === "";
   try {
-    const localConfig = await runtimeServiceGetConfig();
+    const config = await runtimeServiceGetConfig();
+    if (config.readonly) {
+      throw error(404, "Page not found");
+    }
 
     await runtimeServiceGetFile(
-      localConfig.instance_id,
+      config.instance_id,
       getFilePathFromNameAndType(params.name, EntityType.Model)
     );
 

--- a/web-local/src/routes/(application)/source/[name]/+page.ts
+++ b/web-local/src/routes/(application)/source/[name]/+page.ts
@@ -11,13 +11,16 @@ export const ssr = false;
 
 /** @type {import('./$types').PageLoad} */
 export async function load({ params }) {
-  const localConfig = await runtimeServiceGetConfig();
+  const config = await runtimeServiceGetConfig();
+  if (config.readonly) {
+    throw error(404, "Page not found");
+  }
 
   // try to get the catalog entry.
   let catalogEntry;
   try {
     catalogEntry = await runtimeServiceGetCatalogEntry(
-      localConfig.instance_id,
+      config.instance_id,
       params.name
     );
     // if this is a valid catalog entry, then we can return it.
@@ -32,7 +35,7 @@ export async function load({ params }) {
 
   try {
     await runtimeServiceGetFile(
-      localConfig.instance_id,
+      config.instance_id,
       getFilePathFromNameAndType(params.name, EntityType.Table)
     );
 


### PR DESCRIPTION
This PR provides that when `rill start --readonly`:
- Sources and Models are hidden from the navigation sidebar. Any direct navigation to these pages results in a 404.
- There is no "Add Dashboard" button in the navigation sidebar.
- The `Edit Metrics` button is hidden from the Dashboard workspace.
- The onboarding workspace does not mention Sources, Models, or Metric Definitions