### PR TITLE
fixes case where low-cardinality diagnostic histograms add an extra bucket

### DIFF
--- a/runtime/queries/column_numeric_histogram.go
+++ b/runtime/queries/column_numeric_histogram.go
@@ -270,7 +270,7 @@ func (q *ColumnNumericHistogram) calculateDiagnosticMethod(ctx context.Context, 
 	startTick, endTick, gap := NiceAndStep(min, max, ticks)
 	bucketCount := int(math.Ceil((endTick - startTick) / gap))
 	if gap == 1 {
-		bucketCount = bucketCount + 1
+		bucketCount++
 	}
 
 	selectColumn := fmt.Sprintf("%s::DOUBLE", sanitizedColumnName)

--- a/runtime/queries/column_numeric_histogram.go
+++ b/runtime/queries/column_numeric_histogram.go
@@ -269,6 +269,9 @@ func (q *ColumnNumericHistogram) calculateDiagnosticMethod(ctx context.Context, 
 	}
 	startTick, endTick, gap := NiceAndStep(min, max, ticks)
 	bucketCount := int(math.Ceil((endTick - startTick) / gap))
+	if gap == 1 {
+		bucketCount = bucketCount + 1
+	}
 
 	selectColumn := fmt.Sprintf("%s::DOUBLE", sanitizedColumnName)
 	histogramSQL := fmt.Sprintf(

--- a/runtime/server/queries_columns_test.go
+++ b/runtime/server/queries_columns_test.go
@@ -228,7 +228,7 @@ func TestServer_GetNumericHistogram_Diagnostic(t *testing.T) {
 	for i := 0; i < len(bins); i++ {
 		fmt.Printf("%d %f %f %f\n", bins[i].Bucket, bins[i].Low, bins[i].High, bins[i].Count)
 	}
-	require.Equal(t, 4, len(bins))
+	require.Equal(t, 5, len(bins))
 
 	require.Equal(t, int32(0), bins[0].Bucket)
 	require.Equal(t, start, bins[0].Low)

--- a/runtime/server/queries_columns_test.go
+++ b/runtime/server/queries_columns_test.go
@@ -242,7 +242,7 @@ func TestServer_GetNumericHistogram_Diagnostic(t *testing.T) {
 
 	require.Equal(t, 1.0, bins[2].Count)
 
-	require.Equal(t, 1.0, bins[3].Count)
+	require.Equal(t, 0.0, bins[3].Count)
 }
 
 func TestServer_Model_Nulls(t *testing.T) {


### PR DESCRIPTION
closes #1821

This PR blocks the rest of the diagnostic test integration. I'll need to make a couple other frontend changes before then.