### PR TITLE
Edit Typescript and Vite config in `web-admin`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,8 +26,9 @@
     "allowJs": true,
     "checkJs": true,
     "paths": {
-      "@rilldata/web-local/lib/*": ["web-local/src/lib/*"],
-      "@rilldata/web-common/*": ["web-common/src/*"]
+      "@rilldata/web-admin/*": ["web-admin/src/*"],
+      "@rilldata/web-common/*": ["web-common/src/*"],
+      "@rilldata/web-local/lib/*": ["web-local/src/lib/*"]
     },
     "outDir": "dist"
   },

--- a/web-admin/tsconfig.json
+++ b/web-admin/tsconfig.json
@@ -1,17 +1,3 @@
 {
-  "extends": "./.svelte-kit/tsconfig.json",
-  "compilerOptions": {
-    "allowJs": true,
-    "checkJs": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
-    "skipLibCheck": true,
-    "sourceMap": true,
-    "strict": true
-  }
-  // Path aliases are handled by https://kit.svelte.dev/docs/configuration#alias
-  //
-  // If you want to overwrite includes/excludes, make sure to copy over the relevant includes/excludes
-  // from the referenced tsconfig.json - TypeScript does not merge them in
+  "extends": "../tsconfig.json",
 }

--- a/web-admin/vite.config.ts
+++ b/web-admin/vite.config.ts
@@ -2,6 +2,13 @@ import { sveltekit } from "@sveltejs/kit/vite";
 import type { UserConfig } from "vite";
 
 const config: UserConfig = {
+  resolve: {
+    alias: {
+      "@rilldata/web-admin": "/src",
+      "@rilldata/web-common": "/../web-common/src",
+      "@rilldata/web-local": "/../web-local/src",
+    },
+  },
   plugins: [sveltekit()],
 };
 


### PR DESCRIPTION
This PR:
- Adds `web-admin` to our root `tsconfig.json`
- Edits `web-admin/tsconfig.json` to inherit from root
- Wires up aliases for Vite

Part of #1780.