### PR TITLE
Remove CLI spinners

### DIFF
--- a/cli/cmd/auth/login.go
+++ b/cli/cmd/auth/login.go
@@ -2,7 +2,6 @@ package auth
 
 import (
 	"github.com/fatih/color"
-	"github.com/rilldata/rill/cli/cmd/cmdutil"
 	"github.com/rilldata/rill/cli/pkg/browser"
 	"github.com/rilldata/rill/cli/pkg/config"
 	"github.com/rilldata/rill/cli/pkg/deviceauth"
@@ -16,9 +15,6 @@ func LoginCmd(cfg *config.Config) *cobra.Command {
 		Use:   "login",
 		Short: "Authenticate with the Rill API",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			sp := cmdutil.Spinner("Login in...")
-			sp.Start()
-
 			warn := color.New(color.Bold).Add(color.FgYellow)
 			if cfg.AdminTokenDefault != "" {
 				warn.Println("You are already logged in. To log in again, run `rill auth logout` first.")
@@ -50,7 +46,6 @@ func LoginCmd(cfg *config.Config) *cobra.Command {
 				return err
 			}
 
-			sp.Stop()
 			bold.Print("Successfully logged in.\n")
 
 			err = dotrill.SetAccessToken(OAuthTokenResponse.AccessToken)

--- a/cli/cmd/org/create.go
+++ b/cli/cmd/org/create.go
@@ -19,9 +19,6 @@ func CreateCmd(cfg *config.Config) *cobra.Command {
 		Short: "Create",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			sp := cmdutil.Spinner("Creating org...")
-			sp.Start()
-
 			client, err := client.New(cfg.AdminURL, cfg.AdminToken())
 			if err != nil {
 				return err
@@ -42,7 +39,6 @@ func CreateCmd(cfg *config.Config) *cobra.Command {
 				return err
 			}
 
-			sp.Stop()
 			cmdutil.TextPrinter("Created organization \n")
 			cmdutil.TablePrinter(toRow(org.Organization))
 			return nil

--- a/cli/cmd/org/delete.go
+++ b/cli/cmd/org/delete.go
@@ -17,9 +17,6 @@ func DeleteCmd(cfg *config.Config) *cobra.Command {
 		Short: "Delete",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			sp := cmdutil.Spinner("Deleting org...")
-			sp.Start()
-
 			client, err := client.New(cfg.AdminURL, cfg.AdminToken())
 			if err != nil {
 				return err
@@ -33,7 +30,6 @@ func DeleteCmd(cfg *config.Config) *cobra.Command {
 				return err
 			}
 
-			sp.Stop()
 			cmdutil.TextPrinter(fmt.Sprintf("Deleted organization: %v\n", org))
 			return nil
 		},

--- a/cli/cmd/org/edit.go
+++ b/cli/cmd/org/edit.go
@@ -18,9 +18,6 @@ func EditCmd(cfg *config.Config) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		Short: "Edit",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			sp := cmdutil.Spinner("Updating org...")
-			sp.Start()
-
 			client, err := client.New(cfg.AdminURL, cfg.AdminToken())
 			if err != nil {
 				return err
@@ -35,7 +32,6 @@ func EditCmd(cfg *config.Config) *cobra.Command {
 				return err
 			}
 
-			sp.Stop()
 			cmdutil.TextPrinter("Updated organization \n")
 			cmdutil.TablePrinter(toRow(org.Organization))
 			return nil

--- a/cli/cmd/org/list.go
+++ b/cli/cmd/org/list.go
@@ -15,9 +15,6 @@ func ListCmd(cfg *config.Config) *cobra.Command {
 		Use:   "list",
 		Short: "List",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			sp := cmdutil.Spinner("Listing orgs...")
-			sp.Start()
-
 			client, err := client.New(cfg.AdminURL, cfg.AdminToken())
 			if err != nil {
 				return err
@@ -29,7 +26,6 @@ func ListCmd(cfg *config.Config) *cobra.Command {
 				return err
 			}
 
-			sp.Stop()
 			cmdutil.TextPrinter("Organizations list \n")
 			cmdutil.TablePrinter(toTable(orgs.Organization))
 			return nil

--- a/cli/cmd/org/show.go
+++ b/cli/cmd/org/show.go
@@ -18,9 +18,6 @@ func ShowCmd(cfg *config.Config) *cobra.Command {
 		Short: "Show",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			sp := cmdutil.Spinner("Finding org...")
-			sp.Start()
-
 			var name string
 			if len(args) == 0 {
 				name = cfg.Org()
@@ -45,7 +42,6 @@ func ShowCmd(cfg *config.Config) *cobra.Command {
 				return err
 			}
 
-			sp.Stop()
 			cmdutil.TextPrinter("Found organization \n")
 			cmdutil.TablePrinter(toRow(org.Organization))
 			return nil

--- a/cli/cmd/org/switch.go
+++ b/cli/cmd/org/switch.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/rilldata/rill/admin/client"
-	"github.com/rilldata/rill/cli/cmd/cmdutil"
 	"github.com/rilldata/rill/cli/pkg/config"
 	"github.com/rilldata/rill/cli/pkg/dotrill"
 	adminv1 "github.com/rilldata/rill/proto/gen/rill/admin/v1"
@@ -18,9 +17,6 @@ func SwitchCmd(cfg *config.Config) *cobra.Command {
 		Short: "Switch",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			sp := cmdutil.Spinner("Switching org...")
-			sp.Start()
-
 			client, err := client.New(cfg.AdminURL, cfg.AdminToken())
 			if err != nil {
 				return err
@@ -39,7 +35,6 @@ func SwitchCmd(cfg *config.Config) *cobra.Command {
 				return err
 			}
 
-			sp.Stop()
 			fmt.Printf("Set default organization to %q", args[0])
 			return nil
 		},

--- a/cli/cmd/project/connect.go
+++ b/cli/cmd/project/connect.go
@@ -13,7 +13,6 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/rilldata/rill/admin/client"
-	"github.com/rilldata/rill/cli/cmd/cmdutil"
 	"github.com/rilldata/rill/cli/pkg/browser"
 	"github.com/rilldata/rill/cli/pkg/config"
 	"github.com/rilldata/rill/cli/pkg/gitutil"
@@ -36,9 +35,6 @@ func ConnectCmd(cfg *config.Config) *cobra.Command {
 		Short: "Setup continuous deployment to Rill Cloud",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			sp := cmdutil.Spinner("Connecting project...")
-			sp.Start()
-
 			// Allow setting project path as arg (instead of flag)
 			if len(args) > 0 {
 				projectPath = args[0]
@@ -145,7 +141,6 @@ func ConnectCmd(cfg *config.Config) *cobra.Command {
 				return err
 			}
 
-			sp.Stop()
 			// Success!
 			fmt.Printf("Created project %s/%s\n", cfg.Org(), projRes.Project.Name)
 			return nil
@@ -240,6 +235,6 @@ Follow these steps to push your project to Github.
 
 6. Connect Rill to your repository
 
-	rill connect
+	rill project connect
 
 `

--- a/cli/cmd/project/delete.go
+++ b/cli/cmd/project/delete.go
@@ -17,9 +17,6 @@ func DeleteCmd(cfg *config.Config) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		Short: "Delete",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			sp := cmdutil.Spinner("Deleting project...")
-			sp.Start()
-
 			client, err := client.New(cfg.AdminURL, cfg.AdminToken())
 			if err != nil {
 				return err
@@ -34,7 +31,6 @@ func DeleteCmd(cfg *config.Config) *cobra.Command {
 				return err
 			}
 
-			sp.Stop()
 			cmdutil.TextPrinter(fmt.Sprintf("Deleted project: %v\n", proj))
 			return nil
 		},

--- a/cli/cmd/project/edit.go
+++ b/cli/cmd/project/edit.go
@@ -19,9 +19,6 @@ func EditCmd(cfg *config.Config) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		Short: "Edit",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			sp := cmdutil.Spinner("Updating project...")
-			sp.Start()
-
 			client, err := client.New(cfg.AdminURL, cfg.AdminToken())
 			if err != nil {
 				return err
@@ -37,7 +34,6 @@ func EditCmd(cfg *config.Config) *cobra.Command {
 				return err
 			}
 
-			sp.Stop()
 			cmdutil.TextPrinter("Updated project \n")
 			cmdutil.TablePrinter(toRow(proj.Project))
 			return nil

--- a/cli/cmd/project/list.go
+++ b/cli/cmd/project/list.go
@@ -15,9 +15,6 @@ func ListCmd(cfg *config.Config) *cobra.Command {
 		Use:   "list",
 		Short: "List",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			sp := cmdutil.Spinner("Listing projects...")
-			sp.Start()
-
 			client, err := client.New(cfg.AdminURL, cfg.AdminToken())
 			if err != nil {
 				return err
@@ -31,7 +28,6 @@ func ListCmd(cfg *config.Config) *cobra.Command {
 				return err
 			}
 
-			sp.Stop()
 			cmdutil.TextPrinter("Projects list \n")
 			cmdutil.TablePrinter(toTable(proj.Projects))
 			return nil

--- a/cli/cmd/project/show.go
+++ b/cli/cmd/project/show.go
@@ -16,9 +16,6 @@ func ShowCmd(cfg *config.Config) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		Short: "Show",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			sp := cmdutil.Spinner("Finding project...")
-			sp.Start()
-
 			client, err := client.New(cfg.AdminURL, cfg.AdminToken())
 			if err != nil {
 				return err
@@ -33,7 +30,6 @@ func ShowCmd(cfg *config.Config) *cobra.Command {
 				return err
 			}
 
-			sp.Stop()
 			cmdutil.TextPrinter("Found project \n")
 			cmdutil.TablePrinter(toRow(proj.Project))
 			return nil

--- a/cli/cmd/project/status.go
+++ b/cli/cmd/project/status.go
@@ -17,9 +17,6 @@ func StatusCmd(cfg *config.Config) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		Short: "Status",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			sp := cmdutil.Spinner("Finding project...")
-			sp.Start()
-
 			client, err := client.New(cfg.AdminURL, cfg.AdminToken())
 			if err != nil {
 				return err
@@ -34,7 +31,6 @@ func StatusCmd(cfg *config.Config) *cobra.Command {
 				return err
 			}
 
-			sp.Stop()
 			cmdutil.TextPrinter("Found project\n")
 			cmdutil.TablePrinter(toRow(proj.Project))
 


### PR DESCRIPTION
They mess up the terminal state when other messages are printed while a spinner is running. We can add them back when other printed messages have stabilized.