### PR TITLE
fixs MAP type errors in frontend but does not do so in the runtime

### DIFF
--- a/web-common/src/components/column-profile/column-types/index.ts
+++ b/web-common/src/components/column-profile/column-types/index.ts
@@ -11,10 +11,11 @@ import TimestampProfile from "./TimestampProfile.svelte";
 import VarcharProfile from "./VarcharProfile.svelte";
 
 export function getColumnType(type) {
+  // deal with nested types before we deal with the others.
+  if (isNested(type)) return NestedProfile;
   // strip decimal brackets
   if (type.includes("DECIMAL")) type = "DECIMAL";
   if (CATEGORICALS.has(type)) return VarcharProfile;
   if (NUMERICS.has(type) || INTERVALS.has(type)) return NumericProfile;
   if (TIMESTAMPS.has(type)) return TimestampProfile;
-  if (isNested(type)) return NestedProfile;
 }

--- a/web-common/src/components/data-types/DataTypeIcon.svelte
+++ b/web-common/src/components/data-types/DataTypeIcon.svelte
@@ -12,6 +12,7 @@
     INTEGERS,
     INTERVALS,
     isList,
+    isMap,
     isNested,
     STRING_LIKES,
     TIMESTAMPS,
@@ -34,6 +35,8 @@
       return TimestampType;
     } else if (BOOLEANS.has(fieldType)) {
       return BooleanType;
+    } else if (isMap(fieldType)) {
+      return StructType;
     } else if (isList(fieldType)) {
       return ListType;
     } else if (isNested(fieldType)) {

--- a/web-common/src/lib/duckdb-data-types.ts
+++ b/web-common/src/lib/duckdb-data-types.ts
@@ -62,11 +62,15 @@ export const TIMESTAMPS = new Set([
 export const INTERVALS = new Set(["INTERVAL"]);
 export const NESTED = new Set(["STRUCT", "MAP", "LIST"]);
 
-export function isList(type) {
+export function isList(type: string) {
   return type.includes("[]");
 }
 
-export function isNested(type) {
+export function isMap(type: string) {
+  return type.startsWith("MAP(");
+}
+
+export function isNested(type: string) {
   return (
     type === "JSON" ||
     [...NESTED].some((typeDef) => type.startsWith(typeDef)) ||

--- a/web-common/src/lib/formatters.ts
+++ b/web-common/src/lib/formatters.ts
@@ -1,11 +1,12 @@
 import { format } from "d3-format";
 import { timeFormat } from "d3-time-format";
-import type { Interval } from "./duckdb-data-types";
 import {
   CATEGORICALS,
   FLOATS,
   INTEGERS,
+  Interval,
   INTERVALS,
+  isMap,
   PreviewRollupInterval,
   TIMESTAMPS,
 } from "./duckdb-data-types";
@@ -158,6 +159,11 @@ export function formatDataType(value: any, type: string) {
   } else if (INTERVALS.has(type)) {
     return intervalToTimestring(value);
   }
+  // maps should be handled like structs, but needs to be checked
+  // before the others, since it often contains nested types.
+  if (isMap(type)) {
+    return JSON.stringify(value).replace(/"/g, "'");
+  }
   // list type
   if (type.includes("[]")) {
     return `[${value
@@ -167,7 +173,7 @@ export function formatDataType(value: any, type: string) {
   if (type === "JSON") {
     return value;
   }
-  // use this for structs, maps, etc
+  // use this for structs
   return JSON.stringify(value).replace(/"/g, "'");
 }
 


### PR DESCRIPTION
work toward #1798, adds more coherent support for nested `MAP` types in Rill Developer. The nest was triggering a mistyping of things