### PR TITLE
Comparison chart fixes

### DIFF
--- a/web-common/src/components/data-graphic/marks/MultiMetricMouseoverLabel.svelte
+++ b/web-common/src/components/data-graphic/marks/MultiMetricMouseoverLabel.svelte
@@ -8,6 +8,7 @@ It is probably not the most up to date code; but it works very well in practice.
 
   import { WithTween } from "../functional-components";
   import type { ScaleStore, SimpleConfigurationStore } from "../state/types";
+  import { preventVerticalOverlap } from "./prevent-vertical-overlap";
 
   interface Point {
     x: number;
@@ -18,6 +19,8 @@ It is probably not the most up to date code; but it works very well in practice.
     labelColorClass?: string;
     labelStyleClass?: string;
     pointColorClass?: string;
+    yOverride?: boolean;
+    yOverrideLabel?: string;
   }
 
   export let point: Point[] = [];
@@ -26,7 +29,8 @@ It is probably not the most up to date code; but it works very well in practice.
   export let xOffset = 0;
   export let fontSize = 11;
   export let xBuffer = 8;
-  export let yBuffer = 3;
+  export let elementHeight = 12;
+  export let yBuffer = 4;
   export let showPoints = true;
   export let showLabels = true;
 
@@ -46,108 +50,32 @@ It is probably not the most up to date code; but it works very well in practice.
   export let direction = "right";
   export let flipAtEdge: "body" | "graphic" | false = "graphic"; // "body", "graphic", or undefined
 
-  // FIXME – we should replace this with preventVerticalOverlap!
-  function toLocations(pt, xs, ys, left, right, top, bottom, elementHeight) {
-    // this is where the boundary condition lives.
-    let locations = [
-      ...pt.map((p) => ({
-        ...p,
-        xRange: Math.max(left, xs(p.x)) || 0,
-        yRange: ys(p.y),
-      })),
-    ];
-    // sort order makes all the difference here
-    locations.sort((a, b) => {
-      if (a.y < b.y) return 1;
-      if (a.y > b.y) return -1;
-      return 0;
-    });
-    if (locations.length === 1) {
-      locations[0].yRange = Math.min(
-        bottom,
-        Math.max(top, locations[0].yRange)
-      );
-      return locations;
-    }
-    if (!locations.length) return locations;
-
-    const middle = ~~(locations.length / 2); // eslint-disable-line
-
-    // STEP 1: inside up to top label.
-    let i = middle;
-    while (i >= 0) {
-      if (i !== middle) {
-        const diff = locations[i + 1].yRange - locations[i].yRange;
-        if (diff <= elementHeight + yBuffer) {
-          locations[i].yRange -= elementHeight + yBuffer - diff;
-        }
-      }
-      i -= 1;
-    }
-
-    // STEP 2: top label shuffle down to reasonable place, shift to middle.
-    if (locations[0].yRange < top + yBuffer) {
-      locations[0].yRange = top + yBuffer;
-      i = 0;
-      while (i < middle) {
-        const diff = locations[i + 1].yRange - locations[i].yRange;
-        if (diff <= elementHeight + yBuffer) {
-          locations[i + 1].yRange += elementHeight + yBuffer - diff;
-        }
-        i += 1;
-      }
-    }
-
-    // STEP 3: inside down to bottom label;
-    i = middle;
-    while (i < locations.length) {
-      if (i !== middle) {
-        const diff = locations[i].yRange - locations[i - 1].yRange;
-        if (diff < elementHeight + yBuffer) {
-          locations[i].yRange += elementHeight + yBuffer - diff;
-        }
-      }
-      i += 1;
-    }
-    if (locations[locations.length - 1].yRange > bottom - yBuffer) {
-      locations[locations.length - 1].yRange = bottom - yBuffer;
-      i = locations.length - 1;
-      while (i > 0) {
-        const diff = locations[i].yRange - locations[i - 1].yRange;
-        if (diff <= fontSize + yBuffer) {
-          locations[i - 1].yRange -= elementHeight + yBuffer - diff;
-        }
-        i -= 1;
-      }
-    }
-    return locations;
-  }
-
-  let locations = toLocations(
-    point,
-    $xScale,
-    $yScale,
-    plotLeft,
-    plotRight,
-    plotTop,
-    plotBottom,
-    fontSize
-  );
   let container;
   let containerWidths = [];
   // let labelWidth = 0;
 
   // update locations.
