### PR TITLE
Style the auth code confirmation page

### DIFF
--- a/web-admin/src/components/CTAButton.svelte
+++ b/web-admin/src/components/CTAButton.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  import { createEventDispatcher } from "svelte";
+
+  export let variant: "primary" | "primary-outline" | "secondary" = "primary";
+  export let disabled = false;
+
+  function getVariantClass() {
+    switch (variant) {
+      case "primary":
+        return "border-blue-600 bg-blue-600 text-white hover:bg-blue-500 hover:border-blue-500";
+      case "primary-outline":
+        return "border-blue-300 text-blue-600 hover:bg-slate-100 hover:border-gray-100";
+      case "secondary":
+        return "border-gray-300 text-gray-600 hover:bg-slate-100";
+    }
+  }
+
+  const dispatch = createEventDispatcher();
+
+  const handleClick = (event: MouseEvent) => {
+    if (!disabled) {
+      dispatch("click", event);
+    }
+  };
+
+  const disabledClasses = `disabled:cursor-not-allowed disabled:text-gray-700 disabled:bg-gray-200 disabled:border disabled:border-gray-400 disabled:opacity-50`;
+</script>
+
+<button
+  class="max-w-[400px] h-10 border rounded-sm {getVariantClass()} {disabled &&
+    disabledClasses}"
+  on:click={handleClick}
+  {disabled}
+>
+  <slot />
+</button>

--- a/web-admin/src/components/CTAButton.svelte
+++ b/web-admin/src/components/CTAButton.svelte
@@ -4,7 +4,7 @@
   export let variant: "primary" | "primary-outline" | "secondary" = "primary";
   export let disabled = false;
 
-  function getVariantClass() {
+  function getVariantClass(variant: string) {
     switch (variant) {
       case "primary":
         return "border-blue-600 bg-blue-600 text-white hover:bg-blue-500 hover:border-blue-500";
@@ -27,8 +27,9 @@
 </script>
 
 <button
-  class="max-w-[400px] h-10 border rounded-sm {getVariantClass()} {disabled &&
-    disabledClasses}"
+  class="max-w-[400px] h-10 border rounded-sm {getVariantClass(
+    variant
+  )} {disabled && disabledClasses}"
   on:click={handleClick}
   {disabled}
 >

--- a/web-admin/src/routes/-/auth/device/+page.svelte
+++ b/web-admin/src/routes/-/auth/device/+page.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
-  import { Button } from "@rilldata/web-common/components/button";
+  import RillLogoSquareNegative from "@rilldata/web-common/components/icons/RillLogoSquareNegative.svelte";
   import { onMount } from "svelte";
+  import type { V1User } from "../../../../client";
   import { ADMIN_URL } from "../../../../client/http-client";
+  import CtaButton from "../../../../components/CTAButton.svelte";
 
-  let user;
+  let user: V1User;
   let userCode;
   let actionTaken = false;
   let successMsg = "";
@@ -83,32 +85,44 @@
 </svelte:head>
 
 {#if user}
-  <div class="flex flex-col justify-center items-center h-3/5">
-    <h1 class="text-3xl font-medium text-gray-800 mb-4">
-      Hello, {user.displayName}!
-    </h1>
-    <p class="text-lg text-gray-700 mb-6">Your user code is: {userCode}</p>
-
-    <Button
-      type="primary"
-      on:click={() => {
-        actionTaken = true;
-        confirmUserCode();
-      }}
-      disabled={actionTaken}>Confirm</Button
+  <div class="flex flex-col justify-center items-center h-4/5 gap-y-6">
+    <RillLogoSquareNegative size="84px" />
+    <h1 class="text-xl font-normal text-gray-800">Authorize Rill CLI</h1>
+    <p class="text-base text-gray-500 text-center">
+      You are authenticating into Rill as <span
+        class="font-medium text-gray-600">{user.email}</span
+      >.<br />Please confirm this is the code displayed in the Rill CLI.
+    </p>
+    <div
+      class="px-2 py-1 rounded-sm text-4xl tracking-widest bg-gray-100 text-gray-700 mb-5 font-mono"
     >
-    <div class="mt-4" />
-    <Button
-      type="secondary"
-      on:click={() => {
-        actionTaken = true;
-        rejectUserCode();
-      }}
-      disabled={actionTaken}>Reject</Button
-    >
+      {userCode}
+    </div>
 
-    <div class="mt-4" />
-    <p class="text-md text-green-700 font-bold mb-6">{successMsg}</p>
-    <p class="text-md text-red-400 font-bold mb-6">{errorMsg}</p>
+    <div class="flex flex-col gap-y-4 w-[400px]">
+      <CtaButton
+        variant="primary"
+        on:click={() => {
+          actionTaken = true;
+          confirmUserCode();
+        }}
+        disabled={actionTaken}>Confirm code</CtaButton
+      >
+      <CtaButton
+        variant="secondary"
+        on:click={() => {
+          actionTaken = true;
+          rejectUserCode();
+        }}
+        disabled={actionTaken}>Cancel</CtaButton
+      >
+    </div>
+
+    {#if successMsg}
+      <p class="text-md text-green-700 font-bold mb-6">{successMsg}</p>
+    {/if}
+    {#if errorMsg}
+      <p class="text-md text-red-400 font-bold mb-6">{errorMsg}</p>
+    {/if}
   </div>
 {/if}

--- a/web-common/src/components/icons/RillLogoSquareNegative.svelte
+++ b/web-common/src/components/icons/RillLogoSquareNegative.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  export let size = "1em";
+</script>
+
+<svg
+  height={size}
+  viewBox="0 0 36 36"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <rect width="36" height="36" rx="2" fill="#2563EB" />
+  <path
+    fill-rule="evenodd"
+    clip-rule="evenodd"
+    d="M23 14V30L19 28V14H23ZM11 14V24L7 22V14H11Z"
+    fill="white"
+  />
+  <path
+    fill-rule="evenodd"
+    clip-rule="evenodd"
+    d="M25 12L29 14V22H25V12ZM13 6L17 8V22H13V6Z"
+    fill="white"
+  />
+</svg>


### PR DESCRIPTION
This PR styles the auth code confirmation page.

It also creates a new call-to-action button component, which we should re-use for the other CTAs in `web-admin`.

Contributes to #2109 