### PR TITLE
navigation always registers click (or appears to register it)

### DIFF
--- a/web-common/src/features/entity-management/actions.ts
+++ b/web-common/src/features/entity-management/actions.ts
@@ -1,5 +1,6 @@
 import { goto } from "$app/navigation";
 import { notifications } from "@rilldata/web-common/components/notifications";
+import { currentHref } from "@rilldata/web-common/layout/navigation/stores";
 import type {
   V1DeleteFileAndReconcileResponse,
   V1RenameFileAndReconcileResponse,
@@ -79,7 +80,10 @@ export async function deleteFileArtifact(
 
     invalidateAfterReconcile(queryClient, instanceId, resp);
     if (activeEntity?.name === name) {
-      goto(getRouteFromName(getNextEntityName(names, name), type));
+      const route = getRouteFromName(getNextEntityName(names, name), type);
+      /** set the href store so the menu selection has an immediate visual update. */
+      currentHref.set(route);
+      goto(route);
     }
   } catch (err) {
     console.error(err);

--- a/web-common/src/layout/navigation/NavigationEntry.svelte
+++ b/web-common/src/layout/navigation/NavigationEntry.svelte
@@ -12,6 +12,7 @@
   import ContextButton from "@rilldata/web-local/lib/components/column-profile/ContextButton.svelte";
   import ExpanderButton from "@rilldata/web-local/lib/components/column-profile/ExpanderButton.svelte";
   import { createCommandClickAction } from "@rilldata/web-local/lib/util/command-click-action";
+  import { currentHref } from "./stores";
 
   export let name: string;
   export let href: string;
@@ -61,6 +62,8 @@
   let innerOpen = false;
   // always keep innerOpen set to open.
   $: innerOpen = open;
+  // register the current open state with the global store on instantiation.
+  if ($currentHref !== href && open) currentHref.set(href);
 </script>
 
 <Tooltip
@@ -76,6 +79,7 @@
       if (open) onShowDetails();
     }}
     on:mousedown={() => {
+      $currentHref = href;
       mousedown = true;
     }}
     on:mouseup={() => {
@@ -89,11 +93,12 @@
       // perform navigation in this case.
       await goto(href);
       mousedown = false;
+      $currentHref = href;
     }}
     style:height="24px"
