### PR TITLE
Fix flash of unstyled font

### DIFF
--- a/web-common/src/app.css
+++ b/web-common/src/app.css
@@ -31,6 +31,11 @@
     @apply text-gray-700 dark:text-white;
   }
 
+  .ui-copy-dashboard-header {
+    @apply ui-copy;
+    font-size: 16px;
+  }
+
   .ui-copy-muted {
     @apply text-gray-600 dark:text-gray-200;
   }

--- a/web-common/src/app.css
+++ b/web-common/src/app.css
@@ -123,10 +123,6 @@ button {
 }
 
 body {
-  /* font-family:  BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica,
-  Arial, sans-serif,"Inter", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-  font-size: 12px; */
-
   font-family: "Inter";
   font-size: 12px;
 

--- a/web-common/src/app.css
+++ b/web-common/src/app.css
@@ -118,6 +118,10 @@ button {
 }
 
 body {
+  /* font-family:  BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica,
+  Arial, sans-serif,"Inter", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  font-size: 12px; */
+
   font-family: "Inter";
   font-size: 12px;
 

--- a/web-common/src/features/dashboards/workspace/DashboardHeader.svelte
+++ b/web-common/src/features/dashboards/workspace/DashboardHeader.svelte
@@ -65,7 +65,7 @@
   >
     <!-- title element -->
     <h1 style:line-height="1.1" style:margin-top="-1px">
-      <div style:font-family="InterDisplay" style:font-size="16px">
+      <div class="ui-copy-dashboard-header">
         {displayName || metricViewName}
       </div>
     </h1>

--- a/web-common/src/layout/RillTheme.svelte
+++ b/web-common/src/layout/RillTheme.svelte
@@ -1,6 +1,6 @@
 <script>
   import "@rilldata/web-common/app.css";
-  import "@rilldata/web-common/fonts.css";
+  // import "fonts.css";
 </script>
 
 <slot />

--- a/web-common/src/layout/RillTheme.svelte
+++ b/web-common/src/layout/RillTheme.svelte
@@ -1,6 +1,5 @@
 <script>
   import "@rilldata/web-common/app.css";
-  // import "fonts.css";
 </script>
 
 <slot />

--- a/web-common/static/fonts/fonts.css
+++ b/web-common/static/fonts/fonts.css
@@ -6,7 +6,7 @@
 @font-face {
   font-family: "InterVar";
   font-weight: 100 900;
-  font-display: swap;
+  font-display: block;
   font-style: normal;
   src: url("/fonts/inter/Inter.var.woff2?v=3.19") format("woff2")
       tech("variations"),
@@ -15,7 +15,7 @@
 @font-face {
   font-family: "InterVar";
   font-weight: 100 900;
-  font-display: swap;
+  font-display: block;
   font-style: italic;
   src: url("/fonts/inter/Inter-Italic.var.woff2?v=3.19") format("woff2")
       tech("variations"),
@@ -26,126 +26,126 @@
   font-family: "Inter";
   font-style: normal;
   font-weight: 100;
-  font-display: swap;
+  font-display: block;
   src: url("/fonts/inter/Inter-Thin.woff2?v=3.19") format("woff2");
 }
 @font-face {
   font-family: "Inter";
   font-style: italic;
   font-weight: 100;
-  font-display: swap;
+  font-display: block;
   src: url("/fonts/inter/Inter-ThinItalic.woff2?v=3.19") format("woff2");
 }
 @font-face {
   font-family: "Inter";
   font-style: normal;
   font-weight: 200;
-  font-display: swap;
+  font-display: block;
   src: url("/fonts/inter/Inter-ExtraLight.woff2?v=3.19") format("woff2");
 }
 @font-face {
   font-family: "Inter";
   font-style: italic;
   font-weight: 200;
-  font-display: swap;
+  font-display: block;
   src: url("/fonts/inter/Inter-ExtraLightItalic.woff2?v=3.19") format("woff2");
 }
 @font-face {
   font-family: "Inter";
   font-style: normal;
   font-weight: 300;
-  font-display: swap;
+  font-display: block;
   src: url("/fonts/inter/Inter-Light.woff2?v=3.19") format("woff2");
 }
 @font-face {
   font-family: "Inter";
   font-style: italic;
   font-weight: 300;
-  font-display: swap;
+  font-display: block;
   src: url("/fonts/inter/Inter-LightItalic.woff2?v=3.19") format("woff2");
 }
 @font-face {
   font-family: "Inter";
   font-style: normal;
   font-weight: 400;
-  font-display: swap;
+  font-display: block;
   src: url("/fonts/inter/Inter-Regular.woff2?v=3.19") format("woff2");
 }
 @font-face {
   font-family: "Inter";
   font-style: italic;
   font-weight: 400;
-  font-display: swap;
+  font-display: block;
   src: url("/fonts/inter/Inter-Italic.woff2?v=3.19") format("woff2");
 }
 @font-face {
   font-family: "Inter";
   font-style: normal;
   font-weight: 500;
-  font-display: swap;
+  font-display: block;
   src: url("/fonts/inter/Inter-Medium.woff2?v=3.19") format("woff2");
 }
 @font-face {
   font-family: "Inter";
   font-style: italic;
   font-weight: 500;
-  font-display: swap;
+  font-display: block;
   src: url("/fonts/inter/Inter-MediumItalic.woff2?v=3.19") format("woff2");
 }
 @font-face {
   font-family: "Inter";
   font-style: normal;
   font-weight: 600;
-  font-display: swap;
+  font-display: block;
   src: url("/fonts/inter/Inter-SemiBold.woff2?v=3.19") format("woff2");
 }
 @font-face {
   font-family: "Inter";
   font-style: italic;
   font-weight: 600;
-  font-display: swap;
+  font-display: block;
   src: url("/fonts/inter/Inter-SemiBoldItalic.woff2?v=3.19") format("woff2");
 }
 @font-face {
   font-family: "Inter";
   font-style: normal;
   font-weight: 700;
-  font-display: swap;
+  font-display: block;
   src: url("/fonts/inter/Inter-Bold.woff2?v=3.19") format("woff2");
 }
 @font-face {
   font-family: "Inter";
   font-style: italic;
   font-weight: 700;
-  font-display: swap;
+  font-display: block;
   src: url("/fonts/inter/Inter-BoldItalic.woff2?v=3.19") format("woff2");
 }
 @font-face {
   font-family: "Inter";
   font-style: normal;
   font-weight: 800;
-  font-display: swap;
+  font-display: block;
   src: url("/fonts/inter/Inter-ExtraBold.woff2?v=3.19") format("woff2");
 }
 @font-face {
   font-family: "Inter";
   font-style: italic;
   font-weight: 800;
-  font-display: swap;
+  font-display: block;
   src: url("/fonts/inter/Inter-ExtraBoldItalic.woff2?v=3.19") format("woff2");
 }
 @font-face {
   font-family: "Inter";
   font-style: normal;
   font-weight: 900;
-  font-display: swap;
+  font-display: block;
   src: url("/fonts/inter/Inter-Black.woff2?v=3.19") format("woff2");
 }
 @font-face {
   font-family: "Inter";
   font-style: italic;
   font-weight: 900;
-  font-display: swap;
+  font-display: block;
   src: url("/fonts/inter/Inter-BlackItalic.woff2?v=3.19") format("woff2");
 }
 /* static fonts "InterDisplay" */
@@ -153,28 +153,28 @@
   font-family: "InterDisplay";
   font-style: normal;
   font-weight: 100;
-  font-display: swap;
+  font-display: block;
   src: url("/fonts/inter/Inter-DisplayThin.woff2?v=3.19") format("woff2");
 }
 @font-face {
   font-family: "InterDisplay";
   font-style: italic;
   font-weight: 100;
-  font-display: swap;
+  font-display: block;
   src: url("/fonts/inter/Inter-DisplayThinItalic.woff2?v=3.19") format("woff2");
 }
 @font-face {
   font-family: "InterDisplay";
   font-style: normal;
   font-weight: 200;
-  font-display: swap;
+  font-display: block;
   src: url("/fonts/inter/Inter-DisplayExtraLight.woff2?v=3.19") format("woff2");
 }
 @font-face {
   font-family: "InterDisplay";
   font-style: italic;
   font-weight: 200;
-  font-display: swap;
+  font-display: block;
   src: url("/fonts/inter/Inter-DisplayExtraLightItalic.woff2?v=3.19")
     format("woff2");
 }
@@ -182,42 +182,42 @@
   font-family: "InterDisplay";
   font-style: normal;
   font-weight: 300;
-  font-display: swap;
+  font-display: block;
   src: url("/fonts/inter/Inter-DisplayLight.woff2?v=3.19") format("woff2");
 }
 @font-face {
   font-family: "InterDisplay";
   font-style: italic;
   font-weight: 300;
-  font-display: swap;
+  font-display: block;
   src: url("/fonts/inter/Inter-DisplayLightItalic.woff2?v=3.19") format("woff2");
 }
 @font-face {
   font-family: "InterDisplay";
   font-style: normal;
   font-weight: 400;
-  font-display: swap;
+  font-display: block;
   src: url("/fonts/inter/Inter-DisplayRegular.woff2?v=3.19") format("woff2");
 }
 @font-face {
   font-family: "InterDisplay";
   font-style: italic;
   font-weight: 400;
-  font-display: swap;
+  font-display: block;
   src: url("/fonts/inter/Inter-DisplayItalic.woff2?v=3.19") format("woff2");
 }
 @font-face {
   font-family: "InterDisplay";
   font-style: normal;
   font-weight: 500;
-  font-display: swap;
+  font-display: block;
   src: url("/fonts/inter/Inter-DisplayMedium.woff2?v=3.19") format("woff2");
 }
 @font-face {
   font-family: "InterDisplay";
   font-style: italic;
   font-weight: 500;
-  font-display: swap;
+  font-display: block;
   src: url("/fonts/inter/Inter-DisplayMediumItalic.woff2?v=3.19")
     format("woff2");
 }
@@ -225,14 +225,14 @@
   font-family: "InterDisplay";
   font-style: normal;
   font-weight: 600;
-  font-display: swap;
+  font-display: block;
   src: url("/fonts/inter/Inter-DisplaySemiBold.woff2?v=3.19") format("woff2");
 }
 @font-face {
   font-family: "InterDisplay";
   font-style: italic;
   font-weight: 600;
-  font-display: swap;
+  font-display: block;
   src: url("/fonts/inter/Inter-DisplaySemiBoldItalic.woff2?v=3.19")
     format("woff2");
 }
