### PR TITLE
Fix content flash when not logged in

### DIFF
--- a/web-admin/src/components/authentication/AuthRedirect.svelte
+++ b/web-admin/src/components/authentication/AuthRedirect.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  import { goto } from "$app/navigation";
+  import { createAdminServiceGetCurrentUser } from "../../client";
+  import { ADMIN_URL } from "../../client/http-client";
+
+  // redirect to login if not logged in
+  const user = createAdminServiceGetCurrentUser({
+    query: {
+      onSuccess: (data) => {
+        if (!data.user) {
+          goto(`${ADMIN_URL}/auth/login?redirect=${window.origin}`);
+        }
+      },
+    },
+  });
+</script>
+
+{#if $user.data && $user.data.user}
+  <slot />
+{/if}

--- a/web-admin/src/components/navigation/TopNavigationBar.svelte
+++ b/web-admin/src/components/navigation/TopNavigationBar.svelte
@@ -10,8 +10,9 @@
 
   $: organization = $page.params.organization;
 
-  const userQuery = createAdminServiceGetCurrentUser();
-  $: signedIn = !!$userQuery.data?.user;
+  const user = createAdminServiceGetCurrentUser({
+    query: { placeholderData: undefined },
+  });
 </script>
 
 <div class="border-b flex items-center">
@@ -29,11 +30,13 @@
     <Breadcrumbs />
   {/if}
   <div class="flex-grow" />
-  <div class="p-2">
-    {#if signedIn}
-      <UserButton />
-    {:else}
-      <SignIn />
-    {/if}
-  </div>
+  {#if $user.isSuccess}
+    <div class="p-2">
+      {#if $user.data && $user.data.user}
+        <UserButton />
+      {:else}
+        <SignIn />
+      {/if}
+    </div>
+  {/if}
 </div>

--- a/web-admin/src/routes/+layout.svelte
+++ b/web-admin/src/routes/+layout.svelte
@@ -2,6 +2,7 @@
   import RillTheme from "@rilldata/web-common/layout/RillTheme.svelte";
   import { featureFlags } from "@rilldata/web-local/lib/application-state-stores/application-store";
   import { QueryClient, QueryClientProvider } from "@tanstack/svelte-query";
+  import AuthRedirect from "../components/authentication/AuthRedirect.svelte";
   import TopNavigationBar from "../components/navigation/TopNavigationBar.svelte";
 
   const queryClient = new QueryClient({
@@ -28,13 +29,15 @@
 
 <RillTheme>
   <QueryClientProvider client={queryClient}>
-    <div class="flex flex-col h-screen">
-      <main class="flex-grow flex flex-col">
-        <TopNavigationBar />
-        <div class="flex-grow overflow-auto">
-          <slot />
-        </div>
-      </main>
-    </div>
+    <AuthRedirect>
+      <div class="flex flex-col h-screen">
+        <main class="flex-grow flex flex-col">
+          <TopNavigationBar />
+          <div class="flex-grow overflow-auto">
+            <slot />
+          </div>
+        </main>
+      </div>
+    </AuthRedirect>
   </QueryClientProvider>
 </RillTheme>

--- a/web-admin/src/routes/+page.svelte
+++ b/web-admin/src/routes/+page.svelte
@@ -1,18 +1,8 @@
 <script lang="ts">
-  import { goto } from "$app/navigation";
   import { createAdminServiceGetCurrentUser } from "../client";
-  import { ADMIN_URL } from "../client/http-client";
   import OrganizationList from "../components/home/OrganizationList.svelte";
 
-  const user = createAdminServiceGetCurrentUser({
-    query: {
-      onSuccess: (data) => {
-        if (!data.user) {
-          goto(`${ADMIN_URL}/auth/login?redirect=${window.origin}`);
-        }
-      },
-    },
-  });
+  const user = createAdminServiceGetCurrentUser();
 </script>
 
 {#if $user.data && $user.data.user}


### PR DESCRIPTION
This PR moves the auth redirect to the top-level of the layout component so that no content is flashed before we redirect the user to the log-in page.

Contributes toward #2109.