### PR TITLE
Using the correct key for display_name

### DIFF
--- a/runtime/services/catalog/artifacts/artifacts_test.go
+++ b/runtime/services/catalog/artifacts/artifacts_test.go
@@ -187,7 +187,7 @@ func TestMetricsLabelBackwardsCompatibility(t *testing.T) {
 	repoStore, _ := fileStore.RepoStore()
 	ctx := context.Background()
 
-	require.NoError(t, repoStore.Put(ctx, "test", "dashboards/MetricsView.yaml", bytes.NewReader([]byte(`name: dashboard name
+	require.NoError(t, repoStore.Put(ctx, "test", "dashboards/MetricsView.yaml", bytes.NewReader([]byte(`display_name: dashboard name
 description: long description for dashboard
 model: Model
 timeseries: time

--- a/runtime/services/catalog/artifacts/yaml/objects.go
+++ b/runtime/services/catalog/artifacts/yaml/objects.go
@@ -47,7 +47,7 @@ type ExtractConfig struct {
 
 type MetricsView struct {
 	Label             string `yaml:"title"`
-	DisplayName       string `yaml:"name,omitempty"` // for backwards compatibility
+	DisplayName       string `yaml:"display_name,omitempty"` // for backwards compatibility
 	Description       string
 	Model             string
 	TimeDimension     string `yaml:"timeseries"`


### PR DESCRIPTION
For adding backwards compatibility with `display_name` in dashboard we used incorrect `name` key. Updating it to use the correct `display_name` key.