### PR TITLE
Updating file upload extension filter logic to allow zipped varations

### DIFF
--- a/web-common/src/features/sources/add-source/file-upload.ts
+++ b/web-common/src/features/sources/add-source/file-upload.ts
@@ -5,7 +5,6 @@ import {
   incrementedNameGetter,
 } from "@rilldata/web-common/features/sources/add-source/duplicateNameUtils";
 import {
-  AllFileExtensions,
   fileHasValidExtension,
   PossibleFileExtensions,
   PossibleZipExtensions,

--- a/web-common/src/features/sources/add-source/file-upload.ts
+++ b/web-common/src/features/sources/add-source/file-upload.ts
@@ -4,13 +4,15 @@ import {
   duplicateNameChecker,
   incrementedNameGetter,
 } from "@rilldata/web-common/features/sources/add-source/duplicateNameUtils";
+import {
+  AllFileExtensions,
+  fileHasValidExtension,
+  PossibleFileExtensions,
+  PossibleZipExtensions,
+} from "@rilldata/web-common/features/sources/add-source/possible-file-extensions";
 import { importOverlayVisible } from "@rilldata/web-common/layout/overlay-store";
 import { runtimeServiceFileUpload } from "@rilldata/web-common/runtime-client/manual-clients";
-import { FILE_EXTENSION_TO_TABLE_TYPE } from "@rilldata/web-local/lib/types";
-import {
-  extractFileExtension,
-  getTableNameFromFile,
-} from "../extract-table-name";
+import { getTableNameFromFile } from "../extract-table-name";
 import {
   DuplicateActions,
   duplicateSourceAction,
@@ -73,8 +75,7 @@ function filterValidFileExtensions(files: Array<File>): {
   const invalidFiles = [];
 
   files.forEach((file: File) => {
-    const fileExtension = extractFileExtension(file.name);
-    if (fileExtension in FILE_EXTENSION_TO_TABLE_TYPE) {
+    if (fileHasValidExtension(file.name)) {
       validFiles.push(file);
     } else {
       invalidFiles.push(file);
@@ -142,7 +143,8 @@ function reportFileErrors(invalidFiles: File[]) {
     message: `${invalidFiles.length} file${
       invalidFiles.length !== 1 ? "s are" : " is"
     } invalid: \n${invalidFiles.map((file) => file.name).join("\n")}`,
-    detail: "Only .parquet, .csv, .tsv, .json, and .ndjson files are supported",
+    detail:
+      "Only .parquet, .csv, .tsv, .json, and .ndjson files are supported, along with their gzipped (.gz) counterparts",
     options: {
       persisted: true,
     },
@@ -188,7 +190,10 @@ export function openFileUploadDialog(multiple = true) {
     };
     window.addEventListener("focus", focusHandler);
     input.multiple = multiple;
-    input.accept = ".csv,.tsv,.txt,.json,.ndjson,.parquet";
+    input.accept = [...PossibleFileExtensions, ...PossibleZipExtensions].join(
+      ","
+    );
+    console.log(input);
     input.click();
   });
 }

--- a/web-common/src/features/sources/add-source/possible-file-extensions.spec.ts
+++ b/web-common/src/features/sources/add-source/possible-file-extensions.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "@jest/globals";
+import { fileHasValidExtension } from "@rilldata/web-common/features/sources/add-source/possible-file-extensions";
+
+describe("fileHasValidExtension", () => {
+  describe("positive cases", () => {
+    [
+      "file.csv.gz",
+      "file.csv",
+      "/path/to/file.parquet",
+      "/path/to/file.parquet.gz",
+      "/path/to/../file.txt",
+      "/path/to/../file.txt.gz",
+      "https://server.com/path/file.json",
+      "https://server.com/path/file.json.gz",
+    ].forEach((positiveCase) => {
+      it(`${positiveCase} => true`, () => {
+        expect(fileHasValidExtension(positiveCase)).toBeTruthy();
+      });
+    });
+  });
+
+  describe("negative cases", () => {
+    [
+      "file",
+      "file.gz", // just gz is not allowed
+      "https://server.com/path/file.js",
+    ].forEach((positiveCase) => {
+      it(`${positiveCase} => false`, () => {
+        expect(fileHasValidExtension(positiveCase)).toBeFalsy();
+      });
+    });
+  });
+});

--- a/web-common/src/features/sources/add-source/possible-file-extensions.ts
+++ b/web-common/src/features/sources/add-source/possible-file-extensions.ts
@@ -1,0 +1,22 @@
+export const PossibleFileExtensions = [
+  ".parquet",
+  ".csv",
+  ".tsv",
+  ".txt",
+  ".json",
+  ".ndjson",
+];
+export const PossibleZipExtensions = [".gz"];
+export const AllFileExtensions = [
+  ...PossibleFileExtensions,
+  ...PossibleFileExtensions.map((extension) =>
+    PossibleZipExtensions.map(
+      (zippedExtension) => `${extension}${zippedExtension}`
+    )
+  ).flat(),
+];
+
+export function fileHasValidExtension(fileName: string) {
+  // Since this check happens pretty rarely and this list is small a brute force check is sufficient
+  return AllFileExtensions.some((extension) => fileName.endsWith(extension));
+}

--- a/web-local/src/lib/types.ts
+++ b/web-local/src/lib/types.ts
@@ -60,14 +60,6 @@ export enum TableSourceType {
   // table is loaded from an existing duckdb table
   DuckDB,
 }
-export const FILE_EXTENSION_TO_TABLE_TYPE = {
-  parquet: TableSourceType.ParquetFile,
-  csv: TableSourceType.CSVFile,
-  tsv: TableSourceType.CSVFile,
-  txt: TableSourceType.CSVFile,
-  json: TableSourceType.JSONFile,
-  ndjson: TableSourceType.JSONFile,
-};
 
 export interface Table extends ColumnarItem {
   path: string;


### PR DESCRIPTION
closes #1978
Adding an abstraction around allowed file extensions to support zipped variations. Currently only .gz is supported.