### PR TITLE
Allow credentials in requests to admin server

### DIFF
--- a/admin/server/server.go
+++ b/admin/server/server.go
@@ -195,6 +195,7 @@ func cors(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if origin := r.Header.Get("Origin"); origin != "" {
 			w.Header().Set("Access-Control-Allow-Origin", origin)
+			w.Header().Set("Access-Control-Allow-Credentials", "true")
 			if r.Method == "OPTIONS" && r.Header.Get("Access-Control-Request-Method") != "" {
 				w.Header().Set("Access-Control-Allow-Headers", "*")
 				w.Header().Set("Access-Control-Allow-Methods", "GET, HEAD, POST, PUT, PATCH, DELETE")

--- a/web-admin/src/client/http-client.ts
+++ b/web-admin/src/client/http-client.ts
@@ -6,6 +6,7 @@ const ADMIN_URL =
 
 export const AXIOS_INSTANCE = Axios.create({
   baseURL: ADMIN_URL,
+  withCredentials: true,
 });
 
 // TODO: use the new client?


### PR DESCRIPTION
This PR configures:
- the server to set the "Access-Control-Allow-Credentials" header to "true" on HTTP responses
- the client to set the "withCredentials" property on HTTP requests

Both are required to get our authentication flow working.