### PR TITLE
Configure eslint in CI/CD

### DIFF
--- a/.github/workflows/web-test.yml
+++ b/.github/workflows/web-test.yml
@@ -63,19 +63,19 @@ jobs:
         if: steps.filter.outputs.common == 'true'
         run: |-
           npx prettier --check "web-common/**/*"
-          npx eslint web-common --quiet
+          npx eslint web-common --config .eslintrc.cjs --quiet
 
       - name: Prettier checks and lint for web local
         if: steps.filter.outputs.local == 'true'
         run: |-
           npx prettier --check "web-local/**/*"
-          npx eslint web-local --quiet
+          npx eslint web-local --config .eslintrc.cjs --quiet
 
       - name: Prettier checks and lint for web admin
         if: steps.filter.outputs.admin == 'true'
         run: |-
           npx prettier --check "web-admin/**/*"
-          npx eslint web-admin --quiet
+          npx eslint web-admin --config .eslintrc.cjs --quiet
 
       - name: Build & Test the web local
         if: ${{ steps.filter.outputs.local == 'true' || steps.filter.outputs.common == 'true' }}


### PR DESCRIPTION
Hypothesis...

Currently, the "web-test" Github Actions workflow doesn't appear to be linting our Svelte files. I think this is because `eslint` in CI/CD might not be wired up to use the `.eslintrc.cjs` configuration file that we use locally in development.

This PR explicitly applies our config file to our `eslint` calls in Github Actions. This should ensure we lint Svelte files in CI/CD.

Findings:
- It actually looks like `web-local`, `web-common`, and `web-admin` pass our configured `eslint` checks, even locally.

TODO:
- [ ] Figure out if we're somehow not using the eslint `svelte3` plugin correctly.