### PR TITLE
Adding empty url for default dashboard

### DIFF
--- a/web-common/src/features/dashboards/proto-state/StateSyncManager.ts
+++ b/web-common/src/features/dashboards/proto-state/StateSyncManager.ts
@@ -18,7 +18,11 @@ export class StateSyncManager {
 
     // if state didn't change do not call goto. this avoids adding unnecessary urls to history stack
     if (this.protoState !== this.urlState) {
-      goto(`${pageUrl.pathname}?state=${this.protoState}`);
+      if (this.protoState === metricsExplorer.defaultProto) {
+        goto(`${pageUrl.pathname}`);
+      } else {
+        goto(`${pageUrl.pathname}?state=${this.protoState}`);
+      }
       this.updating = true;
     }
   }

--- a/web-common/src/features/dashboards/time-controls/TimeControls.svelte
+++ b/web-common/src/features/dashboards/time-controls/TimeControls.svelte
@@ -4,12 +4,14 @@
     useModelAllTimeRange,
     useModelHasTimeSeries,
   } from "@rilldata/web-common/features/dashboards/selectors";
-  import { TIME_GRAIN } from "@rilldata/web-common/lib/time//config";
   import {
     getAvailableComparisonsForTimeRange,
     getComparisonRange,
   } from "@rilldata/web-common/lib/time/comparisons";
-  import { DEFAULT_TIME_RANGES } from "@rilldata/web-common/lib/time/config";
+  import {
+    DEFAULT_TIME_RANGES,
+    TIME_GRAIN,
+  } from "@rilldata/web-common/lib/time/config";
   import {
     checkValidTimeGrain,
     getDefaultTimeGrain,
@@ -114,9 +116,12 @@
 
     /** enable comparisons by default */
     metricsExplorerStore.toggleComparison(metricViewName, true);
+    metricsExplorerStore.allDefaultsSelected(metricViewName);
   }
 
   function setTimeControlsFromUrl(allTimeRange: TimeRange) {
+    metricsExplorerStore.allDefaultsSelected(metricViewName);
+
     if ($dashboardStore?.selectedTimeRange.name === TimeRangePreset.CUSTOM) {
       /** set the time range to the fixed custom time range */
       baseTimeRange = {
@@ -137,7 +142,7 @@
     makeTimeSeriesTimeRangeAndUpdateAppState(
       baseTimeRange,
       $dashboardStore?.selectedTimeRange.interval,
-      // do not reset the comparison state when pullling from the URL
+      // do not reset the comparison state when pulling from the URL
       $dashboardStore?.selectedComparisonTimeRange
     );
   }


### PR DESCRIPTION
If starting from a blank filters in a dashboard the default state will not populate the url state.

But if starting from a url then we cannot get the default state right now. We need to do a refactor of time controls to get the default state in one place and address this in a later PR.

Further changes handled in #2285