### PR TITLE
Set SPA in development

### DIFF
--- a/web-admin/src/routes/+layout.ts
+++ b/web-admin/src/routes/+layout.ts
@@ -1,0 +1,6 @@
+/* 
+In svelte.config.js, the "adapter-static" option makes the application a single-page
+app in production. Here, we are setting server-side rendering (SSR) to false to 
+ensure the same single-page app behavior in development.
+*/
+export const ssr = false;

--- a/web-admin/src/routes/+page.ts
+++ b/web-admin/src/routes/+page.ts
@@ -5,9 +5,6 @@ import {
 } from "../client";
 import { ADMIN_URL } from "../client/http-client";
 
-// The current user is not available on the web server, so SSR would screw up the redirect logic
-export const ssr = false;
-
 export async function load() {
   const user = await adminServiceGetCurrentUser();
   if (!user.user) {

--- a/web-admin/src/routes/-/[organization]/[project]/dashboard/[name]/+page.ts
+++ b/web-admin/src/routes/-/[organization]/[project]/dashboard/[name]/+page.ts
@@ -1,1 +1,0 @@
-export const ssr = false;


### PR DESCRIPTION
Given #1912 makes the `web-admin` app a single-page application in production, we should set the SvelteKit SSR configuration to ensure the same behavior in development. This PR sets `ssr = false` by default for the whole `web-admin` app, which will ensure our app behaves as a SPA in development.