### PR TITLE
Add back Inter to `web-admin`

### DIFF
--- a/web-admin/src/app.html
+++ b/web-admin/src/app.html
@@ -2,14 +2,34 @@
 <html lang="en">
   <head>
     <link rel="stylesheet" href="%sveltekit.assets%/fonts/fonts.css" />
-    <link rel="preload" href="%sveltekit.assets%/fonts/inter/Inter-Regular.woff2?v=3.19" as="font" type="font/woff2"
-      crossorigin />
-    <link rel="preload" href="%sveltekit.assets%/fonts/inter/Inter-Medium.woff2?v=3.19" as="font" type="font/woff2"
-      crossorigin />
-    <link rel="preload" href="%sveltekit.assets%/fonts/inter/Inter-SemiBold.woff2?v=3.19" as="font" type="font/woff2"
-      crossorigin />
-    <link rel="preload" href="%sveltekit.assets%/fonts/inter/Inter-Bold.woff2?v=3.19" as="font" type="font/woff2"
-      crossorigin />
+    <link
+      rel="preload"
+      href="%sveltekit.assets%/fonts/inter/Inter-Regular.woff2?v=3.19"
+      as="font"
+      type="font/woff2"
+      crossorigin
+    />
+    <link
+      rel="preload"
+      href="%sveltekit.assets%/fonts/inter/Inter-Medium.woff2?v=3.19"
+      as="font"
+      type="font/woff2"
+      crossorigin
+    />
+    <link
+      rel="preload"
+      href="%sveltekit.assets%/fonts/inter/Inter-SemiBold.woff2?v=3.19"
+      as="font"
+      type="font/woff2"
+      crossorigin
+    />
+    <link
+      rel="preload"
+      href="%sveltekit.assets%/fonts/inter/Inter-Bold.woff2?v=3.19"
+      as="font"
+      type="font/woff2"
+      crossorigin
+    />
     <meta charset="utf-8" />
     <link rel="icon" href="%sveltekit.assets%/favicon.png" />
     <meta name="viewport" content="width=device-width" />

--- a/web-admin/src/app.html
+++ b/web-admin/src/app.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <link rel="stylesheet" href="%sveltekit.assets%/fonts/fonts.css" />
+    <link rel="preload" href="%sveltekit.assets%/fonts/inter/Inter-Regular.woff2?v=3.19" as="font" type="font/woff2"
+      crossorigin />
+    <link rel="preload" href="%sveltekit.assets%/fonts/inter/Inter-Medium.woff2?v=3.19" as="font" type="font/woff2"
+      crossorigin />
+    <link rel="preload" href="%sveltekit.assets%/fonts/inter/Inter-SemiBold.woff2?v=3.19" as="font" type="font/woff2"
+      crossorigin />
+    <link rel="preload" href="%sveltekit.assets%/fonts/inter/Inter-Bold.woff2?v=3.19" as="font" type="font/woff2"
+      crossorigin />
     <meta charset="utf-8" />
     <link rel="icon" href="%sveltekit.assets%/favicon.png" />
     <meta name="viewport" content="width=device-width" />


### PR DESCRIPTION
PR https://github.com/rilldata/rill-developer/pull/1969 changed the way we load fonts. The PR made the requisite changes for  `web-local`, but not for `web-admin`. This PR mirrors the changes for `web-admin`.