### PR TITLE
Moving the url parsing to dashboard component

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -41,6 +41,7 @@ README.md
 docs
 *.json
 *.cjs
+_redirects
 
 # Java SQL lib
 sql/

--- a/web-admin/src/routes/[organization]/[project]/[dashboard]/+page.svelte
+++ b/web-admin/src/routes/[organization]/[project]/[dashboard]/+page.svelte
@@ -49,15 +49,6 @@
       await getDashboardsForProject($project.data)
     );
   }
-
-  $: metricsExplorer = useDashboardStore(dash);
-  const stateSyncManager = new StateSyncManager(dash);
-  $: if ($metricsExplorer) {
-    stateSyncManager.handleStateChange($metricsExplorer);
-  }
-  $: if ($page) {
-    stateSyncManager.handleUrlChange();
-  }
 </script>
 
 <svelte:head>

--- a/web-admin/src/routes/[organization]/[project]/[dashboard]/+page.svelte
+++ b/web-admin/src/routes/[organization]/[project]/[dashboard]/+page.svelte
@@ -5,8 +5,6 @@
   import { invalidateProjectQueries } from "@rilldata/web-admin/components/projects/invalidations";
   import { useProject } from "@rilldata/web-admin/components/projects/use-project";
   import { Dashboard } from "@rilldata/web-common/features/dashboards";
-  import { useDashboardStore } from "@rilldata/web-common/features/dashboards/dashboard-stores";
-  import { StateSyncManager } from "@rilldata/web-common/features/dashboards/proto-state/StateSyncManager";
   import { useQueryClient } from "@tanstack/svelte-query";
   import ProjectBuilding from "../../../../components/projects/ProjectBuilding.svelte";
   import ProjectErrored from "../../../../components/projects/ProjectErrored.svelte";

