### PR TITLE
Fix empty response error for column rollup interval

### DIFF
--- a/runtime/queries/column_time_grain.go
+++ b/runtime/queries/column_time_grain.go
@@ -129,6 +129,7 @@ func (q *ColumnTimeGrain) Resolve(ctx context.Context, rt *runtime.Runtime, inst
 	}
 
 	if !timeGrainString.Valid {
+		q.Result = runtimev1.TimeGrain_TIME_GRAIN_UNSPECIFIED // It's the default value. This is just to clarify intended behavior.
 		return nil
 	}
 

--- a/runtime/queries/timeseries_interval.go
+++ b/runtime/queries/timeseries_interval.go
@@ -47,6 +47,7 @@ func (q *RollupInterval) Resolve(ctx context.Context, rt *runtime.Runtime, insta
 		return err
 	}
 	if ctr.Result.Interval == nil {
+		q.Result = &runtimev1.ColumnRollupIntervalResponse{}
 		return nil
 	}
 	r := ctr.Result.Interval

--- a/runtime/server/queries_columns.go
+++ b/runtime/server/queries_columns.go
@@ -80,13 +80,17 @@ func (s *Server) ColumnDescriptiveStatistics(ctx context.Context, req *runtimev1
 		return nil, status.Error(codes.Unknown, err.Error())
 	}
 
-	resp := &runtimev1.NumericSummary{
-		Case: &runtimev1.NumericSummary_NumericStatistics{
-			NumericStatistics: q.Result,
-		},
+	// ColumnDescriptiveStatistics may return an empty result
+	if q.Result == nil {
+		return &runtimev1.ColumnDescriptiveStatisticsResponse{}, nil
 	}
+
 	return &runtimev1.ColumnDescriptiveStatisticsResponse{
-		NumericSummary: resp,
+		NumericSummary: &runtimev1.NumericSummary{
+			Case: &runtimev1.NumericSummary_NumericStatistics{
+				NumericStatistics: q.Result,
+			},
+		},
 	}, nil
 }
 
@@ -148,6 +152,9 @@ func (s *Server) ColumnNumericHistogram(ctx context.Context, req *runtimev1.Colu
 	if err != nil {
 		return nil, status.Error(codes.Unknown, err.Error())
 	}
+
+	// NOTE: q.Result may be nil if there were no bins. The below will output it as an empty histogram.
+
 	return &runtimev1.ColumnNumericHistogramResponse{
 		NumericSummary: &runtimev1.NumericSummary{
 			Case: &runtimev1.NumericSummary_NumericHistogramBins{


### PR DESCRIPTION
Hey, sometimes I’m seeing this error message in the logs:

```
2023/03/03 16:36:16 ERROR: [core] [Server #5] grpc: server failed to encode response: rpc error: code = Internal desc = grpc: error while marshaling: proto: Marshal called with nil
```

I think this is when an RPC returns both a `nil` error and a `nil` response.

I noticed it could happen in `RollupInterval` query and the logs appeared correlated.