### PR TITLE
Fix Query cache key for TableHead API

### DIFF
--- a/runtime/queries/table_head.go
+++ b/runtime/queries/table_head.go
@@ -18,7 +18,7 @@ type TableHead struct {
 var _ runtime.Query = &TableHead{}
 
 func (q *TableHead) Key() string {
-	return fmt.Sprintf("TableHead:%s", q.TableName)
+	return fmt.Sprintf("TableHead:%s:%d", q.TableName, q.Limit)
 }
 
 func (q *TableHead) Deps() []string {


### PR DESCRIPTION
Fix query cache key for TableHead API to include limit as well.