### PR TITLE
adds a stopgap for INTERVAL types

### DIFF
--- a/web-common/src/components/data-types/Interval.svelte
+++ b/web-common/src/components/data-types/Interval.svelte
@@ -5,6 +5,10 @@
   export let dark = false;
 </script>
 
-<Base {isNull} classes="font-semibold {inTable && 'block text-right'}" {dark}>
+<Base
+  {isNull}
+  classes="font-semibold truncate {inTable && 'block text-right'}"
+  {dark}
+>
   <slot />
 </Base>

--- a/web-local/src/lib/components/column-profile/column-types/NumericProfile.svelte
+++ b/web-local/src/lib/components/column-profile/column-types/NumericProfile.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { copyToClipboard } from "@rilldata/web-common/lib/actions/shift-click-action";
+  import { INTERVALS } from "@rilldata/web-common/lib/duckdb-data-types";
   import {
     useRuntimeServiceGetDescriptiveStatistics,
     useRuntimeServiceGetRugHistogram,
@@ -104,7 +105,11 @@
     totalRows={$nulls?.totalRows}
     {type}
   />
-  <div class="pl-10 pr-4 py-4" slot="details">
+  <div
+    class="pl-10 pr-4 py-4"
+    slot="details"
+    class:hidden={INTERVALS.has(type)}
+  >
     <NumericPlot
       data={$numericHistogram.data}
       rug={$rug?.data}

--- a/web-local/src/lib/components/column-profile/column-types/index.ts
+++ b/web-local/src/lib/components/column-profile/column-types/index.ts
@@ -1,5 +1,6 @@
 import {
   CATEGORICALS,
+  INTERVALS,
   NUMERICS,
   TIMESTAMPS,
 } from "@rilldata/web-common/lib/duckdb-data-types";
@@ -12,6 +13,6 @@ export function getColumnType(type) {
   if (type.includes("DECIMAL")) type = "DECIMAL";
 
   if (CATEGORICALS.has(type)) return VarcharProfile;
-  if (NUMERICS.has(type)) return NumericProfile;
+  if (NUMERICS.has(type) || INTERVALS.has(type)) return NumericProfile;
   if (TIMESTAMPS.has(type)) return TimestampProfile;
 }


### PR DESCRIPTION
closes #1648 

This PR is a stopgap that brings back intervals into profiling but does not profile them meaningfully (yet). @magorlick took a look at the UX and we feel this is acceptable for now; we need to show _something_.