-  $: locations = toLocations(
-    point,
-    $xScale,
-    $yScale,
-    plotLeft,
-    plotRight,
+  $: nonOverlappingLocations = preventVerticalOverlap(
+    point.map((p, i) => ({
+      key: `${p.x}-${p.y}-${i}`,
+      value: $yScale(p.y),
+    })),
     plotTop,
     plotBottom,
-    fontSize
+    elementHeight,
+    yBuffer
   );
+
+  $: locations = point.map((p, i) => {
+    const key = `${p.x}-${p.y}-${i}`;
+    return {
+      ...p,
+      key,
+      xRange: $xScale(p.x),
+      yRange: nonOverlappingLocations.find((l) => l.key === key).value,
+    };
+  });
+
   // update containerWidths. We keep track of the last 6 points.
   $: if (container && locations) {
     containerWidths = [
@@ -216,7 +144,7 @@ It is probably not the most up to date code; but it works very well in practice.
       );
 
       textWidths = Array.from(container.querySelectorAll(".text-elements")).map(
-        (q) => q.getBoundingClientRect().width
+        (q: SVGElement) => q.getBoundingClientRect().width
       );
       if (!Number.isFinite(labelWidth)) {
         labelWidth = 0;
@@ -228,7 +156,7 @@ It is probably not the most up to date code; but it works very well in practice.
 <g bind:this={container}>
   {#if showLabels}
     {#each locations as location, i (location.key || location.label)}
-      {#if (location.y || location.rangeY) && (location.x || location.rangeX)}
+      {#if (location.y || location.yRange) && (location.x || location.xRange)}
         <WithTween
           value={{
             y: location.yRange || 0,

--- a/web-common/src/components/data-graphic/marks/MultiMetricMouseoverLabel.svelte
+++ b/web-common/src/components/data-graphic/marks/MultiMetricMouseoverLabel.svelte
@@ -164,7 +164,7 @@ It is probably not the most up to date code; but it works very well in practice.
               ? location.xRange + (xBuffer + xOffset + labelWidth)
               : location.xRange - xBuffer - xOffset}
           <WithTween
-            tweenProps={{ duration: 100 }}
+            tweenProps={{ duration: 60 }}
             value={{
               label: location.yRange || 0,
               point: $yScale(location.y),

--- a/web-common/src/components/data-graphic/marks/MultiMetricMouseoverLabel.svelte
+++ b/web-common/src/components/data-graphic/marks/MultiMetricMouseoverLabel.svelte
@@ -185,7 +185,7 @@ It is probably not the most up to date code; but it works very well in practice.
               <tspan
                 dy=".35em"
                 y={v.y}
-                x={v.x}
+                x={v.x - (location?.yOverride ? labelWidth : 0)}
                 class="mc-mouseover-label  {location?.labelStyleClass ||
                   ''} {(!location?.yOverride && location?.labelColorClass) ||
                   ''}"

--- a/web-common/src/components/data-graphic/marks/MultiMetricMouseoverLabel.svelte
+++ b/web-common/src/components/data-graphic/marks/MultiMetricMouseoverLabel.svelte
@@ -14,6 +14,7 @@ It is probably not the most up to date code; but it works very well in practice.
     x: number;
     y: number;
     label: string;
+    key: string;
     valueColorClass?: string;
     valueStyleClass?: string;
     labelColorClass?: string;
@@ -56,8 +57,8 @@ It is probably not the most up to date code; but it works very well in practice.
 
   // update locations.
   $: nonOverlappingLocations = preventVerticalOverlap(
-    point.map((p, i) => ({
-      key: `${p.x}-${p.y}-${i}`,
+    point.map((p) => ({
+      key: p.key,
       value: $yScale(p.y),
     })),
     plotTop,
@@ -66,13 +67,11 @@ It is probably not the most up to date code; but it works very well in practice.
     yBuffer
   );
 
-  $: locations = point.map((p, i) => {
-    const key = `${p.x}-${p.y}-${i}`;
+  $: locations = point.map((p) => {
     return {
       ...p,
-      key,
       xRange: $xScale(p.x),
-      yRange: nonOverlappingLocations.find((l) => l.key === key).value,
+      yRange: nonOverlappingLocations.find((l) => l.key === p.key).value,
     };
   });
 
@@ -241,12 +240,14 @@ It is probably not the most up to date code; but it works very well in practice.
           ]}
           let:output
         >
-          <circle cx={output[0]} cy={output[1]} r={5} fill="white" />
           <circle
             cx={output[0]}
             cy={output[1]}
             r={3}
+            paint-order="stroke"
             class={location.pointColorClass}
+            stroke="white"
+            stroke-width="3"
           />
         </WithTween>
       {/if}

--- a/web-common/src/components/data-graphic/marks/MultiMetricMouseoverLabel.svelte
+++ b/web-common/src/components/data-graphic/marks/MultiMetricMouseoverLabel.svelte
@@ -157,14 +157,14 @@ It is probably not the most up to date code; but it works very well in practice.
         <WithTween
           value={location.xRange}
           let:output={x}
-          tweenProps={{ duration: 50 }}
+          tweenProps={{ duration: 25 }}
         >
           {@const xText =
             internalDirection === "right"
               ? location.xRange + (xBuffer + xOffset + labelWidth)
               : location.xRange - xBuffer - xOffset}
           <WithTween
-            tweenProps={{ duration: 1000 }}
+            tweenProps={{ duration: 100 }}
             value={{
               label: location.yRange || 0,
               point: $yScale(location.y),

--- a/web-common/src/components/data-graphic/marks/MultiMetricMouseoverLabel.svelte
+++ b/web-common/src/components/data-graphic/marks/MultiMetricMouseoverLabel.svelte
@@ -35,8 +35,6 @@ It is probably not the most up to date code; but it works very well in practice.
   export let showPoints = true;
   export let showLabels = true;
 
-  export let keepPointsTrue = false;
-
   // plot the middle and push out from there
 
   const xScale = getContext(contexts.scale("x")) as ScaleStore;
@@ -157,79 +155,98 @@ It is probably not the most up to date code; but it works very well in practice.
     {#each locations as location, i (location.key || location.label)}
       {#if (location.y || location.yRange) && (location.x || location.xRange)}
         <WithTween
-          value={{
-            y: location.yRange || 0,
-            x:
-              internalDirection === "right"
-                ? location.xRange + (xBuffer + xOffset + labelWidth)
-                : location.xRange - xBuffer - xOffset,
-          }}
-          let:output={v}
+          value={location.xRange}
+          let:output={x}
           tweenProps={{ duration: 50 }}
         >
-          <text font-size={fontSize} class="text-elements pointer-events-none">
-            {#if internalDirection === "right"}
-              <tspan
-                dy=".35em"
-                class="widths {location?.valueStyleClass ||
-                  'font-bold'} {location?.valueColorClass || ''}"
-                y={v.y}
-                text-anchor="end"
-                x={v.x}
-              >
-                {#if !location?.yOverride}
-                  {formatValue(location.y)}
-                {/if}
-              </tspan>
-              <tspan
-                dy=".35em"
-                y={v.y}
-                x={v.x - (location?.yOverride ? labelWidth : 0)}
-                class="mc-mouseover-label  {location?.labelStyleClass ||
-                  ''} {(!location?.yOverride && location?.labelColorClass) ||
-                  ''}"
-              >
-                {#if location?.yOverride}
-                  {location.yOverrideLabel}
-                {:else}
-                  {location.label}
-                {/if}
-              </tspan>
-            {:else}
-              <tspan
-                dy=".35em"
-                y={v.y}
-                x={v.x - labelWidth}
-                class="mc-mouseover-label  {location?.labelStyleClass ||
-                  ''} {(!location?.yOverride && location?.labelColorClass) ||
-                  ''}"
-                text-anchor="end"
-              >
-                {#if location?.yOverride}
-                  {location.yOverrideLabel}
-                {:else}
-                  {location.label}
-                {/if}
-              </tspan>
-              <tspan
-                dy=".35em"
-                class="widths {location?.valueStyleClass ||
-                  'font-bold'} {location?.valueColorClass || ''}"
-                text-anchor="end"
-                y={v.y}
-                x={v.x}
-              >
-                {#if !location?.yOverride}
-                  {formatValue(location.y)}
-                {/if}
-              </tspan>
-            {/if}
-          </text>
+          {@const xText =
+            internalDirection === "right"
+              ? location.xRange + (xBuffer + xOffset + labelWidth)
+              : location.xRange - xBuffer - xOffset}
+          <WithTween
+            tweenProps={{ duration: 1000 }}
+            value={{
+              label: location.yRange || 0,
+              point: $yScale(location.y),
+            }}
+            let:output={y}
+          >
+            <text
+              font-size={fontSize}
+              class="text-elements pointer-events-none"
+            >
+              {#if internalDirection === "right"}
+                <tspan
+                  dy=".35em"
+                  class="widths {location?.valueStyleClass ||
+                    'font-bold'} {location?.valueColorClass || ''}"
+                  y={y.label}
+                  text-anchor="end"
+                  x={xText}
+                >
+                  {#if !location?.yOverride}
+                    {formatValue(location.y)}
+                  {/if}
+                </tspan>
+                <tspan
+                  dy=".35em"
+                  y={y.label}
+                  x={xText - (location?.yOverride ? labelWidth : 0)}
+                  class="mc-mouseover-label  {location?.labelStyleClass ||
+                    ''} {(!location?.yOverride && location?.labelColorClass) ||
+                    ''}"
+                >
+                  {#if location?.yOverride}
+                    {location.yOverrideLabel}
+                  {:else}
+                    {location.label}
+                  {/if}
+                </tspan>
+              {:else}
+                <tspan
+                  dy=".35em"
+                  y={y.label}
+                  x={xText - labelWidth}
+                  class="mc-mouseover-label  {location?.labelStyleClass ||
+                    ''} {(!location?.yOverride && location?.labelColorClass) ||
+                    ''}"
+                  text-anchor="end"
+                >
+                  {#if location?.yOverride}
+                    {location.yOverrideLabel}
+                  {:else}
+                    {location.label}
+                  {/if}
+                </tspan>
+                <tspan
+                  dy=".35em"
+                  class="widths {location?.valueStyleClass ||
+                    'font-bold'} {location?.valueColorClass || ''}"
+                  text-anchor="end"
+                  y={y.label}
+                  x={xText}
+                >
+                  {#if !location?.yOverride}
+                    {formatValue(location.y)}
+                  {/if}
+                </tspan>
+              {/if}
+            </text>
+            <circle
+              cx={x}
+              cy={y.point}
+              r={3}
+              paint-order="stroke"
+              class={location.pointColorClass}
+              stroke="white"
+              stroke-width="3"
+            />
+          </WithTween>
         </WithTween>
       {/if}
     {/each}
   {/if}
-  {#if showPoints}
+  <!-- {#if showPoints}
     {#each locations as location, i (location.key || location.label)}
       {#if (keepPointsTrue && location.x !== undefined && location.y !== undefined) || (location.xRange !== undefined && location.yRange !== undefined)}
         <WithTween
@@ -252,7 +269,7 @@ It is probably not the most up to date code; but it works very well in practice.
         </WithTween>
       {/if}
     {/each}
-  {/if}
+  {/if} -->
 </g>
 
 <style>

--- a/web-common/src/features/dashboards/time-series/MeasureChart.svelte
+++ b/web-common/src/features/dashboards/time-series/MeasureChart.svelte
@@ -182,17 +182,6 @@
         let:point
       >
         <g transition:fly|local={{ duration: 100, x: -4 }}>
-          <MeasureValueMouseover
-            {point}
-            {xAccessor}
-            {yAccessor}
-            {showComparison}
-            {mouseoverFormat}
-            {numberKind}
-          />
-        </g>
-
-        <g transition:fly|local={{ duration: 100, x: -4 }}>
           <text
             class="fill-gray-600"
             style:paint-order="stroke"
@@ -215,6 +204,16 @@
               {mouseoverTimeFormat(point[`comparison.${xAccessor}`])} prev.
             </text>
           {/if}
+        </g>
+        <g transition:fly|local={{ duration: 100, x: -4 }}>
+          <MeasureValueMouseover
+            {point}
+            {xAccessor}
+            {yAccessor}
+            {showComparison}
+            {mouseoverFormat}
+            {numberKind}
+          />
         </g>
       </WithBisector>
     </WithRoundToTimegrain>

--- a/web-common/src/features/dashboards/time-series/MeasureValueMouseover.svelte
+++ b/web-common/src/features/dashboards/time-series/MeasureValueMouseover.svelte
@@ -101,16 +101,16 @@
 <WithGraphicContexts let:xScale let:yScale>
   {@const strokeWidth = showComparison ? 2 : 4}
   {@const colorClass = "stroke-gray-400"}
-  {#if !(currentPointIsNull || comparisonPointIsNull) && x !== undefined && y !== undefined}
-    <WithTween
-      tweenProps={{ duration: 50 }}
-      value={{
-        x: xScale(x),
-        y: yScale(y),
-        dy: yScale(comparisonY) || yScale(0),
-      }}
-      let:output
-    >
+  <WithTween
+    tweenProps={{ duration: 0 }}
+    value={{
+      x: xScale(x),
+      y: yScale(y),
+      dy: yScale(comparisonY) || yScale(0),
+    }}
+    let:output
+  >
+    {#if !(currentPointIsNull || comparisonPointIsNull) && x !== undefined && y !== undefined}
       {#if !showComparison || Math.abs(output.y - output.dy) > 8}
         {@const bufferSize = Math.abs(output.y - output.dy) > 16 ? 8 : 4}
         {@const yBuffer = !hasValidComparisonPoint
@@ -208,19 +208,19 @@
           </g>
         </g>
       {/if}
-      {#if !hasValidComparisonPoint && x !== undefined && y !== null && y !== undefined && !currentPointIsNull}
-        <line
-          transition:fade|local={{ duration: 100 }}
-          x1={output.x}
-          x2={output.x}
-          y1={yScale(0)}
-          y2={output.y}
-          stroke-width="4"
-          class={"stroke-blue-300"}
-        />
-      {/if}
-    </WithTween>
-  {/if}
+    {/if}
+    {#if !hasValidComparisonPoint && x !== undefined && y !== null && y !== undefined && !currentPointIsNull}
+      <line
+        transition:fade|local={{ duration: 100 }}
+        x1={output.x}
+        x2={output.x}
+        y1={yScale(0)}
+        y2={output.y}
+        stroke-width="4"
+        class={"stroke-blue-300"}
+      />
+    {/if}
+  </WithTween>
 
   <MultiMetricMouseoverLabel
     direction="right"

--- a/web-common/src/features/dashboards/time-series/MeasureValueMouseover.svelte
+++ b/web-common/src/features/dashboards/time-series/MeasureValueMouseover.svelte
@@ -208,19 +208,17 @@
           </g>
         </g>
       {/if}
-    </WithTween>
-  {/if}
-  {#if !hasValidComparisonPoint && x !== undefined && y !== null && y !== undefined && !currentPointIsNull}
-    <WithTween value={{ x: xScale(x), y: yScale(y) }} let:output>
-      <line
-        transition:fade|local={{ duration: 100 }}
-        x1={output.x}
-        x2={output.x}
-        y1={yScale(0)}
-        y2={output.y}
-        stroke-width="4"
-        class={"stroke-blue-300"}
-      />
+      {#if !hasValidComparisonPoint && x !== undefined && y !== null && y !== undefined && !currentPointIsNull}
+        <line
+          transition:fade|local={{ duration: 100 }}
+          x1={output.x}
+          x2={output.x}
+          y1={yScale(0)}
+          y2={output.y}
+          stroke-width="4"
+          class={"stroke-blue-300"}
+        />
+      {/if}
     </WithTween>
   {/if}
 

--- a/web-common/src/features/dashboards/time-series/MeasureValueMouseover.svelte
+++ b/web-common/src/features/dashboards/time-series/MeasureValueMouseover.svelte
@@ -85,7 +85,7 @@
   /** get the final point set*/
   $: pointSet =
     showComparison && hasValidComparisonPoint
-      ? [mainPoint, comparisonPoint]
+      ? [comparisonPoint, mainPoint]
       : [mainPoint];
 
   /** modes
@@ -102,130 +102,134 @@
   {@const strokeWidth = showComparison ? 2 : 4}
   {@const colorClass = "stroke-gray-400"}
   <WithTween
-    tweenProps={{ duration: 50 }}
+    tweenProps={{ duration: 1000 }}
     value={{
-      x: xScale(x),
       y: yScale(y),
       dy: yScale(comparisonY) || yScale(0),
     }}
     let:output
   >
-    {#if !(currentPointIsNull || comparisonPointIsNull) && x !== undefined && y !== undefined}
-      {#if !showComparison || Math.abs(output.y - output.dy) > 8}
-        {@const bufferSize = Math.abs(output.y - output.dy) > 16 ? 8 : 4}
-        {@const yBuffer = !hasValidComparisonPoint
-          ? 0
-          : !comparisonIsPositive
-          ? -bufferSize
-          : bufferSize}
+    <WithTween
+      tweenProps={{ duration: 50 }}
+      value={xScale(x)}
+      let:output={xArrow}
+    >
+      {#if !(currentPointIsNull || comparisonPointIsNull) && x !== undefined && y !== undefined}
+        {#if !showComparison || Math.abs(output.y - output.dy) > 8}
+          {@const bufferSize = Math.abs(output.y - output.dy) > 16 ? 8 : 4}
+          {@const yBuffer = !hasValidComparisonPoint
+            ? 0
+            : !comparisonIsPositive
+            ? -bufferSize
+            : bufferSize}
 
-        {@const sign = !comparisonIsPositive ? -1 : 1}
-        {@const dist = 3}
-        {@const signedDist = sign * dist}
-        {@const yLoc = output.y + bufferSize * sign}
-        {@const show =
-          Math.abs(output.y - output.dy) > 16 && hasValidComparisonPoint}
-        <!-- arrows -->
-        <g>
-          {#if show}
+          {@const sign = !comparisonIsPositive ? -1 : 1}
+          {@const dist = 3}
+          {@const signedDist = sign * dist}
+          {@const yLoc = output.y + bufferSize * sign}
+          {@const show =
+            Math.abs(output.y - output.dy) > 16 && hasValidComparisonPoint}
+          <!-- arrows -->
+          <g>
+            {#if show}
+              <line
+                x1={xArrow}
+                x2={xArrow + dist}
+                y1={yLoc}
+                y2={yLoc + signedDist}
+                stroke="white"
+                stroke-width={strokeWidth + 3}
+                stroke-linecap="round"
+              />
+              <line
+                x1={xArrow}
+                x2={xArrow - dist}
+                y1={yLoc}
+                y2={yLoc + signedDist}
+                stroke="white"
+                stroke-width={strokeWidth + 3}
+                stroke-linecap="round"
+              />
+            {/if}
+
             <line
-              x1={output.x}
-              x2={output.x + dist}
-              y1={yLoc}
-              y2={yLoc + signedDist}
+              x1={xArrow}
+              x2={xArrow}
+              y1={output.y + yBuffer}
+              y2={output.dy - yBuffer}
               stroke="white"
               stroke-width={strokeWidth + 3}
               stroke-linecap="round"
             />
+
             <line
-              x1={output.x}
-              x2={output.x - dist}
-              y1={yLoc}
-              y2={yLoc + signedDist}
-              stroke="white"
-              stroke-width={strokeWidth + 3}
+              x1={xArrow}
+              x2={xArrow}
+              y1={output.y + yBuffer}
+              y2={output.dy - yBuffer}
+              class={colorClass}
+              stroke-width={strokeWidth}
               stroke-linecap="round"
             />
-          {/if}
 
-          <line
-            x1={output.x}
-            x2={output.x}
-            y1={output.y + yBuffer}
-            y2={output.dy - yBuffer}
-            stroke="white"
-            stroke-width={strokeWidth + 3}
-            stroke-linecap="round"
-          />
-
-          <line
-            x1={output.x}
-            x2={output.x}
-            y1={output.y + yBuffer}
-            y2={output.dy - yBuffer}
-            class={colorClass}
-            stroke-width={strokeWidth}
-            stroke-linecap="round"
-          />
-
-          <g class:opacity-0={!show} class="transition-opacity">
-            <g>
-              <line
-                x1={output.x}
-                x2={output.x + dist}
-                y1={yLoc}
-                stroke-width={strokeWidth}
-                y2={yLoc + signedDist}
-                class={colorClass}
-                stroke-linecap="round"
-              />
-              <line
-                x1={output.x}
-                x2={output.x - dist}
-                y1={yLoc}
-                stroke-width={strokeWidth}
-                y2={yLoc + signedDist}
-                class={colorClass}
-                stroke-linecap="round"
-              />
-              <!-- <path
-                d="M {output.x} {yLoc} L {output.x + signedDist} {yLoc +
-                  signedDist} L {output.x - signedDist} {yLoc +
-                  signedDist} M {output.x} {yLoc} L {output.x} {output.dy -
+            <g class:opacity-0={!show} class="transition-opacity">
+              <g>
+                <line
+                  x1={xArrow}
+                  x2={xArrow + dist}
+                  y1={yLoc}
+                  stroke-width={strokeWidth}
+                  y2={yLoc + signedDist}
+                  class={colorClass}
+                  stroke-linecap="round"
+                />
+                <line
+                  x1={xArrow}
+                  x2={xArrow - dist}
+                  y1={yLoc}
+                  stroke-width={strokeWidth}
+                  y2={yLoc + signedDist}
+                  class={colorClass}
+                  stroke-linecap="round"
+                />
+                <!-- <path
+                d="M {xArrow} {yLoc} L {xArrow + signedDist} {yLoc +
+                  signedDist} L {xArrow - signedDist} {yLoc +
+                  signedDist} M {xArrow} {yLoc} L {xArrow} {output.dy -
                   yBuffer} Z"
                 stroke="white"
                 stroke-width="5"
               /> -->
-              <!-- <path
-                d="M {output.x} {yLoc} L {output.x + signedDist} {yLoc +
-                  signedDist} L {output.x - signedDist} {yLoc +
-                  signedDist} {output.x} {yLoc} M {output.x} {yLoc +
-                  2} L {output.x} {output.dy - yBuffer} Z"
+                <!-- <path
+                d="M {xArrow} {yLoc} L {xArrow + signedDist} {yLoc +
+                  signedDist} L {xArrow - signedDist} {yLoc +
+                  signedDist} {xArrow} {yLoc} M {xArrow} {yLoc +
+                  2} L {xArrow} {output.dy - yBuffer} Z"
                 stroke-linecap="round"
                 class={colorClass}
               /> -->
+              </g>
             </g>
           </g>
-        </g>
+        {/if}
       {/if}
-    {/if}
-    {#if !hasValidComparisonPoint && x !== undefined && y !== null && y !== undefined && !currentPointIsNull}
-      <line
-        transition:fade|local={{ duration: 100 }}
-        x1={output.x}
-        x2={output.x}
-        y1={yScale(0)}
-        y2={output.y}
-        stroke-width="4"
-        class={"stroke-blue-300"}
-      />
-    {/if}
+      {#if !hasValidComparisonPoint && x !== undefined && y !== null && y !== undefined && !currentPointIsNull}
+        <line
+          transition:fade|local={{ duration: 100 }}
+          x1={xArrow}
+          x2={xArrow}
+          y1={yScale(0)}
+          y2={output.y}
+          stroke-width="4"
+          class={"stroke-blue-300"}
+        />
+      {/if}
+    </WithTween>
   </WithTween>
 
   <MultiMetricMouseoverLabel
     direction="right"
     flipAtEdge={false}
-    keepPointsTrue
     formatValue={mouseoverFormat}
     point={pointSet || []}
   />

--- a/web-common/src/features/dashboards/time-series/MeasureValueMouseover.svelte
+++ b/web-common/src/features/dashboards/time-series/MeasureValueMouseover.svelte
@@ -102,7 +102,7 @@
   {@const strokeWidth = showComparison ? 2 : 4}
   {@const colorClass = "stroke-gray-400"}
   <WithTween
-    tweenProps={{ duration: 0 }}
+    tweenProps={{ duration: 50 }}
     value={{
       x: xScale(x),
       y: yScale(y),

--- a/web-common/src/features/dashboards/time-series/MeasureValueMouseover.svelte
+++ b/web-common/src/features/dashboards/time-series/MeasureValueMouseover.svelte
@@ -102,7 +102,7 @@
   {@const strokeWidth = showComparison ? 2 : 4}
   {@const colorClass = "stroke-gray-400"}
   <WithTween
-    tweenProps={{ duration: 1000 }}
+    tweenProps={{ duration: 100 }}
     value={{
       y: yScale(y),
       dy: yScale(comparisonY) || yScale(0),
@@ -110,7 +110,7 @@
     let:output
   >
     <WithTween
-      tweenProps={{ duration: 50 }}
+      tweenProps={{ duration: 25 }}
       value={xScale(x)}
       let:output={xArrow}
     >

--- a/web-common/src/features/dashboards/time-series/MeasureValueMouseover.svelte
+++ b/web-common/src/features/dashboards/time-series/MeasureValueMouseover.svelte
@@ -83,9 +83,10 @@
       : undefined;
 
   /** get the final point set*/
-  $: pointSet = hasValidComparisonPoint
-    ? [mainPoint, comparisonPoint]
-    : [mainPoint];
+  $: pointSet =
+    showComparison && hasValidComparisonPoint
+      ? [mainPoint, comparisonPoint]
+      : [mainPoint];
 
   /** modes
    * 1. comparison not activated b/c not valid for time range

--- a/web-common/src/features/dashboards/time-series/MeasureValueMouseover.svelte
+++ b/web-common/src/features/dashboards/time-series/MeasureValueMouseover.svelte
@@ -102,7 +102,7 @@
   {@const strokeWidth = showComparison ? 2 : 4}
   {@const colorClass = "stroke-gray-400"}
   <WithTween
-    tweenProps={{ duration: 100 }}
+    tweenProps={{ duration: 60 }}
     value={{
       y: yScale(y),
       dy: yScale(comparisonY) || yScale(0),
@@ -115,7 +115,7 @@
       let:output={xArrow}
     >
       {#if !(currentPointIsNull || comparisonPointIsNull) && x !== undefined && y !== undefined}
-        {#if !showComparison || Math.abs(output.y - output.dy) > 8}
+        {#if showComparison && Math.abs(output.y - output.dy) > 8}
           {@const bufferSize = Math.abs(output.y - output.dy) > 16 ? 8 : 4}
           {@const yBuffer = !hasValidComparisonPoint
             ? 0
@@ -213,7 +213,7 @@
           </g>
         {/if}
       {/if}
-      {#if !hasValidComparisonPoint && x !== undefined && y !== null && y !== undefined && !currentPointIsNull}
+      {#if !showComparison && x !== undefined && y !== null && y !== undefined && !currentPointIsNull}
         <line
           transition:fade|local={{ duration: 100 }}
           x1={xArrow}


### PR DESCRIPTION
Comparison chart fixes  - 

- Put value label on top of timestamp label
- Align label when there's no value
- Fix bug to allow switching between non comparison and comparison charts
- Use `preventVerticalOverlap`