### PR TITLE
Device auth: guard against user code clashes

### DIFF
--- a/admin/database/database.go
+++ b/admin/database/database.go
@@ -99,10 +99,10 @@ type DB interface {
 	DeleteUserAuthToken(ctx context.Context, id string) error
 
 	FindDeviceAuthCodeByDeviceCode(ctx context.Context, deviceCode string) (*DeviceAuthCode, error)
-	FindDeviceAuthCodeByUserCode(ctx context.Context, userCode string) (*DeviceAuthCode, error)
+	FindPendingDeviceAuthCodeByUserCode(ctx context.Context, userCode string) (*DeviceAuthCode, error)
 	InsertDeviceAuthCode(ctx context.Context, deviceCode, userCode, clientID string, expiresOn time.Time) (*DeviceAuthCode, error)
 	DeleteDeviceAuthCode(ctx context.Context, deviceCode string) error
-	UpdateDeviceAuthCode(ctx context.Context, userCode, userID string, state DeviceAuthCodeState) error
+	UpdateDeviceAuthCode(ctx context.Context, id, userID string, state DeviceAuthCodeState) error
 
 	FindOrganizationRole(ctx context.Context, name string) (*OrganizationRole, error)
 	FindProjectRole(ctx context.Context, name string) (*ProjectRole, error)

--- a/admin/database/postgres/postgres.go
+++ b/admin/database/postgres/postgres.go
@@ -519,9 +519,9 @@ func (c *connection) FindDeviceAuthCodeByDeviceCode(ctx context.Context, deviceC
 	return authCode, nil
 }
 
-func (c *connection) FindDeviceAuthCodeByUserCode(ctx context.Context, userCode string) (*database.DeviceAuthCode, error) {
+func (c *connection) FindPendingDeviceAuthCodeByUserCode(ctx context.Context, userCode string) (*database.DeviceAuthCode, error) {
 	authCode := &database.DeviceAuthCode{}
-	err := c.getDB(ctx).QueryRowxContext(ctx, "SELECT * FROM device_auth_codes WHERE user_code = $1", userCode).StructScan(authCode)
+	err := c.getDB(ctx).QueryRowxContext(ctx, "SELECT * FROM device_auth_codes WHERE user_code = $1 AND expires_on > now() AND approval_state = 0", userCode).StructScan(authCode)
 	if err != nil {
 		return nil, parseErr(err)
 	}
@@ -557,9 +557,8 @@ func (c *connection) DeleteDeviceAuthCode(ctx context.Context, deviceCode string
 	return nil
 }
 
-func (c *connection) UpdateDeviceAuthCode(ctx context.Context, userCode, userID string, approvalState database.DeviceAuthCodeState) error {
-	res, err := c.getDB(ctx).ExecContext(ctx, "UPDATE device_auth_codes SET approval_state=$1, user_id=$2, updated_on=now() WHERE user_code=$3",
-		approvalState, userID, userCode)
+func (c *connection) UpdateDeviceAuthCode(ctx context.Context, id, userID string, approvalState database.DeviceAuthCodeState) error {
+	res, err := c.getDB(ctx).ExecContext(ctx, "UPDATE device_auth_codes SET approval_state=$1, user_id=$2, updated_on=now() WHERE id=$3", approvalState, userID, id)
 	if err != nil {
 		return parseErr(err)
 	}


### PR DESCRIPTION
User codes can only be assumed to be unique within their TTL