### PR TITLE
No data comparison fixes

### DIFF
--- a/web-common/src/features/dashboards/big-number/MeasureBigNumber.svelte
+++ b/web-common/src/features/dashboards/big-number/MeasureBigNumber.svelte
@@ -20,7 +20,7 @@
   export let comparisonOption: TimeComparisonOption = undefined;
   export let comparisonValue: number = undefined;
   export let comparisonPercChange: number = undefined;
-  export let showComparison: boolean = false;
+  export let showComparison = false;
 
   export let status: EntityStatus;
   export let description: string = undefined;

--- a/web-common/src/features/dashboards/big-number/MeasureBigNumber.svelte
+++ b/web-common/src/features/dashboards/big-number/MeasureBigNumber.svelte
@@ -17,10 +17,10 @@
   } from "../humanize-numbers";
 
   export let value: number;
-  export let comparisonOption: TimeComparisonOption;
-  export let comparisonValue: number;
-  export let comparisonPercChange: number;
-  export let showComparison: boolean;
+  export let comparisonOption: TimeComparisonOption = undefined;
+  export let comparisonValue: number = undefined;
+  export let comparisonPercChange: number = undefined;
+  export let showComparison: boolean = false;
 
   export let status: EntityStatus;
   export let description: string = undefined;
@@ -29,7 +29,7 @@
 
   $: formatPresetEnum =
     (formatPreset as NicelyFormattedTypes) || NicelyFormattedTypes.HUMANIZE;
-  $: valusIsPresent = value !== undefined && value !== null;
+  $: valueIsPresent = value !== undefined && value !== null;
 
   $: isComparisonPositive = comparisonPercChange && comparisonPercChange >= 0;
 
@@ -65,7 +65,7 @@
     override this by filling the slot in the consuming component. -->
     <slot name="value">
       <div>
-        {#if valusIsPresent && status === EntityStatus.Idle}
+        {#if valueIsPresent && status === EntityStatus.Idle}
           <Tooltip distance={8} location="bottom" alignment="start">
             <div class="w-max">
               <WithTween {value} tweenProps={{ duration: 500 }} let:output>
@@ -160,6 +160,8 @@
           >
             <Spinner status={EntityStatus.Running} />
           </div>
+        {:else if !valueIsPresent}
+          <span class="ui-copy-disabled-faint italic text-sm">no data</span>
         {/if}
       </div>
     </slot>

--- a/web-common/src/features/dashboards/dimension-table/dimension-table-utils.ts
+++ b/web-common/src/features/dashboards/dimension-table/dimension-table-utils.ts
@@ -157,14 +157,14 @@ export function getComparisonProperties(
       label: DeltaChangePercentage,
       type: "RILL_PERCENTAGE_CHANGE",
       format: NicelyFormattedTypes.PERCENTAGE,
-      description: "Percentage change over compared period",
+      description: "Perc. change over comparison period",
     };
   else if (measureName.includes("_delta")) {
     return {
       label: DeltaChange,
       type: "RILL_CHANGE",
       format: selectedMeasure.format,
-      description: "Change over compared period",
+      description: "Change over comparison period",
     };
   }
 }

--- a/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
+++ b/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
@@ -324,7 +324,9 @@
             {$topListQuery?.error}
           </div>
         {:else if values.length === 0}
-          <div class="p-1 ui-copy-disabled">no available values</div>
+          <div style:padding-left="28px" class="p-1 ui-copy-disabled">
+            no available values
+          </div>
         {/if}
 
         {#if values.length > slice}

--- a/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
+++ b/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
@@ -324,7 +324,7 @@
             {$topListQuery?.error}
           </div>
         {:else if values.length === 0}
-          <div style:padding-left="28px" class="p-1 ui-copy-disabled">
+          <div style:padding-left="30px" class="p-1 ui-copy-disabled">
             no available values
           </div>
         {/if}

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
@@ -20,11 +20,7 @@
     MetricsExplorerEntity,
     metricsExplorerStore,
   } from "../dashboard-stores";
-  import {
-    getScaleForLeaderboard,
-    NicelyFormattedTypes,
-    ShortHandSymbols,
-  } from "../humanize-numbers";
+  import { NicelyFormattedTypes } from "../humanize-numbers";
   import Leaderboard from "./Leaderboard.svelte";
   import LeaderboardMeasureSelector from "./LeaderboardMeasureSelector.svelte";
 

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
@@ -99,9 +99,6 @@
       .forEach((dimensionName) => leaderboards.delete(dimensionName));
   }
 
-  /** create a scale for the valid leaderboards */
-  let leaderboardFormatScale: ShortHandSymbols = "none";
-
   let leaderboardExpanded;
 
   function onSelectItem(event, item: MetricsViewDimension) {
@@ -115,12 +112,6 @@
 
   function onLeaderboardValues(event) {
     leaderboards.set(event.detail.dimensionName, event.detail.values);
-    if (
-      formatPreset === NicelyFormattedTypes.HUMANIZE ||
-      formatPreset === NicelyFormattedTypes.CURRENCY
-    ) {
-      leaderboardFormatScale = getScaleForLeaderboard(leaderboards);
-    }
   }
 
   /** Functionality for resizing the virtual leaderboard */
@@ -165,7 +156,6 @@
       <!-- the single virtual element -->
       <Leaderboard
         {formatPreset}
-        {leaderboardFormatScale}
         isSummableMeasure={activeMeasure?.expression
           .toLowerCase()
           ?.includes("count(") ||

--- a/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
+++ b/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
@@ -233,7 +233,7 @@
       {@const showComparison = isComparisonRangeAvailable}
       {@const comparisonValue = totalsComparisons?.[measure.name]}
       {@const comparisonPercChange =
-        comparisonValue && bigNum
+        comparisonValue && bigNum !== undefined && bigNum !== null
           ? (bigNum - comparisonValue) / comparisonValue
           : undefined}
       {@const formatPreset =
@@ -269,8 +269,6 @@
             yAccessor={measure.name}
             xMin={startValue}
             xMax={endValue}
-            start={startValue}
-            end={endValue}
             {showComparison}
             mouseoverTimeFormat={(value) => {
               /** format the date according to the time grain */


### PR DESCRIPTION
- Align `no available values` in leaderboard
- Add `no data` label to BigNum
- Fix `NaN% change` in tooltip
- Remove various warnings from console