### PR TITLE
Close runtime metastore on exit

### DIFF
--- a/cli/cmd/runtime/start.go
+++ b/cli/cmd/runtime/start.go
@@ -79,6 +79,7 @@ func StartCmd(ver version.Version) *cobra.Command {
 			if err != nil {
 				logger.Fatal("error: could not create runtime", zap.Error(err))
 			}
+			defer rt.Close()
 
 			// Init server
 			srvOpts := &server.Options{

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -53,5 +53,10 @@ func New(opts *Options, logger *zap.Logger) (*Runtime, error) {
 }
 
 func (r *Runtime) Close() error {
-	return r.connCache.Close()
+	err1 := r.metastore.Close()
+	err2 := r.connCache.Close()
+	if err1 != nil {
+		return err1
+	}
+	return err2
 }


### PR DESCRIPTION
We might refactor this code again soon, but just wanted to get it in so we don't forget