### PR TITLE
Fixing dashboard url not changing on cloud

### DIFF
--- a/web-admin/src/routes/[organization]/[project]/[dashboard]/+page.svelte
+++ b/web-admin/src/routes/[organization]/[project]/[dashboard]/+page.svelte
@@ -9,8 +9,8 @@
 
   $: metricsExplorer = useDashboardStore(metricViewName);
 
-  $: if (metricsExplorer) {
-    stateSyncManager.handleStateChange(metricsExplorer);
+  $: if ($metricsExplorer) {
+    stateSyncManager.handleStateChange($metricsExplorer);
   }
   $: if ($page) {
     stateSyncManager.handleUrlChange();
@@ -23,4 +23,4 @@
   <title>Rill | {metricViewName}</title>
 </svelte:head>
 
-<Dashboard {metricViewName} hasTitle={false} />
+<Dashboard hasTitle={false} {metricViewName} />

--- a/web-local/src/routes/(application)/dashboard/[name]/+page.svelte
+++ b/web-local/src/routes/(application)/dashboard/[name]/+page.svelte
@@ -2,7 +2,7 @@
   import { goto } from "$app/navigation";
   import { page } from "$app/stores";
   import { Dashboard } from "@rilldata/web-common/features/dashboards";
-  import { metricsExplorerStore } from "@rilldata/web-common/features/dashboards/dashboard-stores";
+  import { useDashboardStore } from "@rilldata/web-common/features/dashboards/dashboard-stores";
   import { StateSyncManager } from "@rilldata/web-common/features/dashboards/proto-state/StateSyncManager";
   import { getFilePathFromNameAndType } from "@rilldata/web-common/features/entity-management/entity-mappers";
   import { EntityType } from "@rilldata/web-common/features/entity-management/types";
@@ -17,12 +17,12 @@
   import { CATALOG_ENTRY_NOT_FOUND } from "../../../../lib/errors/messages";
 
   $: metricViewName = $page.params.name;
-  $: metricsExplorer = $metricsExplorerStore.entities[metricViewName];
+  $: metricsExplorer = useDashboardStore(metricViewName);
 
   $: stateSyncManager = new StateSyncManager(metricViewName);
 
-  $: if (metricsExplorer) {
-    stateSyncManager.handleStateChange(metricsExplorer);
+  $: if ($metricsExplorer) {
+    stateSyncManager.handleStateChange($metricsExplorer);
   }
   $: if ($page) {
     stateSyncManager.handleUrlChange();


### PR DESCRIPTION
When we switched to using `useDashboardStore` we didnt change the usage to have a `$` to get the data in the store. Updating the dashboard url code to include the `$`