### PR TITLE
fix the Rill Developer dashboard header spacing disparity

### DIFF
--- a/web-common/src/features/dashboards/workspace/DashboardHeader.svelte
+++ b/web-common/src/features/dashboards/workspace/DashboardHeader.svelte
@@ -60,8 +60,11 @@
   <!-- top row: title and call to action -->
   <!-- Rill Local includes the title, Rill Cloud does not -->
   {#if hasTitle}
+    <!-- FIXME: adding an -mb-3 fixes the spacing issue incurred by changes to the header
+    to accommodate the cloud dashboard. We should go back and reconcile these headers so we don't need
+  to do this. -->
     <div
-      class="flex items-center justify-between w-full pl-1 pr-4"
+      class="flex items-center justify-between -mb-3 w-full pl-1 pr-4"
       style:height="var(--header-height)"
     >
       <!-- title element -->


### PR DESCRIPTION
A recent change for cloud tightened up the spacing and fixed the alignment of the dashboard. This created a large space gap in the Rill Developer dashboard. This PR adds a fix for this, plus a note for us to unify the header components in both Rill Developer and Cloud.