### PR TITLE
moves mouseover date into chart

### DIFF
--- a/web-common/src/features/dashboards/time-series/MeasureChart.svelte
+++ b/web-common/src/features/dashboards/time-series/MeasureChart.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
+  import { outline } from "@rilldata/web-common/components/data-graphic/actions/outline";
   import Body from "@rilldata/web-common/components/data-graphic/elements/Body.svelte";
   import SimpleDataGraphic from "@rilldata/web-common/components/data-graphic/elements/SimpleDataGraphic.svelte";
+  import WithBisector from "@rilldata/web-common/components/data-graphic/functional-components/WithBisector.svelte";
   import {
     Axis,
     Grid,
@@ -11,7 +13,7 @@
   import { extent } from "d3-array";
   import { cubicOut } from "svelte/easing";
   import { writable } from "svelte/store";
-  import { fade } from "svelte/transition";
+  import { fade, fly } from "svelte/transition";
   export let width: number = undefined;
   export let height: number = undefined;
   export let xMin;
@@ -24,6 +26,7 @@
   export let mouseoverValue;
   export let hovered = false;
   export let mouseoverFormat: (d: number) => string = (v) => v.toString();
+  export let mouseoverTimeFormat: (d: number) => string = (v) => v.toString();
 
   export let tweenProps = { duration: 400, easing: cubicOut };
 
@@ -99,6 +102,7 @@
   right={50}
   bind:mouseoverValue
   bind:hovered
+  let:config
   yMinTweenProps={tweenProps}
   yMaxTweenProps={tweenProps}
   xMaxTweenProps={tweenProps}
@@ -132,5 +136,22 @@
         format={mouseoverFormat}
       />
     </g>
+    <WithBisector
+      {data}
+      callback={(d) => d[xAccessor]}
+      value={mouseoverValue.x}
+      let:point
+    >
+      <g transition:fly|local={{ duration: 100, x: -4 }}>
+        <text
+          use:outline
+          class="fill-gray-600"
+          x={config.plotLeft + config.bodyBuffer + 6}
+          y={config.plotTop + 10 + config.bodyBuffer}
+        >
+          {mouseoverTimeFormat(point[xAccessor])}
+        </text>
+      </g></WithBisector
+    >
   {/if}
 </SimpleDataGraphic>

--- a/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
+++ b/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
@@ -23,7 +23,6 @@
   import { convertTimestampPreview } from "@rilldata/web-local/lib/util/convertTimestampPreview";
   import type { UseQueryStoreResult } from "@sveltestack/svelte-query";
   import { extent } from "d3-array";
-  import { fly } from "svelte/transition";
   import { runtime } from "../../../runtime-client/runtime-store";
   import Spinner from "../../entity-management/Spinner.svelte";
   import MeasureBigNumber from "../big-number/MeasureBigNumber.svelte";
@@ -138,22 +137,9 @@
   let:point
 >
   <TimeSeriesChartContainer {workspaceWidth} start={startValue} end={endValue}>
-    <!-- mouseover date elements-->
     <div class="bg-white sticky left-0 top-0" />
     <div class="bg-white sticky left-0 top-0">
-      <div style:padding-left="24px">
-        {#if point?.ts}
-          <div
-            class="absolute text-gray-500"
-            transition:fly|local={{ duration: 100, y: 4 }}
-          >
-            {formatDateByInterval(interval, point.ts)}
-          </div>
-          &nbsp;
-        {:else}
-          &nbsp;
-        {/if}
-      </div>
+      <div style:padding-left="24px" style:height="20px" />
       <!-- top axis element -->
       <div />
       {#if metricsExplorer?.selectedTimeRange}
@@ -207,6 +193,9 @@
               yMin={yExtents[0] < 0 ? yExtents[0] : 0}
               start={startValue}
               end={endValue}
+              mouseoverTimeFormat={(value) => {
+                return formatDateByInterval(interval, value);
+              }}
               mouseoverFormat={(value) =>
                 formatPreset === NicelyFormattedTypes.NONE
                   ? `${value}`


### PR DESCRIPTION
The goal of this PR is to make it easier to see the date against any chart, rather than have to direct your eyes to the top of the screen to see the tiny date.

@magorlick lmk what you think of this approach.

https://user-images.githubusercontent.com/95735/223933399-5a84b20f-3154-49fe-ad25-29cafa28448c.mp4


