### PR TITLE
fixes negative values in measure charts

### DIFF
--- a/web-common/src/components/data-graphic/elements/GraphicContext.svelte
+++ b/web-common/src/components/data-graphic/elements/GraphicContext.svelte
@@ -204,13 +204,13 @@ for any of its children.
     yMaxStore.setTweenProps(yMaxTweenProps);
   }
 
-  $: if (xMin || $config?.xMin)
+  $: if (xMin !== undefined || $config?.xMin)
     xMinStore.setWithKey("global", xMin || $config.xMin, true);
-  $: if (xMax || $config?.xMax)
+  $: if (xMax !== undefined || $config?.xMax)
     xMaxStore.setWithKey("global", xMax || $config.xMax, true);
-  $: if (yMin || $config?.yMin)
+  $: if (yMin !== undefined || $config?.yMin)
     yMinStore.setWithKey("global", yMin || $config.yMin, true);
-  $: if (yMax || $config?.yMax)
+  $: if (yMax !== undefined || $config?.yMax)
     yMaxStore.setWithKey("global", yMax || $config.yMax, true);
 </script>
 

--- a/web-common/src/components/data-graphic/guides/PointLabel.svelte
+++ b/web-common/src/components/data-graphic/guides/PointLabel.svelte
@@ -108,7 +108,7 @@
         transition:fade|local={{ duration: 100 }}
         x1={output.x}
         x2={output.x}
-        y1={yScale.range().at(0)}
+        y1={yScale(0)}
         y2={output.y}
         stroke-width="4"
         class="stroke-blue-300"

--- a/web-common/src/features/dashboards/time-series/MeasureChart.svelte
+++ b/web-common/src/features/dashboards/time-series/MeasureChart.svelte
@@ -14,6 +14,7 @@
   import { cubicOut } from "svelte/easing";
   import { writable } from "svelte/store";
   import { fade, fly } from "svelte/transition";
+  import { niceMeasureExtents } from "./utils";
   export let width: number = undefined;
   export let height: number = undefined;
   export let xMin;
@@ -37,19 +38,17 @@
 
   $: [xExtentMin, xExtentMax] = extent(data, (d) => d[xAccessor]);
   $: [yExtentMin, yExtentMax] = extent(data, (d) => d[yAccessor]);
+
+  $: [internalYMin, internalYMax] = niceMeasureExtents(
+    [
+      yMin !== undefined ? yMin : yExtentMin,
+      yMax !== undefined ? yMax : yExtentMax,
+    ],
+    6 / 5
+  );
+
   $: internalXMin = xMin || xExtentMin;
   $: internalXMax = xMax || xExtentMax;
-  /** we'll set the inflation amount here. */
-  let inflate = 5 / 6;
-
-  $: internalYMin = yExtentMin >= 0 ? 0 : yExtentMin;
-
-  $: internalYMax = yMax
-    ? yMax
-    : yExtentMin == yExtentMax
-    ? yExtentMax / inflate
-    : yExtentMax / inflate;
-
   // we delay the tween if previousYMax < yMax
   let yMaxStore = writable(yExtentMax);
   let previousYMax = previousValueStore(yMaxStore);
@@ -59,6 +58,7 @@
 
   const previousTimeRangeKey = previousValueStore(timeRangeKey);
 
+  // FIXME: move this function to utils.ts
   /** reset the keys to trigger animations on time range changes */
   let syncTimeRangeKey;
   $: {
@@ -90,7 +90,7 @@
 
 <SimpleDataGraphic
   overflowHidden={false}
-  yMin={internalYMin * inflate}
+  yMin={internalYMin}
   yMax={internalYMax}
   shareYScale={false}
   yType="number"
@@ -103,6 +103,7 @@
   bind:mouseoverValue
   bind:hovered
   let:config
+  let:yScale
   yMinTweenProps={tweenProps}
   yMaxTweenProps={tweenProps}
   xMaxTweenProps={tweenProps}
@@ -125,6 +126,13 @@
         key={$timeRangeKey}
       />
     {/key}
+    <line
+      x1={config.plotLeft}
+      x2={config.plotLeft + config.plotRight}
+      y1={yScale(0)}
+      y2={yScale(0)}
+      class="stroke-blue-200"
+    />
   </Body>
   {#if !scrubbing && mouseoverValue?.x}
     <g transition:fade|local={{ duration: 100 }}>

--- a/web-common/src/features/dashboards/time-series/MeasureChart.svelte
+++ b/web-common/src/features/dashboards/time-series/MeasureChart.svelte
@@ -47,6 +47,8 @@
     6 / 5
   );
 
+  $: console.log(internalYMin, internalYMax);
+
   $: internalXMin = xMin || xExtentMin;
   $: internalXMax = xMax || xExtentMax;
   // we delay the tween if previousYMax < yMax

--- a/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
+++ b/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
@@ -22,7 +22,6 @@
   } from "@rilldata/web-common/runtime-client";
   import { convertTimestampPreview } from "@rilldata/web-local/lib/util/convertTimestampPreview";
   import type { UseQueryStoreResult } from "@sveltestack/svelte-query";
