### PR TITLE
Switch to new admin API endpoints

### DIFF
--- a/web-admin/src/routes/+page.ts
+++ b/web-admin/src/routes/+page.ts
@@ -1,7 +1,7 @@
 import { redirect } from "@sveltejs/kit";
 import {
-  adminServiceFindOrganizations,
   adminServiceGetCurrentUser,
+  adminServiceListOrganizations,
 } from "../client";
 import { ADMIN_URL } from "../client/http-client";
 
@@ -14,7 +14,7 @@ export async function load() {
     throw redirect(307, `${ADMIN_URL}/auth/login?redirect=${window.origin}`);
   }
 
-  const orgs = await adminServiceFindOrganizations();
+  const orgs = await adminServiceListOrganizations();
   if (orgs.organization.length > 0) {
     throw redirect(307, `/${orgs.organization[0].name}`);
   }

--- a/web-admin/src/routes/[organization]/+page.svelte
+++ b/web-admin/src/routes/[organization]/+page.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
   import { page } from "$app/stores";
   import {
-    useAdminServiceFindOrganization,
-    useAdminServiceFindProjects,
+    useAdminServiceGetOrganization,
+    useAdminServiceListProjects,
   } from "../../client";
 
-  const org = useAdminServiceFindOrganization($page.params.organization);
-  const projs = useAdminServiceFindProjects($page.params.organization);
+  const org = useAdminServiceGetOrganization($page.params.organization);
+  const projs = useAdminServiceListProjects($page.params.organization);
 </script>
 
 <svelte:head>

--- a/web-admin/src/routes/[organization]/[project]/+page.svelte
+++ b/web-admin/src/routes/[organization]/[project]/+page.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import { page } from "$app/stores";
-  import { useAdminServiceFindProject } from "../../../client";
+  import { useAdminServiceGetProject } from "../../../client";
 
-  const proj = useAdminServiceFindProject(
+  const proj = useAdminServiceGetProject(
     $page.params.organization,
     $page.params.project
   );


### PR DESCRIPTION
The admin API/client changed terminology from `FindOrganization` to `GetOrganization`, and `FindOrganizations` to `ListOrganizations`, and the same for Projects. This updates the frontend code to use the new client.