@@ -240,28 +240,28 @@
   font-family: "InterDisplay";
   font-style: normal;
   font-weight: 700;
-  font-display: swap;
+  font-display: block;
   src: url("/fonts/inter/Inter-DisplayBold.woff2?v=3.19") format("woff2");
 }
 @font-face {
   font-family: "InterDisplay";
   font-style: italic;
   font-weight: 700;
-  font-display: swap;
+  font-display: block;
   src: url("/fonts/inter/Inter-DisplayBoldItalic.woff2?v=3.19") format("woff2");
 }
 @font-face {
   font-family: "InterDisplay";
   font-style: normal;
   font-weight: 800;
-  font-display: swap;
+  font-display: block;
   src: url("/fonts/inter/Inter-DisplayExtraBold.woff2?v=3.19") format("woff2");
 }
 @font-face {
   font-family: "InterDisplay";
   font-style: italic;
   font-weight: 800;
-  font-display: swap;
+  font-display: block;
   src: url("/fonts/inter/Inter-DisplayExtraBoldItalic.woff2?v=3.19")
     format("woff2");
 }
@@ -269,14 +269,14 @@
   font-family: "InterDisplay";
   font-style: normal;
   font-weight: 900;
-  font-display: swap;
+  font-display: block;
   src: url("/fonts/inter/Inter-DisplayBlack.woff2?v=3.19") format("woff2");
 }
 @font-face {
   font-family: "InterDisplay";
   font-style: italic;
   font-weight: 900;
-  font-display: swap;
+  font-display: block;
   src: url("/fonts/inter/Inter-DisplayBlackItalic.woff2?v=3.19") format("woff2");
 }
 

