### PR TITLE
Add `svelte-check` to CI/CD

### DIFF
--- a/.github/workflows/web-test.yml
+++ b/.github/workflows/web-test.yml
@@ -64,18 +64,21 @@ jobs:
         run: |-
           npx prettier --check "web-common/**/*"
           npx eslint web-common --quiet
+          npx svelte-check --workspace web-common --no-tsconfig --ignore "src/components/(data-graphic|table-editable|notifications|column-profile|virtualized-table|menu|modal|chip|overlay|floating-element|data-types|BarAndLabel.svelte|button|icons/CaretDownIcon.svelte|preview-table/ConnectedPreviewTable.svelte),src/features/models/workspace/inspector,src/**/workspace,src/features/dashboards/(time-series|leaderboard|time-controls),src/layout/navigation/NavigationEntry.svelte"
 
       - name: Prettier checks and lint for web local
         if: steps.filter.outputs.local == 'true'
         run: |-
           npx prettier --check "web-local/**/*"
           npx eslint web-local --quiet
+          npx svelte-check --workspace web-local --no-tsconfig --ignore "src/routes/dev,src/routes/\(application\)/(dashboard|model|source)/[name]"
 
       - name: Prettier checks and lint for web admin
         if: steps.filter.outputs.admin == 'true'
         run: |-
           npx prettier --check "web-admin/**/*"
           npx eslint web-admin --quiet
+          npx svelte-check --workspace web-admin --no-tsconfig
 
       - name: Build & Test the web local
         if: ${{ steps.filter.outputs.local == 'true' || steps.filter.outputs.common == 'true' }}


### PR DESCRIPTION
This PR adds `svelte-check` to CI/CD. `svelte-check` detects some code quality issues that `eslint`-with-the-Svelte-plugin does not.

I've "ignored" a bunch of files so that we can adopt `svelte-check` today without having to fix >100 errors. Over time, we can fix those errors and stop ignoring their respective files.