### PR TITLE
A quick fix to handle CSV ingestion failures due to schema detection. 

### DIFF
--- a/runtime/drivers/duckdb/connectors.go
+++ b/runtime/drivers/duckdb/connectors.go
@@ -167,7 +167,7 @@ func sourceReader(paths []string, csvDelimiter, format string, hivePartition int
 	} else if strings.Contains(format, ".parquet") {
 		return fmt.Sprintf("read_parquet(['%s'], HIVE_PARTITIONING=%v)", strings.Join(paths, "','"), hivePartition), nil
 	} else if strings.Contains(format, ".json") || strings.Contains(format, ".ndjson") {
-		return fmt.Sprintf("read_json_auto(['%s'])", strings.Join(paths, "','")), nil
+		return fmt.Sprintf("read_json_auto(['%s'], sample_size=-1)", strings.Join(paths, "','")), nil
 	} else {
 		return "", fmt.Errorf("file type not supported : %s", format)
 	}
@@ -175,9 +175,9 @@ func sourceReader(paths []string, csvDelimiter, format string, hivePartition int
 
 func sourceReaderWithDelimiter(paths []string, delimiter string) string {
 	if delimiter == "" {
-		return fmt.Sprintf("read_csv_auto(['%s'])", strings.Join(paths, "','"))
+		return fmt.Sprintf("read_csv_auto(['%s'], sample_size=-1)", strings.Join(paths, "','"))
 	}
-	return fmt.Sprintf("read_csv_auto(['%s'], delim='%s')", strings.Join(paths, "','"), delimiter)
+	return fmt.Sprintf("read_csv_auto(['%s'], delim='%s', sample_size=-1)", strings.Join(paths, "','"), delimiter)
 }
 
 func fileSize(paths []string) int64 {


### PR DESCRIPTION
A quick fix to handle CSV ingestion failures due to schema detection. 
By default duckDB limits schema detection to 20480 rows. This fails very often for single files. 
This patch changes the behavior to look at full file instead of sample. 

Note: This does have performance impact on ingesting large files, e.g. A CSV file with ~35M rows (700Mb) took 15 secs instead of 13 secs to load. 

Given that we do not have a way to manually override the schema at present, the performance hit is a reasonable tradeoff for now than failing the ingestion completely. 