--- a/web-common/static/fonts/fonts.css
+++ b/web-common/static/fonts/fonts.css
@@ -6,7 +6,7 @@
 @font-face {
   font-family: "InterVar";
   font-weight: 100 900;
-  font-display: block;
+  font-display: swap;
   font-style: normal;
   src: url("/fonts/inter/Inter.var.woff2?v=3.19") format("woff2")
       tech("variations"),
@@ -15,7 +15,7 @@
 @font-face {
   font-family: "InterVar";
   font-weight: 100 900;
-  font-display: block;
+  font-display: swap;
   font-style: italic;
   src: url("/fonts/inter/Inter-Italic.var.woff2?v=3.19") format("woff2")
       tech("variations"),
@@ -26,28 +26,28 @@
   font-family: "Inter";
   font-style: normal;
   font-weight: 100;
-  font-display: block;
+  font-display: swap;
   src: url("/fonts/inter/Inter-Thin.woff2?v=3.19") format("woff2");
 }
 @font-face {
   font-family: "Inter";
   font-style: italic;
   font-weight: 100;
-  font-display: block;
+  font-display: swap;
   src: url("/fonts/inter/Inter-ThinItalic.woff2?v=3.19") format("woff2");
 }
 @font-face {
   font-family: "Inter";
   font-style: normal;
   font-weight: 200;
-  font-display: block;
+  font-display: swap;
   src: url("/fonts/inter/Inter-ExtraLight.woff2?v=3.19") format("woff2");
 }
 @font-face {
   font-family: "Inter";
   font-style: italic;
   font-weight: 200;
-  font-display: block;
+  font-display: swap;
   src: url("/fonts/inter/Inter-ExtraLightItalic.woff2?v=3.19") format("woff2");
 }
 @font-face {
@@ -61,7 +61,7 @@
   font-family: "Inter";
   font-style: italic;
   font-weight: 300;
-  font-display: block;
+  font-display: swap;
   src: url("/fonts/inter/Inter-LightItalic.woff2?v=3.19") format("woff2");
 }
 @font-face {
@@ -75,7 +75,7 @@
   font-family: "Inter";
   font-style: italic;
   font-weight: 400;
-  font-display: block;
+  font-display: swap;
   src: url("/fonts/inter/Inter-Italic.woff2?v=3.19") format("woff2");
 }
 @font-face {
@@ -89,7 +89,7 @@
   font-family: "Inter";
   font-style: italic;
   font-weight: 500;
-  font-display: block;
+  font-display: swap;
   src: url("/fonts/inter/Inter-MediumItalic.woff2?v=3.19") format("woff2");
 }
 @font-face {
@@ -103,7 +103,7 @@
   font-family: "Inter";
   font-style: italic;
   font-weight: 600;
-  font-display: block;
+  font-display: swap;
   src: url("/fonts/inter/Inter-SemiBoldItalic.woff2?v=3.19") format("woff2");
 }
 @font-face {
@@ -117,168 +117,38 @@
   font-family: "Inter";
   font-style: italic;
   font-weight: 700;
-  font-display: block;
+  font-display: swap;
   src: url("/fonts/inter/Inter-BoldItalic.woff2?v=3.19") format("woff2");
 }
 @font-face {
   font-family: "Inter";
   font-style: normal;
   font-weight: 800;
-  font-display: block;
+  font-display: swap;
   src: url("/fonts/inter/Inter-ExtraBold.woff2?v=3.19") format("woff2");
 }
 @font-face {
   font-family: "Inter";
   font-style: italic;
   font-weight: 800;
-  font-display: block;
+  font-display: swap;
   src: url("/fonts/inter/Inter-ExtraBoldItalic.woff2?v=3.19") format("woff2");
 }
 @font-face {
   font-family: "Inter";
   font-style: normal;
   font-weight: 900;
-  font-display: block;
+  font-display: swap;
   src: url("/fonts/inter/Inter-Black.woff2?v=3.19") format("woff2");
 }
 @font-face {
   font-family: "Inter";
   font-style: italic;
   font-weight: 900;
-  font-display: block;
+  font-display: swap;
   src: url("/fonts/inter/Inter-BlackItalic.woff2?v=3.19") format("woff2");
 }
-/* static fonts "InterDisplay" */
-@font-face {
-  font-family: "InterDisplay";
-  font-style: normal;
-  font-weight: 100;
-  font-display: block;
-  src: url("/fonts/inter/Inter-DisplayThin.woff2?v=3.19") format("woff2");
-}
-@font-face {
-  font-family: "InterDisplay";
-  font-style: italic;
-  font-weight: 100;
-  font-display: block;
-  src: url("/fonts/inter/Inter-DisplayThinItalic.woff2?v=3.19") format("woff2");
-}
-@font-face {
-  font-family: "InterDisplay";
-  font-style: normal;
-  font-weight: 200;
-  font-display: block;
-  src: url("/fonts/inter/Inter-DisplayExtraLight.woff2?v=3.19") format("woff2");
-}
-@font-face {
-  font-family: "InterDisplay";
-  font-style: italic;
-  font-weight: 200;
-  font-display: block;
-  src: url("/fonts/inter/Inter-DisplayExtraLightItalic.woff2?v=3.19")
-    format("woff2");
-}
-@font-face {
-  font-family: "InterDisplay";
-  font-style: normal;
-  font-weight: 300;
-  font-display: block;
-  src: url("/fonts/inter/Inter-DisplayLight.woff2?v=3.19") format("woff2");
-}
-@font-face {
-  font-family: "InterDisplay";
-  font-style: italic;
-  font-weight: 300;
-  font-display: block;
-  src: url("/fonts/inter/Inter-DisplayLightItalic.woff2?v=3.19") format("woff2");
-}
-@font-face {
-  font-family: "InterDisplay";
-  font-style: normal;
-  font-weight: 400;
-  font-display: block;
-  src: url("/fonts/inter/Inter-DisplayRegular.woff2?v=3.19") format("woff2");
-}
-@font-face {
-  font-family: "InterDisplay";
-  font-style: italic;
-  font-weight: 400;
-  font-display: block;
-  src: url("/fonts/inter/Inter-DisplayItalic.woff2?v=3.19") format("woff2");
-}
-@font-face {
-  font-family: "InterDisplay";
-  font-style: normal;
-  font-weight: 500;
-  font-display: block;
-  src: url("/fonts/inter/Inter-DisplayMedium.woff2?v=3.19") format("woff2");
-}
-@font-face {
-  font-family: "InterDisplay";
-  font-style: italic;
-  font-weight: 500;
-  font-display: block;
-  src: url("/fonts/inter/Inter-DisplayMediumItalic.woff2?v=3.19")
-    format("woff2");
-}
-@font-face {
-  font-family: "InterDisplay";
-  font-style: normal;
-  font-weight: 600;
-  font-display: block;
-  src: url("/fonts/inter/Inter-DisplaySemiBold.woff2?v=3.19") format("woff2");
-}
-@font-face {
-  font-family: "InterDisplay";
-  font-style: italic;
-  font-weight: 600;
-  font-display: block;
-  src: url("/fonts/inter/Inter-DisplaySemiBoldItalic.woff2?v=3.19")
-    format("woff2");
-}
-@font-face {
-  font-family: "InterDisplay";
-  font-style: normal;
-  font-weight: 700;
-  font-display: block;
-  src: url("/fonts/inter/Inter-DisplayBold.woff2?v=3.19") format("woff2");
-}
-@font-face {
-  font-family: "InterDisplay";
-  font-style: italic;
-  font-weight: 700;
-  font-display: block;
-  src: url("/fonts/inter/Inter-DisplayBoldItalic.woff2?v=3.19") format("woff2");
-}
-@font-face {
-  font-family: "InterDisplay";
-  font-style: normal;
-  font-weight: 800;
-  font-display: block;
-  src: url("/fonts/inter/Inter-DisplayExtraBold.woff2?v=3.19") format("woff2");
-}
-@font-face {
-  font-family: "InterDisplay";
-  font-style: italic;
-  font-weight: 800;
-  font-display: block;
-  src: url("/fonts/inter/Inter-DisplayExtraBoldItalic.woff2?v=3.19")
-    format("woff2");
-}
-@font-face {
-  font-family: "InterDisplay";
-  font-style: normal;
-  font-weight: 900;
-  font-display: block;
-  src: url("/fonts/inter/Inter-DisplayBlack.woff2?v=3.19") format("woff2");
-}
-@font-face {
-  font-family: "InterDisplay";
-  font-style: italic;
-  font-weight: 900;
-  font-display: block;
-  src: url("/fonts/inter/Inter-DisplayBlackItalic.woff2?v=3.19") format("woff2");
-}
+
 
 @font-face {
   font-family: "MD IO";

--- a/web-local/src/app.html
+++ b/web-local/src/app.html
@@ -2,7 +2,6 @@
 <html lang="en">
   <head>
     <link rel="stylesheet" href="%sveltekit.assets%/fonts/fonts.css" />
-
     <link
       rel="preload"
       href="%sveltekit.assets%/fonts/inter/Inter-Regular.woff2?v=3.19"

--- a/web-local/src/app.html
+++ b/web-local/src/app.html
@@ -2,6 +2,35 @@
 <html lang="en">
   <head>
     <link rel="stylesheet" href="%sveltekit.assets%/fonts/fonts.css" />
+
+    <link
+      rel="preload"
+      href="%sveltekit.assets%/fonts/inter/Inter-Regular.woff2?v=3.19"
+      as="font"
+      type="font/woff2"
+      crossorigin
+    />
+    <link
+      rel="preload"
+      href="%sveltekit.assets%/fonts/inter/Inter-Medium.woff2?v=3.19"
+      as="font"
+      type="font/woff2"
+      crossorigin
+    />
+    <link
+      rel="preload"
+      href="%sveltekit.assets%/fonts/inter/Inter-SemiBold.woff2?v=3.19"
+      as="font"
+      type="font/woff2"
+      crossorigin
+    />
+    <link
+      rel="preload"
+      href="%sveltekit.assets%/fonts/inter/Inter-Bold.woff2?v=3.19"
+      as="font"
+      type="font/woff2"
+      crossorigin
+    />
     <meta charset="utf-8" />
     <meta content="" name="description" />
     <link href="%sveltekit.assets%/favicon.png" rel="icon" />

--- a/web-local/src/app.html
+++ b/web-local/src/app.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <link rel="stylesheet" href="%sveltekit.assets%/fonts/fonts.css" />
     <meta charset="utf-8" />
     <meta content="" name="description" />
     <link href="%sveltekit.assets%/favicon.png" rel="icon" />


### PR DESCRIPTION
This fixes the flash of unstyled text that people were seeing. In detail:
- preloads the font definition css and the four most used fonts
   - moves `fonts.css` to static folder 
- sets `font-display` to `block` rather than `swap` for these key fonts, so text that is supposed to use these fonts will not be shown at all until the font is ready 
- also removed Inter Display, which was only used in the dashboard header. (I can't tell the difference at all)

In my local testing with simulated network throttling on Chrome and FF, I see no unstyled text. @hamilton  and @magorlick  please do an experience pass to confirm that you're seeing the behavior you want.

I'll also mention that in the course of doing research on this topic, I found that this method in this PR (preloading and blocking) is controversial because it can lead to a "flash of invisible text" while the fonts are loading, which many people seem to think think is worse than text with the wrong font. I don't think this is a necessarily problem for us, and [some people think it's worth the delay](https://www.smashingmagazine.com/2021/05/reduce-font-loading-impact-css-descriptors/), but it's something to be aware of as you are doing the experience pass.

For the sake of completeness, I thought I'd make a note that there additional optimizations that we could look into if we want to avoid the flash of invisible text problem, or if we want to optimize page load time: 
- to improve load times, you can build subset fonts that just have alphanumeric glyphs, and stick those in a data URI to be downloaded directly in the initial page HTML; then this can be swapped out when the full font is ready. https://markoskon.com/creating-font-subsets/
- to avoid flash of invisible text and show content faster, many people recommend using one of the browser's built in fonts as a backup until the desired font is loaded, and then swapping the fonts. The idea is that by choosing the right built in font and tweaking it a bit to look like the desired font, you can make the transition less jarring when the swap is applied-- part of what was so jarring in our case was that the unstyled text used a serif font that was the wrong size, so the transition looked terrible. This page has some recommended styles to make Arial look like Inter https://deploy-preview-15--upbeat-shirley-608546.netlify.app/perfect-ish-font-fallback/?font=Inter


