### PR TITLE
Add proto serialization of DuckDB maps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -187,4 +187,6 @@ require (
 
 replace github.com/apache/calcite-avatica-go/v5 v5.1.0 => github.com/begelundmuller/calcite-avatica-go/v5 v5.0.0-20221026194811-52480d9968a9
 
+replace github.com/marcboeker/go-duckdb v1.2.0 => github.com/marcboeker/go-duckdb v1.2.1-0.20230219144401-fdeb27f3e1f9
+
 exclude modernc.org/sqlite v1.18.1

--- a/go.sum
+++ b/go.sum
@@ -1137,8 +1137,8 @@ github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7
 github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
-github.com/marcboeker/go-duckdb v1.2.0 h1:VHzRrGE3U7VGi4UsHqOErNeYCR5TP39zlW5AxQOjnSs=
-github.com/marcboeker/go-duckdb v1.2.0/go.mod h1:hiESNxIrSFZGzPbAmcWjaVKYlIW8hB4uGz0AgEba5Ck=
+github.com/marcboeker/go-duckdb v1.2.1-0.20230219144401-fdeb27f3e1f9 h1:LGZZkbyO43Pi4whILIjYa/p2dDISNp3Aic8CXi8Xbso=
+github.com/marcboeker/go-duckdb v1.2.1-0.20230219144401-fdeb27f3e1f9/go.mod h1:wm91jO2GNKa6iO9NTcjXIRsW+/ykPoJbQcHSXhdAl28=
 github.com/markbates/oncer v0.0.0-20181203154359-bf2de49a0be2/go.mod h1:Ld9puTsIW75CHf65OeIOkyKbteujpZVXDpWK6YGZbxE=
 github.com/markbates/safe v1.0.1/go.mod h1:nAqgmRi7cY2nqMc92/bSEeQA+R4OheNU2T1kNSCBdG0=
 github.com/marstr/guid v1.1.0/go.mod h1:74gB1z2wpxxInTG6yaqA7KrtM0NZ+RbrcqDvYHefzho=

--- a/runtime/pkg/pbutil/pbutil.go
+++ b/runtime/pkg/pbutil/pbutil.go
@@ -136,7 +136,7 @@ func ToStructCoerceKeys(v map[any]any) (*structpb.Struct, error) {
 // trimQuotes removes surrounding double quotes from a string, if present.
 // Examples: `"10"` -> `10` and `10` -> `10`.
 func trimQuotes(s string) string {
-	if len(s) > 1 {
+	if len(s) >= 2 {
 		if s[0] == '"' && s[len(s)-1] == '"' {
 			return s[1 : len(s)-1]
 		}

--- a/runtime/pkg/pbutil/pbutil_test.go
+++ b/runtime/pkg/pbutil/pbutil_test.go
@@ -1,0 +1,33 @@
+package pbutil
+
+import (
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func TestToStructCoerceKeys(t *testing.T) {
+	cases := []struct {
+		Input    map[any]any
+		Expected map[string]any
+	}{
+		{Input: map[any]any{10: 1}, Expected: map[string]any{"10": 1}},
+		{Input: map[any]any{big.NewInt(10): 1}, Expected: map[string]any{"10": 1}},
+		{Input: map[any]any{3.141: 1}, Expected: map[string]any{"3.141": 1}},
+		{Input: map[any]any{3.141: map[any]any{1: 2}}, Expected: map[string]any{"3.141": map[string]any{"1": 2}}},
+		{Input: map[any]any{time.Date(2020, 01, 01, 0, 0, 0, 0, time.UTC): 20}, Expected: map[string]any{"2020-01-01T00:00:00Z": 20}},
+	}
+	for _, tt := range cases {
+		expected, err := structpb.NewStruct(tt.Expected)
+		require.NoError(t, err)
+
+		actual, err := ToStructCoerceKeys(tt.Input)
+		require.NoError(t, err)
+
+		require.True(t, proto.Equal(expected, actual))
+	}
+}

--- a/runtime/queries/column_timeseries.go
+++ b/runtime/queries/column_timeseries.go
@@ -11,7 +11,7 @@ import (
 	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
 	"github.com/rilldata/rill/runtime"
 	"github.com/rilldata/rill/runtime/drivers"
-	"github.com/rilldata/rill/runtime/server/pbutil"
+	"github.com/rilldata/rill/runtime/pkg/pbutil"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )

--- a/runtime/queries/column_topk.go
+++ b/runtime/queries/column_topk.go
@@ -7,7 +7,7 @@ import (
 	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
 	"github.com/rilldata/rill/runtime"
 	"github.com/rilldata/rill/runtime/drivers"
-	"github.com/rilldata/rill/runtime/server/pbutil"
+	"github.com/rilldata/rill/runtime/pkg/pbutil"
 )
 
 type ColumnTopK struct {

--- a/runtime/queries/metricsview.go
+++ b/runtime/queries/metricsview.go
@@ -8,7 +8,7 @@ import (
 	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
 	"github.com/rilldata/rill/runtime"
 	"github.com/rilldata/rill/runtime/drivers"
-	"github.com/rilldata/rill/runtime/server/pbutil"
+	"github.com/rilldata/rill/runtime/pkg/pbutil"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/structpb"

--- a/runtime/queries/table_head.go
+++ b/runtime/queries/table_head.go
@@ -1,0 +1,67 @@
+package queries
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/rilldata/rill/runtime"
+	"github.com/rilldata/rill/runtime/drivers"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+type TableHead struct {
+	TableName string
+	Limit     int
+	Result    []*structpb.Struct
+}
+
+var _ runtime.Query = &TableHead{}
+
+func (q *TableHead) Key() string {
+	return fmt.Sprintf("TableHead:%s", q.TableName)
+}
+
+func (q *TableHead) Deps() []string {
+	return []string{q.TableName}
+}
+
+func (q *TableHead) MarshalResult() any {
+	return q.Result
+}
+
+func (q *TableHead) UnmarshalResult(v any) error {
+	res, ok := v.([]*structpb.Struct)
+	if !ok {
+		return fmt.Errorf("TableHead: mismatched unmarshal input")
+	}
+	q.Result = res
+	return nil
+}
+
+func (q *TableHead) Resolve(ctx context.Context, rt *runtime.Runtime, instanceID string, priority int) error {
+	olap, err := rt.OLAP(ctx, instanceID)
+	if err != nil {
+		return err
+	}
+
+	if olap.Dialect() != drivers.DialectDuckDB {
+		return fmt.Errorf("not available for dialect '%s'", olap.Dialect())
+	}
+
+	rows, err := olap.Execute(ctx, &drivers.Statement{
+		Query:    fmt.Sprintf("SELECT * FROM %s LIMIT %d", safeName(q.TableName), q.Limit),
+		Priority: priority,
+	})
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	data, err := rowsToData(rows)
+	if err != nil {
+		return err
+	}
+
+	q.Result = data
+	return nil
+}

--- a/runtime/server/queries.go
+++ b/runtime/server/queries.go
@@ -5,7 +5,7 @@ import (
 
 	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
 	"github.com/rilldata/rill/runtime/drivers"
-	"github.com/rilldata/rill/runtime/server/pbutil"
+	"github.com/rilldata/rill/runtime/pkg/pbutil"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/structpb"

--- a/runtime/server/queries.go
+++ b/runtime/server/queries.go
@@ -2,15 +2,10 @@ package server
 
 import (
 	"context"
-	"fmt"
-	"math"
-	"math/big"
-	"time"
-	"unicode/utf8"
 
-	"github.com/marcboeker/go-duckdb"
 	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
 	"github.com/rilldata/rill/runtime/drivers"
+	"github.com/rilldata/rill/runtime/server/pbutil"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -23,7 +18,12 @@ func (s *Server) Query(ctx context.Context, req *runtimev1.QueryRequest) (*runti
 		args[i] = arg.AsInterface()
 	}
 
-	res, err := s.query(ctx, req.InstanceId, &drivers.Statement{
+	olap, err := s.runtime.OLAP(ctx, req.InstanceId)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := olap.Execute(ctx, &drivers.Statement{
 		Query:    req.Sql,
 		Args:     args,
 		DryRun:   req.DryRun,
@@ -55,15 +55,6 @@ func (s *Server) Query(ctx context.Context, req *runtimev1.QueryRequest) (*runti
 	return resp, nil
 }
 
-func (s *Server) query(ctx context.Context, instanceID string, stmt *drivers.Statement) (*drivers.Result, error) {
-	olap, err := s.runtime.OLAP(ctx, instanceID)
-	if err != nil {
-		return nil, err
-	}
-
-	return olap.Execute(ctx, stmt)
-}
-
 func rowsToData(rows *drivers.Result) ([]*structpb.Struct, error) {
 	var data []*structpb.Struct
 	for rows.Next() {
@@ -73,7 +64,7 @@ func rowsToData(rows *drivers.Result) ([]*structpb.Struct, error) {
 			return nil, err
 		}
 
-		rowStruct, err := mapToPB(rowMap)
+		rowStruct, err := pbutil.ToStruct(rowMap)
 		if err != nil {
 			return nil, err
 		}
@@ -87,101 +78,4 @@ func rowsToData(rows *drivers.Result) ([]*structpb.Struct, error) {
 	}
 
 	return data, nil
-}
-
-// valToPB converts any value to a google.protobuf.Value. It's similar to
-// structpb.NewValue, but adds support for a few extra primitive types.
-func valToPB(v any) (*structpb.Value, error) {
-	switch v := v.(type) {
-	// In addition to the extra supported types, we also override handling for
-	// maps and lists since we need to use valToPB on nested fields.
-	case map[string]interface{}:
-		v2, err := mapToPB(v)
-		if err != nil {
-			return nil, err
-		}
-		return structpb.NewStructValue(v2), nil
-	case []interface{}:
-		v2, err := sliceToPB(v)
-		if err != nil {
-			return nil, err
-		}
-		return structpb.NewListValue(v2), nil
-	// Handle types not handled by structpb.NewValue
-	case int8:
-		return structpb.NewNumberValue(float64(v)), nil
-	case int16:
-		return structpb.NewNumberValue(float64(v)), nil
-	case uint8:
-		return structpb.NewNumberValue(float64(v)), nil
-	case uint16:
-		return structpb.NewNumberValue(float64(v)), nil
-	case time.Time:
-		s := v.Format(time.RFC3339Nano)
-		return structpb.NewStringValue(s), nil
-	case float32:
-		// Turning NaNs and Infs into nulls until frontend can deal with them as strings
-		// (They don't have a native JSON representation)
-		if math.IsNaN(float64(v)) || math.IsInf(float64(v), 0) {
-			return structpb.NewNullValue(), nil
-		}
-		return structpb.NewNumberValue(float64(v)), nil
-	case float64:
-		// Turning NaNs and Infs into nulls until frontend can deal with them as strings
-		// (They don't have a native JSON representation)
-		if math.IsNaN(v) || math.IsInf(v, 0) {
-			return structpb.NewNullValue(), nil
-		}
-		return structpb.NewNumberValue(v), nil
-	case *big.Int:
-		// Evil cast to float until frontend can deal with bigs:
-		v2, _ := new(big.Float).SetInt(v).Float64()
-		return structpb.NewNumberValue(v2), nil
-		// This is what we should do when frontend supports it:
-		// s := v.String()
-		// return structpb.NewStringValue(s), nil
-	case duckdb.Interval:
-		m := map[string]any{"months": v.Months, "days": v.Days, "micros": v.Micros}
-		v2, err := mapToPB(m)
-		if err != nil {
-			return nil, err
-		}
-		return structpb.NewStructValue(v2), nil
-	default:
-		// Default handling for basic types (ints, string, etc.)
-		return structpb.NewValue(v)
-	}
-}
-
-// mapToPB converts a map to a google.protobuf.Struct. It's similar to
-// structpb.NewStruct(), but it recurses on valToPB instead of structpb.NewValue
-// to add support for more types.
-func mapToPB(v map[string]any) (*structpb.Struct, error) {
-	x := &structpb.Struct{Fields: make(map[string]*structpb.Value, len(v))}
-	for k, v := range v {
-		if !utf8.ValidString(k) {
-			return nil, fmt.Errorf("invalid UTF-8 in string: %q", k)
-		}
-		var err error
-		x.Fields[k], err = valToPB(v)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return x, nil
-}
-
-// sliceToPB converts a map to a google.protobuf.List. It's similar to
-// structpb.NewList(), but it recurses on valToPB instead of structpb.NewList
-// to add support for more types.
-func sliceToPB(v []interface{}) (*structpb.ListValue, error) {
-	x := &structpb.ListValue{Values: make([]*structpb.Value, len(v))}
-	for i, v := range v {
-		var err error
-		x.Values[i], err = valToPB(v)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return x, nil
 }

--- a/runtime/server/queries_tables.go
+++ b/runtime/server/queries_tables.go
@@ -7,7 +7,7 @@ import (
 	"github.com/rilldata/rill/runtime/queries"
 )
 
-const _defaultTableHeadLimit = 25
+const _tableHeadDefaultLimit = 25
 
 // Table level profiling APIs.
 func (s *Server) GetTableCardinality(ctx context.Context, req *runtimev1.GetTableCardinalityRequest) (*runtimev1.GetTableCardinalityResponse, error) {
@@ -47,7 +47,7 @@ func (s *Server) ProfileColumns(ctx context.Context, req *runtimev1.ProfileColum
 func (s *Server) GetTableRows(ctx context.Context, req *runtimev1.GetTableRowsRequest) (*runtimev1.GetTableRowsResponse, error) {
 	limit := int(req.Limit)
 	if limit == 0 {
-		limit = _defaultTableHeadLimit
+		limit = _tableHeadDefaultLimit
 	}
 
 	q := &queries.TableHead{

--- a/runtime/server/queries_tables.go
+++ b/runtime/server/queries_tables.go
@@ -2,13 +2,12 @@ package server
 
 import (
 	"context"
-	"fmt"
 
 	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
-	"github.com/rilldata/rill/runtime/drivers"
 	"github.com/rilldata/rill/runtime/queries"
-	"google.golang.org/protobuf/types/known/structpb"
 )
+
+const _defaultTableHeadLimit = 25
 
 // Table level profiling APIs.
 func (s *Server) GetTableCardinality(ctx context.Context, req *runtimev1.GetTableCardinalityRequest) (*runtimev1.GetTableCardinalityResponse, error) {
@@ -46,21 +45,22 @@ func (s *Server) ProfileColumns(ctx context.Context, req *runtimev1.ProfileColum
 }
 
 func (s *Server) GetTableRows(ctx context.Context, req *runtimev1.GetTableRowsRequest) (*runtimev1.GetTableRowsResponse, error) {
-	rows, err := s.query(ctx, req.InstanceId, &drivers.Statement{
-		Query:    fmt.Sprintf("select * from %q limit %d", req.TableName, req.Limit),
-		Priority: int(req.Priority),
-	})
-	if err != nil {
-		return nil, err
+	limit := int(req.Limit)
+	if limit == 0 {
+		limit = _defaultTableHeadLimit
 	}
-	defer rows.Close()
 
-	var data []*structpb.Struct
-	if data, err = rowsToData(rows); err != nil {
+	q := &queries.TableHead{
+		TableName: req.TableName,
+		Limit:     limit,
+	}
+
+	err := s.runtime.Query(ctx, req.InstanceId, q, int(req.Priority))
+	if err != nil {
 		return nil, err
 	}
 
 	return &runtimev1.GetTableRowsResponse{
-		Data: data,
+		Data: q.Result,
 	}, nil
 }

--- a/runtime/server/queries_tables_test.go
+++ b/runtime/server/queries_tables_test.go
@@ -6,19 +6,9 @@ import (
 
 	"github.com/jmoiron/sqlx"
 	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
-	"github.com/rilldata/rill/runtime/drivers"
 	"github.com/rilldata/rill/runtime/testruntime"
 	"github.com/stretchr/testify/require"
 )
-
-func TestServer_Database(t *testing.T) {
-	server, instanceId := getTableTestServer(t)
-	result, err := server.query(context.Background(), instanceId, &drivers.Statement{
-		Query: "select count(*) from test",
-	})
-	require.NoError(t, err)
-	require.Equal(t, 1, getSingleValue(t, result.Rows))
-}
 
 func TestServer_TableCardinality(t *testing.T) {
 	server, instanceId := getTableTestServer(t)

--- a/runtime/server/queries_timeseries_test.go
+++ b/runtime/server/queries_timeseries_test.go
@@ -892,10 +892,14 @@ func TestServer_Timeseries_1day_Count(t *testing.T) {
 func TestServer_RangeSanity(t *testing.T) {
 	server, instanceID := getTimeseriesTestServer(t)
 
-	result, err := server.query(context.Background(), instanceID, &drivers.Statement{
+	olap, err := server.runtime.OLAP(context.Background(), instanceID)
+	require.NoError(t, err)
+
+	result, err := olap.Execute(context.Background(), &drivers.Statement{
 		Query: "select min(time) min, max(time) max, max(time)-min(time) as r from timeseries",
 	})
 	require.NoError(t, err)
+
 	var min, max time.Time
 	var r duckdb.Interval
 	result.Next()


### PR DESCRIPTION
Closes #1785.

One problem here was that JSON object keys must be strings, but DuckDB maps can have any key type. To address that, I made it serialize the DuckDB map key to a JSON string. However, it won't support complex key types, like using other maps or arrays as map keys ([details here](https://github.com/marcboeker/go-duckdb/pull/74)).

Also refactored a few things:
- Added `TableHead` query type to cache table rows result
- Moved `pbutil` to `runtime/pkg`
- Removed `valToPB` due to duplication