### PR TITLE
Fix race condition when configuring a dashboard's model

### DIFF
--- a/web-common/src/features/metrics-views/metrics-internal-store.ts
+++ b/web-common/src/features/metrics-views/metrics-internal-store.ts
@@ -145,6 +145,15 @@ export class MetricsInternalRepresentation {
     this.regenerateInternalYAML();
   }
 
+  updateMetricKeys<K extends keyof MetricsConfig>(
+    metrics: Record<K, MetricsConfig[K]>
+  ) {
+    for (const key in metrics) {
+      this.internalRepresentationDocument.set(key, metrics[key]);
+    }
+    this.regenerateInternalYAML();
+  }
+
   updateErrors(errors: Array<V1ReconcileError>) {
     // set errors for measures and dimensions
     for (const error of errors) {

--- a/web-common/src/features/metrics-views/workspace/MetricsModelSelector.svelte
+++ b/web-common/src/features/metrics-views/workspace/MetricsModelSelector.svelte
@@ -12,8 +12,10 @@
   $: allModels = useModelNames($runtimeStore.instanceId);
   function updateMetricsDefinitionHandler(sourceModelName) {
     // Reset timeseries as some models might not have a timeseries
-    $metricsInternalRep.updateMetricKey("timeseries", "");
-    $metricsInternalRep.updateMetricKey("model", sourceModelName);
+    $metricsInternalRep.updateMetricKeys({
+      model: sourceModelName,
+      timeseries: "",
+    });
   }
 </script>
 


### PR DESCRIPTION
Addresses the [P0 in Notion "I can’t change a model in the metrics config to a new model"](https://www.notion.so/rilldata/Application-Bugs-and-Polish-for-21-1-6d7f59f3076249f7af64dfbc8acc47df)

The problem in the existing code is that we call `$metricsInternalRep.updateMetricKey(...)` twice in quick succession, which leads to two concurrent calls to `PutAndMigrate`. A race condition results in a malformed dashboard YAML file.

This PR changes the call to `$metricsInternalRep.updateMetricKeys(...)`, which ensures `PutAndMigrate` is only called once.

