### PR TITLE
Disable bidirectional models

### DIFF
--- a/web-common/src/features/entity-management/sync-file-system.ts
+++ b/web-common/src/features/entity-management/sync-file-system.ts
@@ -97,6 +97,8 @@ async function syncFileSystem(
 
   const pagePath = get(page).url.pathname;
   if (!isPathToAsset(pagePath)) return;
+  // TEMPORARY: don't reconcile models
+  if (pagePath.startsWith("/model")) return;
 
   const filePath = getFilePathFromPagePath(pagePath);
   fileArtifactsStore.setIsReconciling(filePath, true);


### PR DESCRIPTION
This PR turns off live synchronization between model artifacts and the model editor in the Rill UI.