### PR TITLE
Move auth redirect into specific pages

### DIFF
--- a/web-admin/src/routes/+layout.svelte
+++ b/web-admin/src/routes/+layout.svelte
@@ -2,7 +2,6 @@
   import RillTheme from "@rilldata/web-common/layout/RillTheme.svelte";
   import { featureFlags } from "@rilldata/web-local/lib/application-state-stores/application-store";
   import { QueryClient, QueryClientProvider } from "@tanstack/svelte-query";
-  import AuthRedirect from "../components/authentication/AuthRedirect.svelte";
   import TopNavigationBar from "../components/navigation/TopNavigationBar.svelte";
 
   const queryClient = new QueryClient({
@@ -29,15 +28,13 @@
 
 <RillTheme>
   <QueryClientProvider client={queryClient}>
-    <AuthRedirect>
-      <div class="flex flex-col h-screen">
-        <main class="flex-grow flex flex-col">
-          <TopNavigationBar />
-          <div class="flex-grow overflow-auto">
-            <slot />
-          </div>
-        </main>
-      </div>
-    </AuthRedirect>
+    <div class="flex flex-col h-screen">
+      <main class="flex-grow flex flex-col">
+        <TopNavigationBar />
+        <div class="flex-grow overflow-auto">
+          <slot />
+        </div>
+      </main>
+    </div>
   </QueryClientProvider>
 </RillTheme>

--- a/web-admin/src/routes/+page.svelte
+++ b/web-admin/src/routes/+page.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
   import { createAdminServiceGetCurrentUser } from "../client";
+  import AuthRedirect from "../components/authentication/AuthRedirect.svelte";
   import OrganizationList from "../components/home/OrganizationList.svelte";
 
   const user = createAdminServiceGetCurrentUser();
 </script>
 
-{#if $user.data && $user.data.user}
+<AuthRedirect>
   <section class="flex flex-col justify-center w-4/5 mx-auto h-2/5">
     <h1 class="text-4xl leading-10 font-light mb-2">
       Hi {$user.data.user.displayName}!
@@ -15,4 +16,4 @@
     </h3>
     <OrganizationList />
   </section>
-{/if}
+</AuthRedirect>

--- a/web-admin/src/routes/[organization]/+layout.svelte
+++ b/web-admin/src/routes/[organization]/+layout.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import AuthRedirect from "../../components/authentication/AuthRedirect.svelte";
+</script>
+
+<AuthRedirect>
+  <slot />
+</AuthRedirect>


### PR DESCRIPTION
#2112 introduced a bug where the auth redirect prevents the user from getting to the auth confirmation pages. This PR moves the auth redirect from the top-level into specific pages.

However with this current approach, the top navbar, which is a component placed at the root layout, flashes before the redirect occurs. Should we move the navbar into specific pages too to avoid the flash?