### PR TITLE
Make admin server host configurable

### DIFF
--- a/web-admin/README.md
+++ b/web-admin/README.md
@@ -28,3 +28,7 @@ To re-generate the client, run:
 ```script
 npm run generate:client -w web-admin
 ```
+
+## Building for production
+
+1. Set the `VITE_RILL_ADMIN_URL` environment variable to the URL of the control plane server (e.g. `https://admin.rilldata.com`)

--- a/web-admin/src/client/http-client.ts
+++ b/web-admin/src/client/http-client.ts
@@ -1,8 +1,9 @@
 import type { AxiosRequestConfig } from "axios";
 import Axios from "axios";
+import { ADMIN_URL } from "../lib/connection";
 
 export const AXIOS_INSTANCE = Axios.create({
-  baseURL: "http://localhost:8080",
+  baseURL: ADMIN_URL,
 });
 
 // TODO: use the new client?

--- a/web-admin/src/client/http-client.ts
+++ b/web-admin/src/client/http-client.ts
@@ -1,6 +1,8 @@
 import type { AxiosRequestConfig } from "axios";
 import Axios from "axios";
-import { ADMIN_URL } from "../lib/connection";
+
+const ADMIN_URL =
+  import.meta.env.VITE_RILL_ADMIN_URL || "http://localhost:8080";
 
 export const AXIOS_INSTANCE = Axios.create({
   baseURL: ADMIN_URL,

--- a/web-admin/src/lib/connection.ts
+++ b/web-admin/src/lib/connection.ts
@@ -1,0 +1,8 @@
+export const IS_PRODUCTION = process.env.NODE_ENV === "production";
+
+export const HTTP_PROTOCOL = IS_PRODUCTION ? "https" : "http";
+
+export const ADMIN_HOST = IS_PRODUCTION
+  ? "admin.rilldata.com"
+  : "localhost:8080";
+export const ADMIN_URL = `${HTTP_PROTOCOL}://${ADMIN_HOST}`;

--- a/web-admin/src/lib/connection.ts
+++ b/web-admin/src/lib/connection.ts
@@ -1,8 +1,0 @@
-export const IS_PRODUCTION = process.env.NODE_ENV === "production";
-
-export const HTTP_PROTOCOL = IS_PRODUCTION ? "https" : "http";
-
-export const ADMIN_HOST = IS_PRODUCTION
-  ? "admin.rilldata.com"
-  : "localhost:8080";
-export const ADMIN_URL = `${HTTP_PROTOCOL}://${ADMIN_HOST}`;


### PR DESCRIPTION
This PR sets the admin server URL to be `http://localhost:8080` in development and `https://admin.rilldata.com` in production.