### PR TITLE
Fix leaderboard comparisons

### DIFF
--- a/web-common/src/features/dashboards/dimension-table/DimensionDisplay.svelte
+++ b/web-common/src/features/dashboards/dimension-table/DimensionDisplay.svelte
@@ -39,7 +39,7 @@
     computeComparisonValues,
     customSortMeasures,
     getComparisonProperties,
-    getFilterForComparsion,
+    getFilterForComparisonTable,
     updateFilterOnSearch,
   } from "./dimension-table-utils";
   import DimensionContainer from "./DimensionContainer.svelte";
@@ -187,7 +187,7 @@
     const { start, end } = comparisonTimeRange;
     isComparisonRangeAvailable = comparisonTimeRange.isComparisonRangeAvailable;
 
-    let comparisonFilterSet = getFilterForComparsion(
+    let comparisonFilterSet = getFilterForComparisonTable(
       filterForDimension,
       dimensionName,
       values

--- a/web-common/src/features/dashboards/dimension-table/dimension-table-utils.ts
+++ b/web-common/src/features/dashboards/dimension-table/dimension-table-utils.ts
@@ -51,27 +51,37 @@ export function updateFilterOnSearch(
 export function getFilterForComparsion(
   filterForDimension,
   dimensionName,
-  values
+  filterValues
 ) {
   const comparisonFilterSet = JSON.parse(JSON.stringify(filterForDimension));
 
-  if (!values.length) return comparisonFilterSet;
+  if (!filterValues.length) return comparisonFilterSet;
 
   let foundDimension = false;
   comparisonFilterSet["include"].forEach((filter) => {
     if (filter.name === dimensionName) {
       foundDimension = true;
-      filter.in = values.map((v) => v[dimensionName]);
+      filter.in = filterValues;
     }
   });
 
   if (!foundDimension) {
     comparisonFilterSet["include"].push({
       name: dimensionName,
-      in: values.map((v) => v[dimensionName]),
+      in: filterValues,
     });
   }
   return comparisonFilterSet;
+}
+
+export function getFilterForComparisonTable(
+  filterForDimension,
+  dimensionName,
+  values
+) {
+  if (!values || !values.length) return filterForDimension;
+  const filterValues = values.map((v) => v[dimensionName]);
+  getFilterForComparsion(filterForDimension, dimensionName, filterValues);
 }
 
 // Custom sort that implements the following logic:
@@ -110,9 +120,7 @@ export function computeComparisonValues(
     : comparisonData?.meta[0].name;
 
   const dimensionToValueMap = new Map(
-    comparisonData?.data?.map((obj) => {
-      return [obj[dimensionName], obj[measureName]];
-    })
+    comparisonData?.data?.map((obj) => [obj[dimensionName], obj[measureName]])
   );
 
   for (const value of values) {

--- a/web-common/src/features/dashboards/leaderboard/DimensionLeaderboardEntrySet.svelte
+++ b/web-common/src/features/dashboards/leaderboard/DimensionLeaderboardEntrySet.svelte
@@ -46,10 +46,10 @@ see more button
   const dispatch = createEventDispatcher();
   let renderValues = [];
 
+  $: comparsionMap = new Map(comparisonValues?.map((v) => [v.label, v.value]));
   $: renderValues = values.map((v, i) => {
     const active = activeValues.findIndex((value) => value === v.label) >= 0;
-    // pray to god
-    const comparisonValue = comparisonValues?.[i]?.value;
+    const comparisonValue = comparsionMap.get(v.label);
 
     // Super important special case: if there is not at least one "active" (selected) value,
     // we need to set *all* items to be included, because by default if a user has not


### PR DESCRIPTION
This PR 
- refactors the `topList` call for comparisons to only include visible values
- Map comparison value to the right label
- Other syntax fixes