### PR TITLE
Account for invalid vs. valid dashboards

### DIFF
--- a/web-admin/src/components/home/DashboardList.svelte
+++ b/web-admin/src/components/home/DashboardList.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
-  import { getDashboardsForProject } from "@rilldata/web-admin/components/projects/dashboards";
-  import type { V1CatalogEntry } from "@rilldata/web-common/runtime-client";
+  import {
+    DashboardListItem,
+    getDashboardsForProject,
+  } from "@rilldata/web-admin/components/projects/dashboards";
   import { createAdminServiceGetProject } from "../../client";
 
   export let organization: string;
   export let project: string;
 
-  let dashboards: V1CatalogEntry[];
+  let dashboardListItems: DashboardListItem[];
 
   $: proj = createAdminServiceGetProject(organization, project);
   $: if ($proj.isSuccess && $proj.data?.prodDeployment) {
@@ -14,20 +16,20 @@
   }
 
   async function updateDashboardsForProject() {
-    dashboards = await getDashboardsForProject($proj.data);
+    dashboardListItems = await getDashboardsForProject($proj.data);
   }
 </script>
 
-{#if dashboards?.length === 0}
+{#if dashboardListItems?.length === 0}
   <p class="text-gray-500 text-xs">This project has no dashboards yet.</p>
-{:else if dashboards?.length > 0}
+{:else if dashboardListItems?.length > 0}
   <ol>
-    {#each dashboards as dashboard}
+    {#each dashboardListItems as dashboardListItem}
       <li class="mb-1">
         <a
-          href="/{organization}/{project}/{dashboard.name}"
-          class="text-gray-700 hover:underline text-xs font-medium leading-4"
-          >{dashboard.metricsView?.label || dashboard.name}</a
+          href="/{organization}/{project}/{dashboardListItem.name}"
+          class="text-gray-700 hover:underline text-xs font-medium leading-4 {!dashboardListItem.isValid &&
+            'italic'}">{dashboardListItem?.title || dashboardListItem.name}</a
         >
       </li>
     {/each}

--- a/web-admin/src/components/home/DashboardList.svelte
+++ b/web-admin/src/components/home/DashboardList.svelte
@@ -25,12 +25,19 @@
 {:else if dashboardListItems?.length > 0}
   <ol>
     {#each dashboardListItems as dashboardListItem}
-      <li class="mb-1">
-        <a
-          href="/{organization}/{project}/{dashboardListItem.name}"
-          class="text-gray-700 hover:underline text-xs font-medium leading-4 {!dashboardListItem.isValid &&
-            'italic'}">{dashboardListItem?.title || dashboardListItem.name}</a
-        >
+      <li class="mb-1 text-xs font-medium leading-4">
+        {#if dashboardListItem.isValid}
+          <a
+            href="/{organization}/{project}/{dashboardListItem.name}"
+            class="text-gray-700 hover:underline"
+          >
+            {dashboardListItem?.title || dashboardListItem.name}
+          </a>
+        {:else}
+          <span class="text-gray-400"
+            >{dashboardListItem?.title || dashboardListItem.name}
+          </span>
+        {/if}
       </li>
     {/each}
   </ol>

--- a/web-admin/src/components/home/DeploymentStatusChip.svelte
+++ b/web-admin/src/components/home/DeploymentStatusChip.svelte
@@ -8,6 +8,11 @@
   import Spacer from "@rilldata/web-common/components/icons/Spacer.svelte";
   import Spinner from "@rilldata/web-common/features/entity-management/Spinner.svelte";
   import { EntityStatus } from "@rilldata/web-common/features/entity-management/types";
+  import {
+    getRuntimeServiceListCatalogEntriesQueryKey,
+    getRuntimeServiceListFilesQueryKey,
+  } from "@rilldata/web-common/runtime-client";
+  import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
   import { useQueryClient } from "@tanstack/svelte-query";
   import type { SvelteComponent } from "svelte";
 
@@ -32,6 +37,18 @@
       deploymentStatus === V1DeploymentStatus.DEPLOYMENT_STATUS_OK
     ) {
       getDashboardsAndInvalidate();
+
+      // Invalidate the queries used to compose the dashboard list in the breadcrumbs
+      queryClient.invalidateQueries(
+        getRuntimeServiceListFilesQueryKey($runtime?.instanceId, {
+          glob: "dashboards/*.yaml",
+        })
+      );
+      queryClient.invalidateQueries(
+        getRuntimeServiceListCatalogEntriesQueryKey($runtime?.instanceId, {
+          type: "OBJECT_TYPE_METRICS_VIEW",
+        })
+      );
     }
   }
 

--- a/web-admin/src/components/home/DeploymentStatusChip.svelte
+++ b/web-admin/src/components/home/DeploymentStatusChip.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { V1DeploymentStatus } from "@rilldata/web-admin/client";
   import { getDashboardsForProject } from "@rilldata/web-admin/components/projects/dashboards";
-  import { invalidateProjectQueries } from "@rilldata/web-admin/components/projects/invalidations";
+  import { invalidateDashboardsQueries } from "@rilldata/web-admin/components/projects/invalidations";
   import { useProject } from "@rilldata/web-admin/components/projects/use-project";
   import CancelCircle from "@rilldata/web-common/components/icons/CancelCircle.svelte";
   import CheckCircle from "@rilldata/web-common/components/icons/CheckCircle.svelte";
@@ -38,7 +38,7 @@
   async function getDashboardsAndInvalidate() {
     const dashboardListItems = await getDashboardsForProject($proj.data);
     const dashboardNames = dashboardListItems.map((listing) => listing.name);
-    return invalidateProjectQueries(queryClient, dashboardNames);
+    return invalidateDashboardsQueries(queryClient, dashboardNames);
   }
 
   type StatusDisplay = {

--- a/web-admin/src/components/home/DeploymentStatusChip.svelte
+++ b/web-admin/src/components/home/DeploymentStatusChip.svelte
@@ -36,10 +36,9 @@
   }
 
   async function getDashboardsAndInvalidate() {
-    return invalidateProjectQueries(
-      queryClient,
-      await getDashboardsForProject($proj.data)
-    );
+    const dashboardListItems = await getDashboardsForProject($proj.data);
+    const dashboardNames = dashboardListItems.map((listing) => listing.name);
+    return invalidateProjectQueries(queryClient, dashboardNames);
   }
 
   type StatusDisplay = {

--- a/web-admin/src/components/navigation/BreadcrumbItem.svelte
+++ b/web-admin/src/components/navigation/BreadcrumbItem.svelte
@@ -5,6 +5,7 @@
   export let label: string;
   export let isCurrentPage = false;
   export let menuOptions: { key: string; main: string }[] = [];
+  export let menuKey: string;
   export let onSelectMenuOption: (option: string) => void = undefined;
 
   const activeClass = "text-gray-800 font-semibold";
@@ -26,7 +27,7 @@
       distance={4}
       options={menuOptions}
       selection={{
-        key: label,
+        key: menuKey,
         main: label,
       }}
       on:select={({ detail: { key } }) => onSelectMenuOption(key)}

--- a/web-admin/src/components/projects/dashboards.ts
+++ b/web-admin/src/components/projects/dashboards.ts
@@ -1,9 +1,16 @@
 import type { V1GetProjectResponse } from "@rilldata/web-admin/client";
+import type { V1CatalogEntry } from "@rilldata/web-common/runtime-client";
 import Axios from "axios";
+
+export interface DashboardListItem {
+  name: string;
+  title?: string;
+  isValid: boolean;
+}
 
 export async function getDashboardsForProject(
   projectData: V1GetProjectResponse
-) {
+): Promise<DashboardListItem[]> {
   // Hack: in development, the runtime host is actually on port 8081
   const runtimeHost = projectData.prodDeployment.runtimeHost.replace(
     "localhost:9091",
@@ -17,9 +24,51 @@ export async function getDashboardsForProject(
     },
   });
 
-  const { data } = await axios.get(
+  // get all valid and invalid dashboards
+  const filesRequest = axios.get(
+    `/v1/instances/${projectData.prodDeployment.runtimeInstanceId}/files?glob=dashboards/*.yaml`
+  );
+
+  // get the valid dashboards
+  const catalogEntriesRequest = axios.get(
     `/v1/instances/${projectData.prodDeployment.runtimeInstanceId}/catalog?type=OBJECT_TYPE_METRICS_VIEW`
   );
 
-  return data.entries;
+  const [filesResponse, catalogEntriesResponse] = await Promise.all([
+    filesRequest,
+    catalogEntriesRequest,
+  ]);
+
+  const filePaths = filesResponse.data?.paths;
+  const catalogEntries = catalogEntriesResponse.data?.entries;
+
+  // compose the dashboard list items
+  const dashboardListItems = getDashboardListItemsFromFilesAndCatalogEntries(
+    filePaths,
+    catalogEntries
+  );
+
+  return dashboardListItems;
+}
+
+export function getDashboardListItemsFromFilesAndCatalogEntries(
+  filePaths: string[],
+  catalogEntries: V1CatalogEntry[]
+): DashboardListItem[] {
+  const dashboardListings = filePaths?.map((path: string) => {
+    const name = path.replace("/dashboards/", "").replace(".yaml", "");
+    const catalogEntry = catalogEntries?.find(
+      (entry: V1CatalogEntry) => entry.path === path
+    );
+    const title = catalogEntry?.metricsView?.label;
+    // invalid dashboards are not in the catalog
+    const isValid = !!catalogEntry;
+    return {
+      name,
+      title,
+      isValid,
+    };
+  });
+
+  return dashboardListings;
 }

--- a/web-admin/src/components/projects/invalidations.ts
+++ b/web-admin/src/components/projects/invalidations.ts
@@ -1,7 +1,7 @@
 import { invalidationForMetricsViewData } from "@rilldata/web-local/lib/svelte-query/invalidation";
 import type { QueryClient } from "@tanstack/svelte-query";
 
-export async function invalidateProjectQueries(
+export async function invalidateDashboardsQueries(
   queryClient: QueryClient,
   dashboardNames: Array<string>
 ) {

--- a/web-admin/src/routes/[organization]/[project]/[dashboard]/+page.svelte
+++ b/web-admin/src/routes/[organization]/[project]/[dashboard]/+page.svelte
@@ -11,6 +11,8 @@
   import {
     createRuntimeServiceListCatalogEntries,
     createRuntimeServiceListFiles,
+    getRuntimeServiceListCatalogEntriesQueryKey,
+    getRuntimeServiceListFilesQueryKey,
   } from "@rilldata/web-common/runtime-client";
   import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
   import { useQueryClient } from "@tanstack/svelte-query";
@@ -43,6 +45,18 @@
 
     if (projectWasNotOk && isProjectOK) {
       getDashboardsAndInvalidate();
+
+      // Invalidate the queries used to assess dashboard validity
+      queryClient.invalidateQueries(
+        getRuntimeServiceListFilesQueryKey($runtime?.instanceId, {
+          glob: "dashboards/*.yaml",
+        })
+      );
+      queryClient.invalidateQueries(
+        getRuntimeServiceListCatalogEntriesQueryKey($runtime?.instanceId, {
+          type: "OBJECT_TYPE_METRICS_VIEW",
+        })
+      );
     }
   }
 

--- a/web-admin/src/routes/[organization]/[project]/[dashboard]/+page.svelte
+++ b/web-admin/src/routes/[organization]/[project]/[dashboard]/+page.svelte
@@ -1,24 +1,32 @@
 <script lang="ts">
   import { page } from "$app/stores";
   import { V1DeploymentStatus } from "@rilldata/web-admin/client";
-  import { getDashboardsForProject } from "@rilldata/web-admin/components/projects/dashboards";
+  import {
+    getDashboardListItemsFromFilesAndCatalogEntries,
+    getDashboardsForProject,
+  } from "@rilldata/web-admin/components/projects/dashboards";
   import { invalidateProjectQueries } from "@rilldata/web-admin/components/projects/invalidations";
   import { useProject } from "@rilldata/web-admin/components/projects/use-project";
   import { Dashboard } from "@rilldata/web-common/features/dashboards";
+  import {
+    createRuntimeServiceListCatalogEntries,
+    createRuntimeServiceListFiles,
+  } from "@rilldata/web-common/runtime-client";
+  import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
   import { useQueryClient } from "@tanstack/svelte-query";
   import ProjectBuilding from "../../../../components/projects/ProjectBuilding.svelte";
   import ProjectErrored from "../../../../components/projects/ProjectErrored.svelte";
 
   const queryClient = useQueryClient();
 
-  $: org = $page.params.organization;
-  $: proj = $page.params.project;
-  $: dash = $page.params.dashboard;
+  $: orgName = $page.params.organization;
+  $: projectName = $page.params.project;
+  $: dashboardName = $page.params.dashboard;
+
   // Poll for project status
-  $: project = useProject(org, proj);
+  $: project = useProject(orgName, projectName);
 
   let isProjectBuilding: boolean;
-  let isProjectErrored: boolean;
   let isProjectOK: boolean;
 
   $: if ($project.data?.prodDeployment?.status) {
@@ -29,9 +37,6 @@
         V1DeploymentStatus.DEPLOYMENT_STATUS_PENDING ||
       $project.data?.prodDeployment?.status ===
         V1DeploymentStatus.DEPLOYMENT_STATUS_RECONCILING;
-    isProjectErrored =
-      $project.data?.prodDeployment?.status ===
-      V1DeploymentStatus.DEPLOYMENT_STATUS_ERROR;
     isProjectOK =
       $project.data?.prodDeployment?.status ===
       V1DeploymentStatus.DEPLOYMENT_STATUS_OK;
@@ -42,21 +47,60 @@
   }
 
   async function getDashboardsAndInvalidate() {
-    return invalidateProjectQueries(
-      queryClient,
-      await getDashboardsForProject($project.data)
-    );
+    const dashboardListings = await getDashboardsForProject($project.data);
+    const dashboardNames = dashboardListings.map((listing) => listing.name);
+    return invalidateProjectQueries(queryClient, dashboardNames);
   }
+
+  // Here we check to see if a dashboard is valid by looking at `DashboardListItem.isValid`
+  // As is the case in `Breadcrumbs.svelte`, there are two queries we compose to get the dashboard list items,
+  // and we should hide this complexity in a custom hook.
+  // We avoid calling `GetCatalogEntry` to check for dashboard validity because that would trigger a 404 page.
+  $: dashboardFiles = createRuntimeServiceListFiles(
+    $runtime?.instanceId,
+    {
+      glob: "dashboards/*.yaml",
+    },
+    {
+      query: {
+        placeholderData: undefined,
+        enabled: !!project && !!$runtime?.instanceId,
+      },
+    }
+  );
+  $: dashboardCatalogEntries = createRuntimeServiceListCatalogEntries(
+    $runtime?.instanceId,
+    {
+      type: "OBJECT_TYPE_METRICS_VIEW",
+    },
+    {
+      query: {
+        placeholderData: undefined,
+        enabled: !!project && !!$runtime?.instanceId,
+      },
+    }
+  );
+  $: dashboardListItems = getDashboardListItemsFromFilesAndCatalogEntries(
+    $dashboardFiles.data?.paths,
+    $dashboardCatalogEntries.data?.entries
+  );
+  $: currentDashboard = dashboardListItems?.find(
+    (listing) => listing.name === $page.params.dashboard
+  );
 </script>
 
 <svelte:head>
-  <title>{dash} - Rill</title>
+  <title>{dashboardName} - Rill</title>
 </svelte:head>
 
 {#if isProjectBuilding}
-  <ProjectBuilding organization={org} project={proj} />
-{:else if isProjectErrored}
-  <ProjectErrored organization={org} project={proj} />
-{:else if isProjectOK}
-  <Dashboard leftMargin={"48px"} hasTitle={false} metricViewName={dash} />
+  <ProjectBuilding organization={orgName} project={projectName} />
+{:else if !currentDashboard?.isValid}
+  <ProjectErrored organization={orgName} project={projectName} />
+{:else}
+  <Dashboard
+    leftMargin={"48px"}
+    hasTitle={false}
+    metricViewName={dashboardName}
+  />
 {/if}

--- a/web-admin/src/routes/[organization]/[project]/[dashboard]/+page.svelte
+++ b/web-admin/src/routes/[organization]/[project]/[dashboard]/+page.svelte
@@ -5,7 +5,7 @@
     getDashboardListItemsFromFilesAndCatalogEntries,
     getDashboardsForProject,
   } from "@rilldata/web-admin/components/projects/dashboards";
-  import { invalidateProjectQueries } from "@rilldata/web-admin/components/projects/invalidations";
+  import { invalidateDashboardsQueries } from "@rilldata/web-admin/components/projects/invalidations";
   import { useProject } from "@rilldata/web-admin/components/projects/use-project";
   import { Dashboard } from "@rilldata/web-common/features/dashboards";
   import {
@@ -49,7 +49,7 @@
   async function getDashboardsAndInvalidate() {
     const dashboardListings = await getDashboardsForProject($project.data);
     const dashboardNames = dashboardListings.map((listing) => listing.name);
-    return invalidateProjectQueries(queryClient, dashboardNames);
+    return invalidateDashboardsQueries(queryClient, dashboardNames);
   }
 
   // Here we check to see if a dashboard is valid by looking at `DashboardListItem.isValid`


### PR DESCRIPTION
This PR:
- Includes invalid dashboards in listings (home page, project page, breadcrumbs)
- Allows for navigation to valid dashboards in errored projects

To compose the list of valid & invalid dashboards, we have to synthesize the results from two different runtime queries. Currently, the Tanstack Query code is verbose. We should figure out how to make custom hooks from custom hooks, and that'll clean it up.

Aesthetics can probably be improved, but that can be a follow-on item.

Contributes to #2109.