### PR TITLE
Fix github url search not being case insensitive

### DIFF
--- a/admin/database/postgres/postgres.go
+++ b/admin/database/postgres/postgres.go
@@ -148,7 +148,7 @@ func (c *connection) FindProjectByName(ctx context.Context, orgName, name string
 
 func (c *connection) FindProjectByGithubURL(ctx context.Context, githubURL string) (*database.Project, error) {
 	res := &database.Project{}
-	err := c.getDB(ctx).QueryRowxContext(ctx, "SELECT p.* FROM projects p WHERE p.github_url=lower($1)", githubURL).StructScan(res)
+	err := c.getDB(ctx).QueryRowxContext(ctx, "SELECT p.* FROM projects p WHERE lower(p.github_url)=lower($1)", githubURL).StructScan(res)
 	if err != nil {
 		return nil, parseErr(err)
 	}

--- a/admin/github.go
+++ b/admin/github.go
@@ -80,7 +80,6 @@ func (s *Service) LookupGithubRepo(ctx context.Context, installationID int64, gi
 // ProcessGithubEvent processes a Github event (usually received over webhooks).
 // After validating that the event is a valid Github event, it moves further processing to the background and returns a nil error.
 func (s *Service) ProcessGithubEvent(ctx context.Context, rawEvent any) error {
-	s.logger.Warn(fmt.Sprintf("Have github event. %T", rawEvent))
 	switch event := rawEvent.(type) {
 	// Triggered on push to repository
 	case *github.PushEvent:
@@ -103,20 +102,11 @@ func (s *Service) processGithubPush(ctx context.Context, event *github.PushEvent
 	project, err := s.DB.FindProjectByGithubURL(ctx, githubURL)
 	if err != nil {
 		if errors.Is(err, database.ErrNotFound) {
-			s.logger.Info(fmt.Sprintf("Project not found. url=%s", githubURL))
 			// App is installed on repo not currently deployed. Do nothing.
 			return nil
 		}
 		return err
 	}
-
-	// TODO: remove this log once we finish debugging reconcile not firing
-	s.logger.Info(fmt.Sprintf(
-		"Have github push event. url=%s branch=%s deploymentId=%v",
-		githubURL,
-		project.ProductionBranch,
-		project.ProductionDeploymentID,
-	))
 
 	// Parse the branch that was pushed to
 	// The format is refs/heads/main or refs/tags/v3.14.1


### PR DESCRIPTION
closes #1987

In the project search by github url the check was totally case insensitive. Added `lower` to both the column and search url.

Also removing temporary logs used in debugging.