### PR TITLE
Remove transition from dimension header

### DIFF
--- a/web-common/src/features/dashboards/dimension-table/DimensionHeader.svelte
+++ b/web-common/src/features/dashboards/dimension-table/DimensionHeader.svelte
@@ -62,7 +62,7 @@
     style:grid-column-gap=".4rem"
   >
     {#if isFetching}
-      <div transition:slideRight|local={{ leftOffset: 8 }}>
+      <div>
         <Spinner size="16px" status={EntityStatus.Running} />
       </div>
     {:else}


### PR DESCRIPTION
The transition on the spinner present in Dimension header is preventing `{#if}{:else}{/if} ` from being exclusive. This is a known sveltekit bug which has been noted here as well - https://github.com/rilldata/rill-developer/pull/2015

Adding a `local` modifier doesn't seem to fix it either. Have removed the transition for now. 