### PR TITLE
Account for empty lists on homepage

### DIFF
--- a/web-admin/src/components/home/DashboardList.svelte
+++ b/web-admin/src/components/home/DashboardList.svelte
@@ -40,7 +40,9 @@
   }
 </script>
 
-{#if $proj.isSuccess && dashboards?.length > 0}
+{#if dashboards?.length === 0}
+  <p class="text-gray-500 text-xs">This project has no dashboards yet.</p>
+{:else if dashboards?.length > 0}
   <ol>
     {#each dashboards as dashboard}
       <li class="mb-1">

--- a/web-admin/src/components/home/ProjectList.svelte
+++ b/web-admin/src/components/home/ProjectList.svelte
@@ -10,7 +10,9 @@
   $: projs = createAdminServiceListProjectsForOrganization(organization);
 </script>
 
-{#if $projs.data && $projs.data.projects}
+{#if $projs.data && $projs.data.projects?.length === 0}
+  <p class="text-gray-500 text-xs">This organization has no projects yet.</p>
+{:else if $projs.data && $projs.data.projects?.length > 0}
   <ol>
     {#each $projs.data.projects as proj}
       <li class="ml-2">


### PR DESCRIPTION
This PR adds text to account for the following cases:
- When an organization has 0 projects
- When a project has 0 dashboards

Contributes towards #2109