### PR TITLE
Adding logs to better debug missing webhook events

### DIFF
--- a/admin/github.go
+++ b/admin/github.go
@@ -91,6 +91,8 @@ func (s *Service) ProcessGithubEvent(ctx context.Context, rawEvent any) error {
 	case *github.InstallationRepositoriesEvent:
 		return s.processGithubInstallationRepositoriesEvent(ctx, event)
 	default:
+		// TODO: remove this log once we finish debugging reconcile not firing
+		s.logger.Warn("Unknown github event.")
 		return nil
 	}
 }
@@ -107,6 +109,14 @@ func (s *Service) processGithubPush(ctx context.Context, event *github.PushEvent
 		}
 		return err
 	}
+
+	// TODO: remove this log once we finish debugging reconcile not firing
+	s.logger.Info(fmt.Sprintf(
+		"Have github event. url=%s branch=%s deploymentId=%s",
+		githubURL,
+		project.ProductionBranch,
+		project.ProductionDeploymentID,
+	))
 
 	// Parse the branch that was pushed to
 	// The format is refs/heads/main or refs/tags/v3.14.1


### PR DESCRIPTION
For a certain repo there are no logs for receiving a github push event. The github app does have a 200ok response for the requests.

Since there are no error logs either, adding logs to see where the code reaches.