### PR TITLE
Fix places where dashboard name went blank

### DIFF
--- a/web-admin/src/components/home/DashboardList.svelte
+++ b/web-admin/src/components/home/DashboardList.svelte
@@ -49,9 +49,7 @@
         <a
           href="/{organization}/{project}/{dashboard.name}"
           class="text-gray-700 hover:underline text-xs font-medium leading-4"
-          >{dashboard.metricsView?.label !== ""
-            ? dashboard.metricsView.label
-            : dashboard.name}</a
+          >{dashboard.metricsView?.label || dashboard.name}</a
         >
       </li>
     {/each}

--- a/web-admin/src/components/home/DashboardList.svelte
+++ b/web-admin/src/components/home/DashboardList.svelte
@@ -49,7 +49,9 @@
         <a
           href="/{organization}/{project}/{dashboard.name}"
           class="text-gray-700 hover:underline text-xs font-medium leading-4"
-          >{dashboard.metricsView?.label ?? dashboard.name}</a
+          >{dashboard.metricsView?.label !== ""
+            ? dashboard.metricsView.label
+            : dashboard.name}</a
         >
       </li>
     {/each}

--- a/web-admin/src/components/navigation/Breadcrumbs.svelte
+++ b/web-admin/src/components/navigation/Breadcrumbs.svelte
@@ -77,12 +77,17 @@
     {#if currentDashboard}
       <span class="text-gray-600">/</span>
       <BreadcrumbItem
-        label={currentDashboard.metricsView?.label ?? currentDashboard.name}
+        label={currentDashboard.metricsView?.label !== ""
+          ? currentDashboard.metricsView.label
+          : currentDashboard.name}
         isCurrentPage={isDashboardPage}
         menuOptions={$dashboards.data?.entries?.length > 1 &&
           $dashboards.data.entries.map((dash) => ({
             key: dash.name,
-            main: dash.metricsView?.label ?? dash.name,
+            main:
+              dash.metricsView?.label !== ""
+                ? dash.metricsView.label
+                : dash.name,
             callback: () => goto(`/${organization}/${project}/${dash.name}`),
           }))}
         onSelectMenuOption={(dashboard) =>

--- a/web-admin/src/components/navigation/Breadcrumbs.svelte
+++ b/web-admin/src/components/navigation/Breadcrumbs.svelte
@@ -77,17 +77,12 @@
     {#if currentDashboard}
       <span class="text-gray-600">/</span>
       <BreadcrumbItem
-        label={currentDashboard.metricsView?.label !== ""
-          ? currentDashboard.metricsView.label
-          : currentDashboard.name}
+        label={currentDashboard.metricsView?.label || currentDashboard.name}
         isCurrentPage={isDashboardPage}
         menuOptions={$dashboards.data?.entries?.length > 1 &&
           $dashboards.data.entries.map((dash) => ({
             key: dash.name,
-            main:
-              dash.metricsView?.label !== ""
-                ? dash.metricsView.label
-                : dash.name,
+            main: dash.metricsView?.label || dash.name,
             callback: () => goto(`/${organization}/${project}/${dash.name}`),
           }))}
         onSelectMenuOption={(dashboard) =>


### PR DESCRIPTION
Fixes an issue where a dashboard's display name went blank. It happened in:
- The homepage list of dashboards
- The breadcrumb dashboard label
- The breadcrumb dashboard options