### PR TITLE
fixes broken navigation state

### DIFF
--- a/web-common/src/features/dashboards/time-controls/TimeControls.svelte
+++ b/web-common/src/features/dashboards/time-controls/TimeControls.svelte
@@ -88,7 +88,7 @@ We should rename TimeSeriesTimeRange to a better name.
   $: allTimeRange = $allTimeRangeQuery?.data as TimeRange | undefined;
 
   // once we have the allTimeRange, set the default time range and time grain
-  $: if (allTimeRange) {
+  $: if (allTimeRange && $dashboardStore) {
     if (!$dashboardStore?.selectedTimeRange) {
       setDefaultTimeControls(allTimeRange);
     } else if (!$dashboardStore?.selectedTimeRange.start) {

--- a/web-common/src/features/dashboards/time-series/MeasureChart.svelte
+++ b/web-common/src/features/dashboards/time-series/MeasureChart.svelte
@@ -49,8 +49,6 @@
     6 / 5
   );
 
-  $: console.log(internalYMin, internalYMax);
-
   $: internalXMin = xMin || xExtentMin;
   $: internalXMax = xMax || xExtentMax;
   // we delay the tween if previousYMax < yMax


### PR DESCRIPTION
we're attempting to re-create state from an empty `dashboardState` when a user first navigates to a dashboard. This PR fixes this for now so we can push a patch release.

Not super comfortable with merging this; in the future, it'd be great for us to have more tests around this `dashboardState` store + the protobuf state methods. e2e tests would have also caught this, most likely.