### PR TITLE
preview table: punt on overscan for 1 second

### DIFF
--- a/web-local/src/lib/components/preview-table/ConnectedPreviewTable.svelte
+++ b/web-local/src/lib/components/preview-table/ConnectedPreviewTable.svelte
@@ -3,6 +3,7 @@
     useRuntimeServiceGetTableRows,
     useRuntimeServiceProfileColumns,
   } from "@rilldata/web-common/runtime-client";
+  import { onMount } from "svelte";
 
   import { PreviewTable } from ".";
   import { runtimeStore } from "../../application-state-stores/application-store";
@@ -24,8 +25,27 @@
   );
 
   $: rows = $tableQuery?.data?.data;
+
+  /** We will set the overscan amounts to 0 for initial render;
+   * in practice, this will shave off around 200ms from the initial render.
+   * Then, after 1 second, we will set the overscan amounts to 40 and 10,
+   * which wil then cause the table to render with the overscan amounts.
+   */
+  let rowOverscanAmount = 0;
+  let columnOverscanAmount = 0;
+  onMount(() => {
+    setTimeout(() => {
+      rowOverscanAmount = 40;
+      columnOverscanAmount = 10;
+    }, 1000);
+  });
 </script>
 
 {#if rows && profileColumns}
-  <PreviewTable {rows} columnNames={profileColumns} />
+  <PreviewTable
+    {rows}
+    columnNames={profileColumns}
+    {rowOverscanAmount}
+    {columnOverscanAmount}
+  />
 {/if}


### PR DESCRIPTION
Looking at a performance assessment of a model workspace render, it seems that rendering even the virtualized table was causing an additional ~240ms to the script + paint. This likely happens because we're also rendering the row & column overscans, which is an additional 40 rows & 10 columns. An extra 400 cells is quite a bit; so this PR reduces the overscan on mount and then applies it a second later, which seems to improve the initial mount time & brings down the render to ~7ms.