### PR TITLE
Disable sync-on-navigate & sync-on-focus

### DIFF
--- a/web-common/src/features/entity-management/sync-file-system.ts
+++ b/web-common/src/features/entity-management/sync-file-system.ts
@@ -138,8 +138,7 @@ export function addReconcilingOverlay(pagePath: string) {
     if (isFileReconciling) {
       delayedOverlayTimeout = setTimeout(() => {
         overlay.set({
-          title: `Loading`,
-          message: `Rill is validating your assets and ingesting new sources — this could take a moment`,
+          title: `Updating project — this could take a moment`,
         });
       }, RECONCILE_OVERLAY_DELAY_MILLISECONDS);
     } else {

--- a/web-common/src/features/entity-management/sync-file-system.ts
+++ b/web-common/src/features/entity-management/sync-file-system.ts
@@ -44,7 +44,7 @@ export function syncFileSystemPeriodically(
     if (afterNavigateRanOnce) return;
 
     // Scenario 1: sync when the user navigates to a new page
-    syncFileSystem(queryClient, runtimeInstanceId, page, fileArtifactsStore);
+    // syncFileSystem(queryClient, runtimeInstanceId, page, fileArtifactsStore);
 
     // setup Scenario 2: sync every X seconds
     syncFileSystemInterval = setInterval(
@@ -59,17 +59,17 @@ export function syncFileSystemPeriodically(
     );
 
     // setup Scenario 3: sync when the user returns focus to the browser tab
-    syncFileSystemOnVisibleDocument = async () => {
-      if (document.visibilityState === "visible") {
-        await syncFileSystem(
-          queryClient,
-          runtimeInstanceId,
-          page,
-          fileArtifactsStore
-        );
-      }
-    };
-    window.addEventListener("focus", syncFileSystemOnVisibleDocument);
+    // syncFileSystemOnVisibleDocument = async () => {
+    //   if (document.visibilityState === "visible") {
+    //     await syncFileSystem(
+    //       queryClient,
+    //       runtimeInstanceId,
+    //       page,
+    //       fileArtifactsStore
+    //     );
+    //   }
+    // };
+    // window.addEventListener("focus", syncFileSystemOnVisibleDocument);
 
     afterNavigateRanOnce = true;
   });
@@ -79,7 +79,7 @@ export function syncFileSystemPeriodically(
     clearInterval(syncFileSystemInterval);
 
     // teardown Scenario 3
-    window.removeEventListener("focus", syncFileSystemOnVisibleDocument);
+    // window.removeEventListener("focus", syncFileSystemOnVisibleDocument);
 
     afterNavigateRanOnce = false;
   });


### PR DESCRIPTION
Disables two scenarios under which we sync the Rill UI with code artifacts: on page navigation & on browser focus.