### PR TITLE
Adjust contrast in project logs

### DIFF
--- a/web-admin/src/components/projects/ProjectDeploymentLogs.svelte
+++ b/web-admin/src/components/projects/ProjectDeploymentLogs.svelte
@@ -34,10 +34,12 @@
     <ul class="w-full">
       {#each errors as error}
         <li
-          class="flex justify-between py-1 px-12 border-b border-gray-200 bg-red-50 font-mono"
+          class="flex gap-x-2 justify-between py-1 px-12 border-b border-gray-200 bg-red-50 font-mono"
         >
           <span class="text-red-600">{error.message}</span>
-          <span class="text-stone-500 font-semibold">{error.filePath}</span>
+          <span class="text-stone-500 font-semibold shrink-0">
+            {error.filePath}
+          </span>
         </li>
       {/each}
     </ul>

--- a/web-admin/src/components/projects/ProjectDeploymentLogs.svelte
+++ b/web-admin/src/components/projects/ProjectDeploymentLogs.svelte
@@ -36,7 +36,9 @@
         <li
           class="flex gap-x-5 justify-between py-1 px-12 border-b border-gray-200 bg-red-50 font-mono"
         >
-          <span class="text-red-600">{error.message}</span>
+          <span class="text-red-600 break-all">
+            {error.message}
+          </span>
           <span class="text-stone-500 font-semibold shrink-0">
             {error.filePath}
           </span>

--- a/web-admin/src/components/projects/ProjectDeploymentLogs.svelte
+++ b/web-admin/src/components/projects/ProjectDeploymentLogs.svelte
@@ -34,11 +34,10 @@
     <ul class="w-full">
       {#each errors as error}
         <li
-          class="flex justify-between py-1 px-12 border-b border-gray-200 bg-gray-50"
-          style="font-family: 'Source Code Variable';"
+          class="flex justify-between py-1 px-12 border-b border-gray-200 bg-red-50 font-mono"
         >
-          <span class="text-gray-900">{error.message}</span>
-          <span class="text-gray-500 font-semibold">{error.filePath}</span>
+          <span class="text-red-600">{error.message}</span>
+          <span class="text-stone-500 font-semibold">{error.filePath}</span>
         </li>
       {/each}
     </ul>

--- a/web-admin/src/components/projects/ProjectDeploymentLogs.svelte
+++ b/web-admin/src/components/projects/ProjectDeploymentLogs.svelte
@@ -34,7 +34,7 @@
     <ul class="w-full">
       {#each errors as error}
         <li
-          class="flex gap-x-2 justify-between py-1 px-12 border-b border-gray-200 bg-red-50 font-mono"
+          class="flex gap-x-5 justify-between py-1 px-12 border-b border-gray-200 bg-red-50 font-mono"
         >
           <span class="text-red-600">{error.message}</span>
           <span class="text-stone-500 font-semibold shrink-0">


### PR DESCRIPTION
This PR:
- Changes the log colors to match the new Figma mock
- Tweaks the spacing between a long error message and its associated file name
- Adds line breaks so screen-wide strings will break to the next line

Contributes to #2109.