--- a/web-common/src/features/dashboards/dashboard-stores.ts
+++ b/web-common/src/features/dashboards/dashboard-stores.ts
@@ -53,6 +53,7 @@ const updateMetricsExplorerByName = (
   absenceCallback?: () => MetricsExplorerEntity
 ) => {
   update((state) => {
+    console.log(name, state.entities[name]);
     if (!state.entities[name]) {
       if (absenceCallback) {
         state.entities[name] = absenceCallback();

--- a/web-common/src/features/dashboards/dashboard-stores.ts
+++ b/web-common/src/features/dashboards/dashboard-stores.ts
@@ -6,7 +6,7 @@ import type {
   V1MetricsViewFilter,
 } from "@rilldata/web-common/runtime-client";
 import { removeIfExists } from "@rilldata/web-local/lib/util/arrayUtils";
-import { derived, Readable, Writable, writable } from "svelte/store";
+import { Readable, Writable, derived, writable } from "svelte/store";
 
 export interface LeaderboardValue {
   value: number;
@@ -53,7 +53,6 @@ const updateMetricsExplorerByName = (
   absenceCallback?: () => MetricsExplorerEntity
 ) => {
   update((state) => {
-    console.log(name, state.entities[name]);
     if (!state.entities[name]) {
       if (absenceCallback) {
         state.entities[name] = absenceCallback();

--- a/web-common/src/features/dashboards/proto-state/StateSyncManager.ts
+++ b/web-common/src/features/dashboards/proto-state/StateSyncManager.ts
@@ -26,6 +26,7 @@ export class StateSyncManager {
   public handleUrlChange() {
     const pageUrl = get(page).url;
     const newUrlState = pageUrl.searchParams.get("state");
+    console.log(newUrlState);
     if (this.urlState === newUrlState) return;
     this.urlState = newUrlState;
 

--- a/web-common/src/features/dashboards/proto-state/StateSyncManager.ts
+++ b/web-common/src/features/dashboards/proto-state/StateSyncManager.ts
@@ -1,7 +1,7 @@
-import { metricsExplorerStore } from "@rilldata/web-common/features/dashboards/dashboard-stores";
-import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/dashboard-stores";
 import { goto } from "$app/navigation";
 import { page } from "$app/stores";
+import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/dashboard-stores";
+import { metricsExplorerStore } from "@rilldata/web-common/features/dashboards/dashboard-stores";
 import { get } from "svelte/store";
 
 export class StateSyncManager {
@@ -26,7 +26,6 @@ export class StateSyncManager {
   public handleUrlChange() {
     const pageUrl = get(page).url;
     const newUrlState = pageUrl.searchParams.get("state");
-    console.log(newUrlState);
     if (this.urlState === newUrlState) return;
     this.urlState = newUrlState;
 

--- a/web-common/src/features/dashboards/workspace/Dashboard.svelte
+++ b/web-common/src/features/dashboards/workspace/Dashboard.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import { goto } from "$app/navigation";
+  import { page } from "$app/stores";
+  import { StateSyncManager } from "@rilldata/web-common/features/dashboards/proto-state/StateSyncManager";
   import {
     useMetaQuery,
     useModelHasTimeSeries,
@@ -9,7 +11,7 @@
   import { featureFlags } from "@rilldata/web-local/lib/application-state-stores/application-store";
   import { runtime } from "../../../runtime-client/runtime-store";
   import MeasuresContainer from "../big-number/MeasuresContainer.svelte";
-  import { metricsExplorerStore } from "../dashboard-stores";
+  import { metricsExplorerStore, useDashboardStore } from "../dashboard-stores";
   import DimensionDisplay from "../dimension-table/DimensionDisplay.svelte";
   import LeaderboardDisplay from "../leaderboard/LeaderboardDisplay.svelte";
   import MetricsTimeSeriesCharts from "../time-series/MetricsTimeSeriesCharts.svelte";
@@ -45,7 +47,16 @@
 
   let width;
 
-  $: metricsExplorer = $metricsExplorerStore.entities[metricViewName];
+  $: metricsExplorer = useDashboardStore(metricViewName);
+
+  $: stateSyncManager = new StateSyncManager(metricViewName);
+  $: if ($metricsExplorer) {
+    stateSyncManager.handleStateChange($metricsExplorer);
+  }
+  $: if ($page) {
+    stateSyncManager.handleUrlChange();
+  }
+
   $: selectedDimensionName = metricsExplorer?.selectedDimensionName;
   $: metricTimeSeries = useModelHasTimeSeries(
     $runtime.instanceId,

--- a/web-local/src/routes/(application)/dashboard/[name]/+page.svelte
+++ b/web-local/src/routes/(application)/dashboard/[name]/+page.svelte
@@ -3,7 +3,6 @@
   import { page } from "$app/stores";
   import { Dashboard } from "@rilldata/web-common/features/dashboards";
   import { useDashboardStore } from "@rilldata/web-common/features/dashboards/dashboard-stores";
-  import { StateSyncManager } from "@rilldata/web-common/features/dashboards/proto-state/StateSyncManager";
   import { getFilePathFromNameAndType } from "@rilldata/web-common/features/entity-management/entity-mappers";
   import { EntityType } from "@rilldata/web-common/features/entity-management/types";
   import { WorkspaceContainer } from "@rilldata/web-common/layout/workspace";
@@ -18,15 +17,6 @@
 
   $: metricViewName = $page.params.name;
   $: metricsExplorer = useDashboardStore(metricViewName);
-
-  $: stateSyncManager = new StateSyncManager(metricViewName);
-
-  $: if ($metricsExplorer) {
-    stateSyncManager.handleStateChange($metricsExplorer);
-  }
-  $: if ($page) {
-    stateSyncManager.handleUrlChange();
-  }
 
   $: fileQuery = createRuntimeServiceGetFile(
     $runtime.instanceId,


### PR DESCRIPTION
In cloud since we make a network call for project status, there is a delay in getting the dashboard name. This will lead to some race condition between creating a store entry from meta api vs parsing from url.

Moving the parsing of url to Dashboard component to make sure that data is available when dashboard is navigated to.