### PR TITLE
Support adding measure name in dashboard.yaml

### DIFF
--- a/runtime/services/catalog/artifacts/artifacts_test.go
+++ b/runtime/services/catalog/artifacts/artifacts_test.go
@@ -119,7 +119,7 @@ region: us-east-2
 							Format:      "humanise",
 						},
 						{
-							Name:        "measure_1",
+							Name:        "avg_measure",
 							Label:       "Mea1_L",
 							Expression:  "avg(c1)",
 							Description: "Mea1_D",
@@ -145,10 +145,12 @@ dimensions:
   description: Dim1_D
 measures:
 - label: Mea0_L
+  name: measure_0
   expression: count(c0)
   description: Mea0_D
   format_preset: humanise
 - label: Mea1_L
+  name: avg_measure
   expression: avg(c1)
   description: Mea1_D
   format_preset: humanise

--- a/runtime/services/catalog/artifacts/yaml/objects.go
+++ b/runtime/services/catalog/artifacts/yaml/objects.go
@@ -58,6 +58,7 @@ type MetricsView struct {
 
 type Measure struct {
 	Label       string
+	Name        string
 	Expression  string
 	Description string
 	Format      string `yaml:"format_preset"`
@@ -311,7 +312,9 @@ func fromMetricsViewArtifact(metrics *MetricsView, path string) (*drivers.Catalo
 
 	// this is needed since measure names are not given by the user
 	for i, measure := range apiMetrics.Measures {
-		measure.Name = fmt.Sprintf("measure_%d", i)
+		if measure.Name == "" {
+			measure.Name = fmt.Sprintf("measure_%d", i)
+		}
 	}
 
 	timeGrainEnum, err := getTimeGrainEnum(metrics.SmallestTimeGrain)


### PR DESCRIPTION
closes #2084
If there is no name specified, default to measure_<index> as before.