-  import { extent } from "d3-array";
   import { runtime } from "../../../runtime-client/runtime-store";
   import Spinner from "../../entity-management/Spinner.svelte";
   import MeasureBigNumber from "../big-number/MeasureBigNumber.svelte";
@@ -159,7 +158,6 @@
       {#each $metaQuery.data?.measures as measure, index (measure.name)}
         <!-- FIXME: I can't select the big number by the measure id. -->
         {@const bigNum = $totalsQuery?.data.data?.[measure.name]}
-        {@const yExtents = extent(dataCopy ?? [], (d) => d[`measure_${index}`])}
         {@const formatPreset =
           NicelyFormattedTypes[measure?.format] ||
           NicelyFormattedTypes.HUMANIZE}

--- a/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
+++ b/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
@@ -190,7 +190,6 @@
               xMin={startValue}
               xMax={endValue}
               timegrain={metricsExplorer.selectedTimeRange?.interval}
-              yMin={yExtents[0] < 0 ? yExtents[0] : 0}
               start={startValue}
               end={endValue}
               mouseoverTimeFormat={(value) => {

--- a/web-common/src/features/dashboards/time-series/utils.spec.ts
+++ b/web-common/src/features/dashboards/time-series/utils.spec.ts
@@ -1,0 +1,19 @@
+import { niceMeasureExtents } from "./utils";
+
+describe("niceMeasureExtents", () => {
+  it("should return [0, 1] if both values are 0", () => {
+    expect(niceMeasureExtents([0, 0], 1)).toEqual([0, 1]);
+  });
+  it("should ensure that if the minimum is positive, it returns 0", () => {
+    expect(niceMeasureExtents([1, 2], 1)).toEqual([0, 2]);
+  });
+  it("should ensure that if the maximum is negative, it returns 0", () => {
+    expect(niceMeasureExtents([-5, -2], 1)).toEqual([-5, 0]);
+  });
+  it("should inflate the minimum if it is negative", () => {
+    expect(niceMeasureExtents([-5, 0], 2)).toEqual([-10, 0]);
+  });
+  it("should inflate the maximum if it is positive", () => {
+    expect(niceMeasureExtents([0, 5], 2)).toEqual([0, 10]);
+  });
+});

--- a/web-common/src/features/dashboards/time-series/utils.ts
+++ b/web-common/src/features/dashboards/time-series/utils.ts
@@ -1,0 +1,14 @@
+export function niceMeasureExtents(
+  [smallest, largest]: [number, number],
+  inflator: number
+) {
+  if (smallest === 0 && largest === 0) {
+    return [0, 1];
+  }
+  return [
+    // If the smallest value is negative, we want to inflate it by the inflation factor.
+    smallest < 0 ? smallest * inflator : 0,
+    // If the largest value is positive, we want to inflate it by the inflation factor.
+    largest > 0 ? largest * inflator : 0,
+  ];
+}

--- a/web-common/src/features/dashboards/time-series/utils.ts
+++ b/web-common/src/features/dashboards/time-series/utils.ts
@@ -1,3 +1,4 @@
+/** sets extents to 0 if it makes sense; otherwise, inflates each extent component */
 export function niceMeasureExtents(
   [smallest, largest]: [number, number],
   inflator: number
@@ -6,9 +7,7 @@ export function niceMeasureExtents(
     return [0, 1];
   }
   return [
-    // If the smallest value is negative, we want to inflate it by the inflation factor.
     smallest < 0 ? smallest * inflator : 0,
-    // If the largest value is positive, we want to inflate it by the inflation factor.
     largest > 0 ? largest * inflator : 0,
   ];
 }


### PR DESCRIPTION
This is accomplished by creating a special function that aids in setting "nice" bounds for a measure chart y extents. Also fixes a bug in GraphicContext.svelte that prevents extent values from updating if they were previously 0.

https://user-images.githubusercontent.com/95735/225213395-e607ecc7-fcf4-4043-810d-b0a15eca34c4.mp4


