### PR TITLE
Support setting `api_url` in `~/.rill/config.yaml`

### DIFF
--- a/cli/pkg/dotrill/dotrill.go
+++ b/cli/pkg/dotrill/dotrill.go
@@ -22,6 +22,7 @@ const (
 // Constants for YAML keys
 const (
 	DefaultOrgConfigKey       = "org"
+	DefaultAdminURLConfigKey  = "api_url"
 	AnalyticsEnabledConfigKey = "analytics_enabled"
 	AccessTokenCredentialsKey = "token"
 	InstallIDStateKey         = "install_id"
@@ -104,6 +105,11 @@ func GetDefaultOrg() (string, error) {
 // SetDefaultOrg saves the default org
 func SetDefaultOrg(orgName string) error {
 	return Set(ConfigFilename, DefaultOrgConfigKey, orgName)
+}
+
+// GetDefaultAdminURL loads the default admin URL (if set)
+func GetDefaultAdminURL() (string, error) {
+	return Get(ConfigFilename, DefaultAdminURLConfigKey)
 }
 
 // GetToken loads the current auth token


### PR DESCRIPTION
This is an undocumented feature to set the admin server URL in the global config file instead of passing `--api-url` on every call.