### PR TITLE
Edit breadcrumb menus

### DIFF
--- a/web-admin/src/components/navigation/BreadcrumbItem.svelte
+++ b/web-admin/src/components/navigation/BreadcrumbItem.svelte
@@ -1,30 +1,50 @@
 <script lang="ts">
-  import { IconButton } from "@rilldata/web-common/components/button";
   import CaretDownIcon from "@rilldata/web-common/components/icons/CaretDownIcon.svelte";
-  import SimpleActionMenu from "@rilldata/web-common/components/menu/wrappers/SimpleActionMenu.svelte";
+  import WithSelectMenu from "@rilldata/web-common/components/menu/wrappers/WithSelectMenu.svelte";
 
   export let label: string;
-  export let isActive = false;
-  export let options: { main: string; callback: () => void }[] = [];
+  export let isCurrentPage = false;
+  export let menuOptions: { key: string; main: string }[] = [];
+  export let onSelectMenuOption: (option: string) => void = undefined;
 
-  const inactiveClass = "text-gray-500";
   const activeClass = "text-gray-800 font-semibold";
+  const inactiveClass = "text-gray-500";
+
+  let hovered = false;
+  function setHovered(value: boolean) {
+    hovered = value;
+  }
 </script>
 
-<li class={isActive ? activeClass : inactiveClass}>
-  <div class="flex flex items-center gap-x-3 p-2 ">
-    <slot name="icon" />
-    <div class="flex items-center gap-x-1">
-      <span>
-        {label}
-      </span>
-      {#if options}
-        <SimpleActionMenu {options} let:toggleMenu minWidth="0px" distance={4}>
-          <IconButton on:click={toggleMenu}>
-            <CaretDownIcon size="14px" className="text-gray-500" />
-          </IconButton>
-        </SimpleActionMenu>
-      {/if}
-    </div>
-  </div>
+<li class="flex flex items-center gap-x-3 p-2">
+  <slot name="icon" />
+  {#if !menuOptions}
+    <span class={isCurrentPage ? activeClass : inactiveClass}>{label}</span>
+  {:else}
+    <WithSelectMenu
+      minWidth="0px"
+      distance={4}
+      options={menuOptions}
+      selection={{
+        key: label,
+        main: label,
+      }}
+      on:select={({ detail: { key } }) => onSelectMenuOption(key)}
+      let:toggleMenu
+    >
+      <button
+        class="flex flex-row gap-x-1 items-center {isCurrentPage
+          ? activeClass
+          : inactiveClass}"
+        on:click={toggleMenu}
+        on:mouseenter={() => setHovered(true)}
+        on:mouseleave={() => setHovered(false)}
+      >
+        <span>{label}</span>
+        <div class="transition-transform" class:translate-y-2={hovered}>
+          <CaretDownIcon size="14px" />
+        </div>
+      </button>
+    </WithSelectMenu>
+  {/if}
 </li>

--- a/web-admin/src/components/navigation/Breadcrumbs.svelte
+++ b/web-admin/src/components/navigation/Breadcrumbs.svelte
@@ -12,15 +12,15 @@
 
   $: organization = $page.params.organization;
   $: organizations = createAdminServiceListOrganizations();
-  $: organizationPageActive = $page.route.id === "/[organization]";
+  $: isOrganizationPage = $page.route.id === "/[organization]";
 
   $: project = $page.params.project;
   $: projects = createAdminServiceListProjectsForOrganization(organization);
-  $: projectPageActive = $page.route.id === "/[organization]/[project]";
+  $: isProjectPage = $page.route.id === "/[organization]/[project]";
 
   $: dashboard = $page.params.dashboard;
   $: dashboards = useDashboardNames($runtime?.instanceId);
-  $: dashboardPageActive =
+  $: isDashboardPage =
     $page.route.id === "/[organization]/[project]/[dashboard]";
 </script>
 
@@ -29,12 +29,14 @@
     {#if organization}
       <BreadcrumbItem
         label={organization}
-        isActive={organizationPageActive}
-        options={$organizations.data?.organizations?.length > 1 &&
+        isCurrentPage={isOrganizationPage}
+        menuOptions={$organizations.data?.organizations?.length > 1 &&
           $organizations.data.organizations.map((org) => ({
+            key: org.name,
             main: org.name,
             callback: () => goto(`/${org.name}`),
           }))}
+        onSelectMenuOption={(organization) => goto(`/${organization}`)}
       >
         <OrganizationAvatar {organization} slot="icon" />
       </BreadcrumbItem>
@@ -43,24 +45,29 @@
       <span class="text-gray-600">/</span>
       <BreadcrumbItem
         label={project}
-        isActive={projectPageActive}
-        options={$projects.data?.projects?.length > 1 &&
+        isCurrentPage={isProjectPage}
+        menuOptions={$projects.data?.projects?.length > 1 &&
           $projects.data.projects.map((proj) => ({
+            key: proj.name,
             main: proj.name,
             callback: () => goto(`/${organization}/${proj.name}`),
           }))}
+        onSelectMenuOption={(project) => goto(`/${organization}/${project}`)}
       />
     {/if}
     {#if dashboard}
       <span class="text-gray-600">/</span>
       <BreadcrumbItem
         label={dashboard}
-        isActive={dashboardPageActive}
-        options={$dashboards.data?.length > 1 &&
+        isCurrentPage={isDashboardPage}
+        menuOptions={$dashboards.data?.length > 1 &&
           $dashboards.data.map((dash) => ({
+            key: dash,
             main: dash,
             callback: () => goto(`/${organization}/${project}/${dash}`),
           }))}
+        onSelectMenuOption={(dashboard) =>
+          goto(`/${organization}/${project}/${dashboard}`)}
       />
     {/if}
   </ol>

--- a/web-common/src/components/floating-element/WithTogglableFloatingElement.svelte
+++ b/web-common/src/components/floating-element/WithTogglableFloatingElement.svelte
@@ -1,16 +1,15 @@
 <script lang="ts">
   import { setContext } from "svelte";
   import { writable } from "svelte/store";
-
-  import { FloatingElement } from "./index";
   import Portal from "../Portal.svelte";
+  import { FloatingElement } from "./index";
+
   export let location = "bottom";
   export let alignment = "middle";
   export let relationship = "parent";
   export let distance = 0;
   export let pad = 8;
   export let suppress = false;
-
   export let active = false;
 
   /** this passes down the dom element used for the "outside click" action.
@@ -25,7 +24,7 @@
 </script>
 
 <!-- svelte-ignore a11y-click-events-have-key-events -->
-<div class="contents" bind:this={parent}>
+<div bind:this={parent}>
   <slot
     {active}
     handleClose={() => {


### PR DESCRIPTION
This PR brings the top navbar closer to the Figma mock. The PR:
- Uses a different component for the dropdown menu (one with a check mark to denote the current selection)
- Adds a hover animation 