### PR TITLE
Improve layout of cloud dashboards

### DIFF
--- a/web-admin/src/routes/+layout.svelte
+++ b/web-admin/src/routes/+layout.svelte
@@ -31,7 +31,7 @@
     <div class="flex flex-col min-h-screen">
       <main class="flex-grow flex flex-col">
         <TopNavigationBar />
-        <div class="flex-grow overflow-auto mt-4">
+        <div class="flex-grow overflow-auto">
           <slot />
         </div>
       </main>

--- a/web-admin/src/routes/-/[organization]/[project]/dashboard/[name]/+page.svelte
+++ b/web-admin/src/routes/-/[organization]/[project]/dashboard/[name]/+page.svelte
@@ -23,6 +23,4 @@
   <title>Rill | {metricViewName}</title>
 </svelte:head>
 
-<div class="p-2">
-  <Dashboard {metricViewName} hasTitle={false} />
-</div>
+<Dashboard {metricViewName} hasTitle={false} />

--- a/web-admin/src/routes/-/[organization]/[project]/dashboard/[name]/+page.svelte
+++ b/web-admin/src/routes/-/[organization]/[project]/dashboard/[name]/+page.svelte
@@ -24,5 +24,5 @@
 </svelte:head>
 
 <div class="p-2">
-  <Dashboard {metricViewName} />
+  <Dashboard {metricViewName} hasTitle={false} />
 </div>

--- a/web-common/src/features/dashboards/workspace/Dashboard.svelte
+++ b/web-common/src/features/dashboards/workspace/Dashboard.svelte
@@ -16,6 +16,7 @@
   import DashboardHeader from "./DashboardHeader.svelte";
 
   export let metricViewName: string;
+  export let hasTitle: boolean;
 
   const switchToMetrics = async (metricViewName: string) => {
     if (!metricViewName) return;
@@ -66,7 +67,7 @@
 </script>
 
 <DashboardContainer bind:exploreContainerWidth bind:width {gridConfig}>
-  <DashboardHeader {metricViewName} slot="header" />
+  <DashboardHeader {metricViewName} {hasTitle} slot="header" />
 
   <svelte:fragment let:width slot="metrics">
     {#key metricViewName}

--- a/web-common/src/features/dashboards/workspace/DashboardContainer.svelte
+++ b/web-common/src/features/dashboards/workspace/DashboardContainer.svelte
@@ -44,7 +44,7 @@
 
 <style>
   section {
-    grid-template-rows: auto 1fr;
+    grid-template-rows: auto auto 1fr;
     height: 100vh;
     overflow-x: auto;
     overflow-y: hidden;

--- a/web-common/src/features/dashboards/workspace/DashboardContainer.svelte
+++ b/web-common/src/features/dashboards/workspace/DashboardContainer.svelte
@@ -23,7 +23,7 @@
 
 <section
   use:listenToNodeResize
-  class="grid items-stretch leaderboard-layout surface"
+  class="grid items-stretch surface"
   style:grid-template-columns={gridConfig}
   style:padding-left={leftSide}
 >

--- a/web-common/src/features/dashboards/workspace/DashboardHeader.svelte
+++ b/web-common/src/features/dashboards/workspace/DashboardHeader.svelte
@@ -21,6 +21,7 @@
   import TimeControls from "../time-controls/TimeControls.svelte";
 
   export let metricViewName: string;
+  export let hasTitle: boolean;
 
   //  const navigationVisibilityTween = getContext(
   //    "rill:app:navigation-visibility-tween"
@@ -56,40 +57,44 @@
 </script>
 
 <section class="w-full flex flex-col" id="header">
-  <!-- top row
-    title and call to action
-  -->
-  <div
-    class="flex items-center justify-between w-full pl-1 pr-4"
-    style:height="var(--header-height)"
-  >
-    <!-- title element -->
-    <h1 style:line-height="1.1" style:margin-top="-1px">
-      <div class="ui-copy-dashboard-header">
-        {displayName || metricViewName}
-      </div>
-    </h1>
-    <!-- top right CTAs -->
-    {#if isEditableDashboard}
-      <PanelCTA side="right">
-        <Tooltip distance={8}>
-          <Button on:click={() => viewMetrics(metricViewName)} type="secondary">
-            Edit Metrics <MetricsIcon size="16px" />
-          </Button>
-          <TooltipContent slot="tooltip-content">
-            Edit this dashboard's metrics & settings
-          </TooltipContent>
-        </Tooltip>
-        <Tooltip distance={8}>
-          <Button on:click={openCalendly} type="primary">Publish</Button>
-          <TooltipContent slot="tooltip-content">
-            Schedule time to chat with Rill about early access to hosted
-            dashboards.
-          </TooltipContent>
-        </Tooltip>
-      </PanelCTA>
-    {/if}
-  </div>
+  <!-- top row: title and call to action -->
+  <!-- Rill Local includes the title, Rill Cloud does not -->
+  {#if hasTitle}
+    <div
+      class="flex items-center justify-between w-full pl-1 pr-4"
+      style:height="var(--header-height)"
+    >
+      <!-- title element -->
+      <h1 style:line-height="1.1" style:margin-top="-1px">
+        <div class="ui-copy-dashboard-header">
+          {displayName || metricViewName}
+        </div>
+      </h1>
+      <!-- top right CTAs -->
+      {#if isEditableDashboard}
+        <PanelCTA side="right">
+          <Tooltip distance={8}>
+            <Button
+              on:click={() => viewMetrics(metricViewName)}
+              type="secondary"
+            >
+              Edit Metrics <MetricsIcon size="16px" />
+            </Button>
+            <TooltipContent slot="tooltip-content">
+              Edit this dashboard's metrics & settings
+            </TooltipContent>
+          </Tooltip>
+          <Tooltip distance={8}>
+            <Button on:click={openCalendly} type="primary">Publish</Button>
+            <TooltipContent slot="tooltip-content">
+              Schedule time to chat with Rill about early access to hosted
+              dashboards.
+            </TooltipContent>
+          </Tooltip>
+        </PanelCTA>
+      {/if}
+    </div>
+  {/if}
   <!-- bottom row -->
   <div class="-ml-3 p-1">
     <TimeControls {metricViewName} />

--- a/web-local/src/routes/(application)/dashboard/[name]/+page.svelte
+++ b/web-local/src/routes/(application)/dashboard/[name]/+page.svelte
@@ -75,6 +75,6 @@
     bgClass="bg-white"
     inspector={false}
   >
-    <Dashboard {metricViewName} slot="body" />
+    <Dashboard {metricViewName} hasTitle slot="body" />
   </WorkspaceContainer>
 {/if}


### PR DESCRIPTION
In `web-admin`, this PR:
- Removes the title from the dashboard header
- Removes the excess spacing between dashboard header and dashboard charts & leaderboards
- Makes minor padding adjustments, but we'll revisit the alignment soon