### PR TITLE
Add Rill theme

### DIFF
--- a/web-admin/src/routes/+layout.svelte
+++ b/web-admin/src/routes/+layout.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
+  import RillTheme from "@rilldata/web-common/layout/RillTheme.svelte";
   import { QueryClient, QueryClientProvider } from "@sveltestack/svelte-query";
-  import "../app.css";
 
   const queryClient = new QueryClient();
 </script>
@@ -10,38 +10,13 @@
 </svelte:head>
 
 <main>
-  <QueryClientProvider client={queryClient}>
-    <slot />
-  </QueryClientProvider>
+  <RillTheme>
+    <QueryClientProvider client={queryClient}>
+      <slot />
+    </QueryClientProvider>
+  </RillTheme>
 </main>
 
 <footer>
   <p>Rill Data</p>
 </footer>
-
-<style>
-  main {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    padding: 1rem;
-    width: 100%;
-    max-width: 1024px;
-    margin: 0 auto;
-    box-sizing: border-box;
-  }
-
-  footer {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    padding: 40px;
-  }
-
-  @media (min-width: 480px) {
-    footer {
-      padding: 40px 0;
-    }
-  }
-</style>


### PR DESCRIPTION
This PR adds the Rill theme to the `web-admin` project.

Without this PR, the `web-admin` project currently does not build because `+layout.svelte` references the `app.css` file removed in #1813. (To avoid this state going forward, for code that touches `web-admin`, we should add a CI/CD check to verify that `npm run build -w web-admin` works.)
