### PR TITLE
Handle null and undefined numeric values

### DIFF
--- a/web-common/src/features/dashboards/humanize-numbers.ts
+++ b/web-common/src/features/dashboards/humanize-numbers.ts
@@ -197,7 +197,7 @@ export function humanizeDataType(
   type: NicelyFormattedTypes,
   options?: FormatterFactoryOptions
 ): string {
-  if (value === undefined) return "";
+  if (value === undefined || value === null) return "";
   if (typeof value != "number") return value.toString();
 
   const numberKind = nicelyFormattedTypesToNumberKind(type);


### PR DESCRIPTION
If the numeric leaderboard value is null our formatter breaks. Handling null along with undefined.