### PR TITLE
adds `JSON` type to nested types

### DIFF
--- a/web-common/src/lib/duckdb-data-types.ts
+++ b/web-common/src/lib/duckdb-data-types.ts
@@ -68,7 +68,9 @@ export function isList(type) {
 
 export function isNested(type) {
   return (
-    [...NESTED].some((typeDef) => type.startsWith(typeDef)) || isList(type)
+    type === "JSON" ||
+    [...NESTED].some((typeDef) => type.startsWith(typeDef)) ||
+    isList(type)
   );
 }
 

--- a/web-common/src/lib/formatters.ts
+++ b/web-common/src/lib/formatters.ts
@@ -164,6 +164,9 @@ export function formatDataType(value: any, type: string) {
       .map((entry) => (+entry ? +entry : `'${entry}'`))
       .join(", ")}]`;
   }
+  if (type === "JSON") {
+    return value;
+  }
   // use this for structs, maps, etc
   return JSON.stringify(value).replace(/"/g, "'");
 }


### PR DESCRIPTION
This will treat any `JSON` columns the same as structs or lists, using the same styling / decision criteria as structs.