### PR TITLE
fixes console error

### DIFF
--- a/web-common/src/components/data-graphic/marks/MultiMetricMouseoverLabel.svelte
+++ b/web-common/src/components/data-graphic/marks/MultiMetricMouseoverLabel.svelte
@@ -134,17 +134,19 @@ It is probably not the most up to date code; but it works very well in practice.
   $: if (container && locations && $xScale && $yScale) {
     clearTimeout(transitionalTimeoutForCalculatingLabelWidth);
     transitionalTimeoutForCalculatingLabelWidth = setTimeout(() => {
-      labelWidth = Math.max(
-        ...Array.from(container.querySelectorAll(".widths")).map(
-          (q: SVGElement) => q.getBoundingClientRect().width
-        )
-      );
+      if (container) {
+        labelWidth = Math.max(
+          ...Array.from(container.querySelectorAll(".widths")).map(
+            (q: SVGElement) => q.getBoundingClientRect().width
+          )
+        );
 
-      textWidths = Array.from(container.querySelectorAll(".text-elements")).map(
-        (q: SVGElement) => q.getBoundingClientRect().width
-      );
-      if (!Number.isFinite(labelWidth)) {
-        labelWidth = 0;
+        textWidths = Array.from(
+          container.querySelectorAll(".text-elements")
+        ).map((q: SVGElement) => q.getBoundingClientRect().width);
+        if (!Number.isFinite(labelWidth)) {
+          labelWidth = 0;
+        }
       }
     }, 0);
   }


### PR DESCRIPTION
This fixes a console error that is showing up all the time and driving me crazy while debugging other code. There is a subtle bug here where the `container` item may exist when the the `setTimeout` is set, but it may not exist by the time the callback is triggered. This adds a guard _within_ the callback to make sure that the `container` elt exists at the time the callback is fired (just added the `if (container)`, the rest is indentation change)