### PR TITLE
Fixing rill intake url not being json

### DIFF
--- a/web-local/src/lib/metrics/service/RillIntakeClient.ts
+++ b/web-local/src/lib/metrics/service/RillIntakeClient.ts
@@ -1,4 +1,3 @@
-import { fetchWrapper } from "@rilldata/web-local/lib/util/fetchWrapper";
 import type { MetricsEvent } from "./MetricsTypes";
 
 const RillIntakeUser = "data-modeler";

--- a/web-local/src/lib/metrics/service/RillIntakeClient.ts
+++ b/web-local/src/lib/metrics/service/RillIntakeClient.ts
@@ -16,14 +16,15 @@ export class RillIntakeClient {
 
   public async fireEvent(event: MetricsEvent) {
     try {
-      await fetchWrapper({
-        url: `${RILL_RUNTIME_URL}/local/track`,
+      const resp = await fetch(`${RILL_RUNTIME_URL}/local/track`, {
         method: "POST",
-        data: event,
+        body: JSON.stringify(event),
         headers: {
           Authorization: this.authHeader,
         },
       });
+      if (!resp.ok)
+        console.error(`Failed to send ${event.event_type}. ${resp.statusText}`);
     } catch (err) {
       console.error(`Failed to send ${event.event_type}. ${err.message}`);
     }


### PR DESCRIPTION
Rill Intake response is not JSON. Hence not using `fetchWrapper` that assumes a JSON response.