-    class:font-bold={innerOpen || mousedown}
-    class:bg-gray-200={innerOpen && !mousedown}
-    class:bg-gray-100={mousedown}
+    class:font-bold={(innerOpen || mousedown) && $currentHref === href}
+    class:bg-gray-200={$currentHref === href}
+    class:bg-gray-100={$currentHref !== href && mousedown}
     class="
     navigation-entry-title grid gap-x-1 items-center pl-2 pr-2 {!innerOpen &&
     !mousedown
@@ -133,7 +138,7 @@
         {#if $$slots["name"]}
           <slot name="name" />
         {:else}
-          {name}
+          {$currentHref === href} {name}
         {/if}
       </div>
     </div>
@@ -150,7 +155,7 @@
         class="self-center"
         class:opacity-0={!containerFocused &&
           !contextMenuOpen &&
-          !open &&
+          !innerOpen &&
           !contextMenuHovered}
       >
         <ContextButton

--- a/web-common/src/layout/navigation/NavigationEntry.svelte
+++ b/web-common/src/layout/navigation/NavigationEntry.svelte
@@ -89,6 +89,8 @@
     class:bg-gray-200={isActive}
     class:bg-gray-100={isActive && mousedown}
     class="
+    focus:bg-gray-200
+    focus:outline-none
     navigation-entry-title grid gap-x-1 items-center pl-2 pr-2 {!isActive &&
     !mousedown
       ? 'hover:bg-gray-100'

--- a/web-common/src/layout/navigation/NavigationEntry.svelte
+++ b/web-common/src/layout/navigation/NavigationEntry.svelte
@@ -138,7 +138,7 @@
         {#if $$slots["name"]}
           <slot name="name" />
         {:else}
-          {$currentHref === href} {name}
+          {name}
         {/if}
       </div>
     </div>

--- a/web-common/src/layout/navigation/stores.ts
+++ b/web-common/src/layout/navigation/stores.ts
@@ -1,7 +1,21 @@
-import { writable } from "svelte/store";
+import { page } from "$app/stores";
+import { get, writable } from "svelte/store";
+
 /** maintains the global state across all navigation entries.
  * We use this store to track immediate clicks, rather than use the page store
  * from sveltekit. This is because the page store is updated after the navigation
  * while we need to capture immediate clicks.
  */
 export const currentHref = writable<string>(undefined);
+
+page.subscribe((pageState) => {
+  const href = get(currentHref);
+  const pathname = pageState?.url?.pathname;
+  // This is a hack to prevent the currentHref from being set to undefined.
+  if (!pathname) return;
+  // look at only the first two segments of the path. We map all file type views to these two for now.
+  // later, we will have better decision rules for reactively setting this variable.
+  const segments = pathname.split("/").slice(0, 3);
+  const path = segments.join("/");
+  if (href !== path) currentHref.set(path);
+});

--- a/web-common/src/layout/navigation/stores.ts
+++ b/web-common/src/layout/navigation/stores.ts
@@ -4,18 +4,21 @@ import { get, writable } from "svelte/store";
 /** maintains the global state across all navigation entries.
  * We use this store to track immediate clicks, rather than use the page store
  * from sveltekit. This is because the page store is updated after the navigation
- * while we need to capture immediate clicks.
+ * while we need to capture immediate clicks for styling information.
  */
 export const currentHref = writable<string>(undefined);
 
+/**
+ * For now, we will reactively update currentHref when the page store changes
+ * and the pathname doesn't match. This enables us to reduce the latency in
+ * the perceived click event of a menu item. Once we are able to reduce route
+ * change loads to < 50ms, we can re-address whether we need this store.
+ */
 page.subscribe((pageState) => {
   const href = get(currentHref);
   const pathname = pageState?.url?.pathname;
-  // This is a hack to prevent the currentHref from being set to undefined.
+  // prevent the currentHref from being set to undefined.
   if (!pathname) return;
-  // look at only the first two segments of the path. We map all file type views to these two for now.
-  // later, we will have better decision rules for reactively setting this variable.
-  const segments = pathname.split("/").slice(0, 3);
-  const path = segments.join("/");
-  if (href !== path) currentHref.set(path);
+  // only update the currentHref if needed
+  if (href !== pathname) currentHref.set(pathname);
 });

--- a/web-common/src/layout/navigation/stores.ts
+++ b/web-common/src/layout/navigation/stores.ts
@@ -1,0 +1,7 @@
+import { writable } from "svelte/store";
+/** maintains the global state across all navigation entries.
+ * We use this store to track immediate clicks, rather than use the page store
+ * from sveltekit. This is because the page store is updated after the navigation
+ * while we need to capture immediate clicks.
+ */
+export const currentHref = writable<string>(undefined);

--- a/web-local/src/lib/components/column-profile/ContextButton.svelte
+++ b/web-local/src/lib/components/column-profile/ContextButton.svelte
@@ -28,7 +28,7 @@
   suppress={suppressTooltip || tooltipText === undefined}
 >
   <button
-    on:click
+    on:click|preventDefault
     {id}
     use:captureHoverState
     style:width={`${width}px`}

--- a/web-local/src/lib/components/column-profile/ContextButton.svelte
+++ b/web-local/src/lib/components/column-profile/ContextButton.svelte
@@ -36,6 +36,8 @@
     style:grid-column="left-control"
     class:rounded
     class="
+        focus:outline-none
+        focus:bg-gray-300
         hover:bg-gray-300
         transition-tranform 
         text-gray-500

--- a/web-local/src/lib/components/column-profile/ExpanderButton.svelte
+++ b/web-local/src/lib/components/column-profile/ExpanderButton.svelte
@@ -22,7 +22,7 @@
   suppress={suppressTooltip}
 >
   <button
-    on:click
+    on:click|preventDefault|stopPropagation
     use:captureHoverState
     style:width="20px"
     style:height="20px"

--- a/web-local/src/lib/components/column-profile/ExpanderButton.svelte
+++ b/web-local/src/lib/components/column-profile/ExpanderButton.svelte
@@ -28,6 +28,8 @@
     style:height="20px"
     style:grid-column="left-control"
     class="
+    focus:outline-none
+    focus:bg-gray-300
     hover:bg-gray-300
     transition-tranform 
     text-gray-400


### PR DESCRIPTION
closes #1670

The point of this PR is to reduce perceived click latency in the navigation menu.

This PR does the following:
- inverts the `a` tag to be the container element of the `NavigationEntry`, increasing the click area and thus preventing a bad experience on the edges of the nav entry
- adds a `preventDefault` to the inner buttons to prevent navigation when clicking on the expander / context button
- highlights soon-to-be active navigation entry on mousedown
- adds a global `currentHref` store that also applies styling to all nav entries, making it appear that the newly-mousdown entry is the only one selected
- all navigation events will reactively update the `currentHref` store if it doesn't match the current path. For the navigation items, only look at the first two segments of the path, since we will likely have other subviews (e.g. config is at `/dashboard/<name>/edit`)
- `dragend` also selects item now, which means that quick mousedown + drags will be registered the same as a click. This might not be the right move once we migrate to a different form of navigation.

What this PR _doesn't_ do:
- does not reduce time to render workspace. This will be covered in another PR as we handle (1) virtualization and (2) aborting the query queue more quickly.

![Kapture 2023-02-04 at 06 50 12](https://user-images.githubusercontent.com/95735/216773930-2dac5bcc-9b7c-48e7-9554-0a241dd5c2b8.gif)
