### PR TITLE
Fix race condition in passing JWT to runtime

### DIFF
--- a/web-admin/src/routes/[organization]/[project]/+layout.svelte
+++ b/web-admin/src/routes/[organization]/[project]/+layout.svelte
@@ -3,26 +3,36 @@
   import RuntimeProvider from "@rilldata/web-common/runtime-client/RuntimeProvider.svelte";
   import { createAdminServiceGetProject } from "../../../client";
 
-  $: proj = createAdminServiceGetProject(
+  $: projRuntime = createAdminServiceGetProject(
     $page.params.organization,
     $page.params.project,
     {
       query: {
         // Proactively refetch the JWT because it's only valid for 1 hour
         refetchInterval: 1000 * 60 * 30, // 30 minutes
+        select: (data) => {
+          return {
+            // Hack: in development, the runtime host is actually on port 8081
+            host: data.productionDeployment.runtimeHost.replace(
+              "localhost:9091",
+              "localhost:8081"
+            ),
+            instanceId: data.productionDeployment.runtimeInstanceId,
+            jwt: data?.jwt,
+          };
+        },
+        placeholderData: undefined,
       },
     }
   );
-
-  // Hack: in development, the runtime host is actually on port 8081
-  $: runtimeHost = $proj.data?.productionDeployment?.runtimeHost.replace(
-    "localhost:9091",
-    "localhost:8081"
-  );
-  $: runtimeInstanceId = $proj.data?.productionDeployment?.runtimeInstanceId;
-  $: jwt = $proj.data?.jwt;
 </script>
 
-<RuntimeProvider host={runtimeHost} instanceId={runtimeInstanceId} {jwt}>
-  <slot />
-</RuntimeProvider>
+{#if $projRuntime.data}
+  <RuntimeProvider
+    host={$projRuntime.data.host}
+    instanceId={$projRuntime.data.instanceId}
+    jwt={$projRuntime.data?.jwt}
+  >
+    <slot />
+  </RuntimeProvider>
+{/if}

--- a/web-admin/src/routes/[organization]/[project]/+page.svelte
+++ b/web-admin/src/routes/[organization]/[project]/+page.svelte
@@ -3,6 +3,7 @@
   import { page } from "$app/stores";
   import Button from "@rilldata/web-common/components/button/Button.svelte";
   import { useDashboardNames } from "@rilldata/web-common/features/dashboards/selectors";
+  import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
   import { createAdminServiceGetProject } from "../../../client";
 
   $: proj = createAdminServiceGetProject(
@@ -11,9 +12,7 @@
   );
 
   // Go to first dashboard
-  $: dashboardsQuery = useDashboardNames(
-    $proj.data?.productionDeployment?.runtimeInstanceId
-  );
+  $: dashboardsQuery = useDashboardNames($runtime.instanceId);
   $: if ($dashboardsQuery.data && $dashboardsQuery.data.length > 0) {
     goto(
       `/${$page.params.organization}/${$page.params.project}/${$dashboardsQuery.data[0]}`

--- a/web-common/src/runtime-client/RuntimeProvider.svelte
+++ b/web-common/src/runtime-client/RuntimeProvider.svelte
@@ -16,7 +16,7 @@
   // Re-run all runtime queries when `host` changes
   // By default, a new `instanceId` triggers a re-run because it's in the queryKeys
   const queryClient = useQueryClient();
-  $: host && invalidateRuntimeQueries(queryClient);
+  $: $runtime.host && invalidateRuntimeQueries(queryClient);
 </script>
 
 {#if $runtime.host !== undefined && $runtime.instanceId}


### PR DESCRIPTION
This PR seeks to avoid 401 errors when changing projects via the breadcrumb dropdown. The problem seems to be a race condition when setting a runtime's instance ID and its associated JWT.

The PR makes a few changes to protect against race conditions. The change that ultimately seemed to fix the problem was the change in `web-admin/src/routes/[organization]/[project]/+page.svelte`.

Contributes to #2109.