### PR TITLE
Fixing home page list getting cut off

### DIFF
--- a/web-admin/src/components/home/OrganizationList.svelte
+++ b/web-admin/src/components/home/OrganizationList.svelte
@@ -15,3 +15,9 @@
     {/each}
   </ol>
 {/if}
+
+<style>
+  ol:last-child {
+    margin-bottom: auto;
+  }
+</style>

--- a/web-admin/src/routes/+layout.svelte
+++ b/web-admin/src/routes/+layout.svelte
@@ -35,15 +35,15 @@
 </script>
 
 <svelte:head>
-  <meta name="description" content="Rill Cloud" />
+  <meta content="Rill Cloud" name="description" />
 </svelte:head>
 
 <RillTheme>
   <QueryClientProvider client={queryClient}>
     <div class="flex flex-col h-screen">
-      <main class="flex-grow flex flex-col">
+      <main class="flex-grow flex flex-col h-full">
         <TopNavigationBar />
-        <div class="flex-grow overflow-auto">
+        <div class="flex-grow overflow-auto h-full">
           <ErrorBoundary>
             <slot />
           </ErrorBoundary>

--- a/web-admin/src/routes/+page.svelte
+++ b/web-admin/src/routes/+page.svelte
@@ -21,8 +21,8 @@
 </svelte:head>
 
 <AuthRedirect>
-  <section class="flex flex-col justify-center w-4/5 mx-auto h-2/5">
-    <h1 class="text-4xl leading-10 font-light mb-2">
+  <section class="flex flex-col w-4/5 mx-auto h-2/5">
+    <h1 class="text-4xl leading-10 font-light mb-2 my-auto">
       Hi {$user.data.user.displayName}!
     </h1>
     {#if $orgs.isSuccess}


### PR DESCRIPTION
Using justify-center can break scrolling and make some parts inaccessible while using flex. instead using margin auto to achieve similar behaviour.

Ref: https://bhch.github.io/posts/2021/04/centring-flex-items-and-allowing-overflow-scroll/