### PR TITLE
Handle dashboard yaml changes outside of our app

### DIFF
--- a/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
+++ b/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
@@ -214,10 +214,11 @@
       $dashboardStore?.selectedComparisonTimeRange;
     const { start, end } = selectedComparisonTimeRange;
     // add all sliced and active values to the include filter.
-    const currentVisibleValues = values
-      ?.slice(0, slice)
-      ?.concat(selectedValuesThatAreBelowTheFold)
-      ?.map((v) => v[dimensionName]);
+    const currentVisibleValues =
+      values
+        ?.slice(0, slice)
+        ?.concat(selectedValuesThatAreBelowTheFold)
+        ?.map((v) => v[dimensionName]) ?? [];
 
     const updatedFilters = getFilterForComparsion(
       filterForDimension,

--- a/web-common/src/features/dashboards/workspace/Dashboard.svelte
+++ b/web-common/src/features/dashboards/workspace/Dashboard.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
   import { goto } from "$app/navigation";
-  import { useModelHasTimeSeries } from "@rilldata/web-common/features/dashboards/selectors";
+  import {
+    useMetaQuery,
+    useModelHasTimeSeries,
+  } from "@rilldata/web-common/features/dashboards/selectors";
   import { EntityType } from "@rilldata/web-common/features/entity-management/types";
   import { appStore } from "@rilldata/web-local/lib/application-state-stores/app-store";
   import { featureFlags } from "@rilldata/web-local/lib/application-state-stores/application-store";
-  import { createRuntimeServiceGetCatalogEntry } from "../../../runtime-client";
   import { runtime } from "../../../runtime-client/runtime-store";
   import MeasuresContainer from "../big-number/MeasuresContainer.svelte";
   import { metricsExplorerStore } from "../dashboard-stores";
@@ -27,15 +29,7 @@
 
   $: switchToMetrics(metricViewName);
 
-  $: metricsViewQuery = createRuntimeServiceGetCatalogEntry(
-    $runtime.instanceId,
-    metricViewName,
-    {
-      query: {
-        select: (data) => data?.entry?.metricsView,
-      },
-    }
-  );
+  $: metricsViewQuery = useMetaQuery($runtime.instanceId, metricViewName);
 
   $: if ($metricsViewQuery.data) {
     if (!$featureFlags.readOnly && !$metricsViewQuery.data?.measures?.length) {
@@ -61,7 +55,7 @@
 </script>
 
 <DashboardContainer bind:exploreContainerWidth bind:width {leftMargin}>
-  <DashboardHeader {metricViewName} {hasTitle} slot="header" />
+  <DashboardHeader {hasTitle} {metricViewName} slot="header" />
 
   <svelte:fragment let:width slot="metrics">
     {#key metricViewName}

--- a/web-common/src/features/metrics-views/workspace/MetricsWorkspace.svelte
+++ b/web-common/src/features/metrics-views/workspace/MetricsWorkspace.svelte
@@ -91,16 +91,24 @@
     callReconcileAndUpdateYaml(yaml);
   });
 
-  function updateInternalRep() {
+  async function updateInternalRep() {
+    const isDifferent =
+      $metricsInternalRep && yaml !== $metricsInternalRep.internalYAML;
+
     metricsInternalRep = createInternalRepresentation(
       yaml,
       callReconcileAndUpdateYaml
     );
+
+    if (isDifferent) {
+      $metricsInternalRep.regenerateInternalYAML(true);
+    }
+
     if (errors) $metricsInternalRep.updateErrors(errors);
   }
 
   // reset internal representation in case of deviation from runtime YAML
-  $: if (yaml !== $metricsInternalRep.internalYAML) {
+  $: if (yaml) {
     updateInternalRep();
   }
 

--- a/web-local/src/routes/(application)/dashboard/[name]/edit/+page.svelte
+++ b/web-local/src/routes/(application)/dashboard/[name]/edit/+page.svelte
@@ -33,6 +33,8 @@
 
           throw error(err.response?.status || 500, err.message);
         },
+        // this will ensure that any changes done outside our app is pulled in.
+        refetchOnWindowFocus: true,
       },
     }
   );


### PR DESCRIPTION
Any changes done to dashboard.yaml when the editor is open will overwrite it if further changes are made. This is because we do not have a periodic fetch the yaml file.

Adding `refetchOnWindowFocus` to make it refetch when user came back to the app. Periodic refetch might add some other inconstancies when the user is editing the dashboard on the app.