### PR TITLE
Add `svelte-check --watch` to `npm run dev`

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "npm run build -w web-local",
     "dev": "sh -c 'npm run dev-runtime & npm run dev-web & wait'",
-    "dev-web": "npm run dev -w web-local",
+    "dev-web": "npm run dev -w web-local & npm run check:watch -w web-local",
     "dev-runtime": "go run cli/main.go start --no-ui --project dev-project",
     "clean": "rm -rf dev-project",
     "test": "npm run test -w web-local"

--- a/web-local/package.json
+++ b/web-local/package.json
@@ -7,7 +7,7 @@
     "build": "vite build",
     "install-and-build": "npm install && npm run build",
     "check": "svelte-check --tsconfig ./tsconfig.json",
-    "check:watch": "svelte-check --tsconfig ./tsconfig.json --watch",
+    "check:watch": "svelte-check --tsconfig ./tsconfig.json --watch --output human --threshold warning",
     "lint": "eslint --ignore-path .gitignore .",
     "format": "prettier --ignore-path .gitignore --write --plugin-search-dir=. .",
     "test": "npm run test:backend && npm run test:ui",


### PR DESCRIPTION
This PR adds `svelte-check --watch` to our `npm run dev` script. `svelte-check` currently reports 135 errors. Once we fix the errors, we can add `svelte-check` to CI/CD to ensure no errors get merged into `main` going forward.