### PR TITLE
Format logs page

### DIFF
--- a/web-admin/src/components/projects/ProjectDeploymentLogs.svelte
+++ b/web-admin/src/components/projects/ProjectDeploymentLogs.svelte
@@ -5,6 +5,8 @@
   export let project: string;
 
   $: proj = createAdminServiceGetProject(organization, project);
+  $: hasAdminAccess = $proj.data?.projectPermissions?.manageProject;
+
   $: errors = parseLogs($proj.data?.prodDeployment?.logs);
 
   interface Error {
@@ -23,7 +25,11 @@
 
 {#if $proj.isSuccess && errors}
   <ul class="w-full">
-    {#if errors.length === 0}
+    {#if !hasAdminAccess}
+      <li class="px-12 py-2 font-semibold text-gray-500 border-b">
+        You don't have permission to view project logs
+      </li>
+    {:else if errors.length === 0}
       <li class="px-12 py-2 font-semibold text-gray-500 border-b">
         No logs present
       </li>

--- a/web-admin/src/components/projects/ProjectDeploymentLogs.svelte
+++ b/web-admin/src/components/projects/ProjectDeploymentLogs.svelte
@@ -22,16 +22,18 @@
 </script>
 
 {#if $proj.isSuccess && errors}
-  {#if errors.length === 0}
-    <p class="text-gray-500 my-6">No logs available.</p>
-  {:else}
-    <!-- logs count -->
-    <div class="w-full px-12 py-3 border-b border-gray-200 font-semibold">
-      <span class="text-red-600">{errors.length} </span>
-      <span class="text-gray-800"> error(s)</span>
-    </div>
-    <!-- logs -->
-    <ul class="w-full">
+  <ul class="w-full">
+    {#if errors.length === 0}
+      <li class="px-12 py-2 font-semibold text-gray-500 border-b">
+        No logs present
+      </li>
+    {:else}
+      <!-- logs -->
+      <li class="px-12 py-2 font-semibold text-gray-800 border-b">
+        This project has
+        <span class="text-red-600">{errors.length} </span>
+        {errors.length === 1 ? "error" : "errors"}
+      </li>
       {#each errors as error}
         <li
           class="flex gap-x-5 justify-between py-1 px-12 border-b border-gray-200 bg-red-50 font-mono"
@@ -44,6 +46,6 @@
           </span>
         </li>
       {/each}
-    </ul>
-  {/if}
+    {/if}
+  </ul>
 {/if}


### PR DESCRIPTION
- Format logs page to match the mocks
- Add a copy for non admin roles

Couple of questions @ericpgreen2 
- In the mocks it says the copy for viewer should be - "This project has 11 errors. Ask your organization’s admin for help resolving these." But the `logs` key is empty for the viewer. Is there a may to retrieve the number of log errors?

- For checking if the user has permission to view logs I am using the `manageProject` permission, although I saw that there were various other permissions as well. Not sure if `manageProject` is the right one or I should use `readProdStatus` here. 