### PR TITLE
ensures dialog height for other dialogs is same as before, unless using `yFixed`

### DIFF
--- a/web-common/src/components/modal/dialog/Dialog.svelte
+++ b/web-common/src/components/modal/dialog/Dialog.svelte
@@ -29,22 +29,22 @@
     switch (size) {
       case "sm":
         xDimClasses = "w-1/2 md:w-1/3 xl:w-1/4 2xl:w-1/5";
-        yDimClasses = "h-1/3";
+        yDimClasses = yFixed ? "h-1/3" : "";
         break;
 
       case "md":
         xDimClasses = "w-2/3 md:w-2/3 xl:w-1/3 2xl:w-1/3 max-w-2xl";
-        yDimClasses = "h-1/2";
+        yDimClasses = yFixed ? "h-1/2" : "";
         break;
 
       case "lg":
         xDimClasses = "w-4/5 md:w-3/5 xl:w-1/2 2xl:w-1/3";
-        yDimClasses = "h-3/5";
+        yDimClasses = yFixed ? "h-3/5" : "";
         break;
 
       case "full":
         xDimClasses = "w-4/5 md:w-3/5 xl:w-1/2 2xl:w-2/3";
-        yDimClasses = "h-4/5";
+        yDimClasses = yFixed ? "h-4/5" : "";
         break;
     }
   }


### PR DESCRIPTION
The other dialogs seemed to be too tall, so we need to revert to variable heights unless we use `yFixed`