### PR TITLE
Add docs for S3 and GCS service accounts

### DIFF
--- a/cli/cmd/env/configure.go
+++ b/cli/cmd/env/configure.go
@@ -134,7 +134,11 @@ func VariablesFlow(ctx context.Context, projectPath string, tel *telemetry.Telem
 		}
 		connectorVariables := c.Spec.ConnectorVariables
 		if len(connectorVariables) != 0 {
-			fmt.Printf("\nConnector %s requires credentials\n\n", c.Type)
+			fmt.Printf("\nConnector %q requires credentials.\n", c.Type)
+			if c.Spec.ServiceAccountDocs != "" {
+				fmt.Printf("For instructions on how to create a service account, see: %s\n", c.Spec.ServiceAccountDocs)
+			}
+			fmt.Printf("\n")
 		}
 		if c.Spec.Help != "" {
 			fmt.Println(c.Spec.Help)

--- a/docs/docs/connectors/_category_.yml
+++ b/docs/docs/connectors/_category_.yml
@@ -1,0 +1,4 @@
+position: 29
+label: Connectors
+collapsible: true
+collapsed: false

--- a/docs/docs/connectors/gcs.md
+++ b/docs/docs/connectors/gcs.md
@@ -1,0 +1,59 @@
+---
+title: Google Cloud Storage (GCS)
+description: Create a Google Cloud service account for connecting to a GCS bucket from Rill Cloud
+sidebar_label: GCS
+sidebar_position: 20
+---
+
+## Create a service account
+
+Follow the steps below to create a Google Cloud service account for connecting to a GCS bucket from Rill Cloud.
+
+### Using the Google Cloud Console
+
+Here is a step-by-step guide on how to create a Google Cloud service account with read-only access to GCS:
+
+1. Navigate to the [Service Accounts page](https://console.cloud.google.com/iam-admin/serviceaccounts) under "IAM & Admin" in the Google Cloud Console.
+
+2. Click the "Create Service Account" button at the top of the page.
+
+3. In the "Create Service Account" window, enter a name for the service account, then click "Create and continue".
+
+4. In the "Role" field, search for and select the "Storage Object Viewer" role. Click "Continue", then click "Done".
+
+5. On the "Service Accounts" page, locate the service account you just created and click on the three dots on the right-hand side. Select "Manage Keys" from the dropdown menu.
+
+6. On the "Keys" page, click the "Add key" button and select "Create new key".
+
+7. Choose the "JSON" key type and click "Create".
+
+8. Download and save the JSON key file to a secure location on your computer.
+
+### Using the `gcloud` CLI
+
+1. Open a terminal window. [Install and initialize the Google Cloud CLI](https://cloud.google.com/sdk/docs/install-sdk) if you haven't already done so.
+
+2. You will need your Google Cloud project ID to complete this tutorial. Run the following command to show it:
+```bash
+gcloud config get project
+```
+
+3. Replace `[PROJECT_ID]` with your project ID in the following command, and run it to create a new service account (optionally also replace `rill-service-account` with a name of your choice):
+```bash
+gcloud iam service-accounts create rill-service-account --project [PROJECT_ID]
+```
+
+3. Replace `[PROJECT_ID]` with your project ID in the following command, and run it to grant the "Storage Object Viewer" role to the service account:
+```bash
+gcloud projects add-iam-policy-binding [PROJECT_ID] \
+    --member="serviceAccount:rill-service-account@[PROJECT_ID].iam.gserviceaccount.com" \
+    --role="roles/storage.objectViewer"
+```
+
+4. Replace `[PROJECT_ID]` with your project ID in the following command, and run it to create a key file for the service account:
+```bash
+gcloud iam service-accounts keys create rill-service-account.json \
+    --iam-account rill-service-account@[PROJECT_ID].iam.gserviceaccount.com
+```
+
+5. You have now created a JSON key file named `rill-service-account.json` in your current working directory.

--- a/docs/docs/connectors/s3.md
+++ b/docs/docs/connectors/s3.md
@@ -1,0 +1,60 @@
+---
+title: Amazon S3
+description: Create an AWS service account for connecting to an S3 bucket from Rill Cloud
+sidebar_label: S3
+sidebar_position: 10
+---
+
+## Create a service account
+
+Follow the steps below to create an AWS service account for connecting to an S3 bucket from Rill Cloud.
+
+### Using the AWS Management Console
+
+Here is a step-by-step guide on how to create an AWS service account with read-only access to S3:
+
+1. Log in to the AWS Management Console and navigate to the [IAM dashboard](https://console.aws.amazon.com/iam).
+
+2. In the sidebar, select "Users" and click the "Add users" button.
+
+3. Enter a username for the service account and click "Next".
+
+4. Select "Attach existing policies directly" and search for the "AmazonS3ReadOnlyAccess" policy. Check the box next to the policy to select it and click "Next". Then, under "Set permissions boundaries and tags", click the "Create user" button.
+
+5. On the "Users" page, navigate to the newly created user and go to the "Security credentials" tab.
+
+7. Under the "Access keys" section, click "Create access key".
+
+8. On the "Access key best practices & alternatives" screen, select "Third-party service", confirm the checkbox, and click "Next".
+
+9. On the "Set description tag" screen, optionally enter a description, and click "Create access key".
+
+10. Note down the "Access key" and "Secret access key" values for the service account. (Hint: Click the ❐ icon next to the secrets to copy them to the clipboard.)
+
+### Using the `aws` CLI
+
+Here is a step-by-step guide on how to create an AWS service account with read-only access to S3 using the AWS CLI:
+
+1. Open a terminal window and [install the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) if it is not already installed on your system.
+
+2. Run the following command to create a new user for your service account (optionally replace `rill-service-account` with a name of your choice):
+```bash
+aws iam create-user --no-cli-pager --user-name rill-service-account
+```
+
+3. Run the following command to attach the `AmazonS3ReadOnlyAccess` policy to the user:
+
+```bash
+aws iam attach-user-policy \
+    --policy-arn arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess \
+    --user-name rill-service-account
+```
+
+4. Run the following command to create an access key pair for the user:
+
+```bash
+aws iam create-access-key --user-name rill-service-account
+```
+
+5. Note down the `AccessKeyId` and `SecretAccessKey` values in the returned JSON object. Click "q" to exit the page.
+

--- a/runtime/connectors/connectors.go
+++ b/runtime/connectors/connectors.go
@@ -39,6 +39,7 @@ type Connector interface {
 type Spec struct {
 	DisplayName        string
 	Description        string
+	ServiceAccountDocs string
 	Properties         []PropertySchema
 	ConnectorVariables []VariableSchema
 	Help               string

--- a/runtime/connectors/gcs/gcs.go
+++ b/runtime/connectors/gcs/gcs.go
@@ -24,8 +24,9 @@ func init() {
 var errNoCredentials = errors.New("empty credentials: set `google_application_credentials` env variable")
 
 var spec = connectors.Spec{
-	DisplayName: "Google Cloud Storage",
-	Description: "Connect to Google Cloud Storage.",
+	DisplayName:        "Google Cloud Storage",
+	Description:        "Connect to Google Cloud Storage.",
+	ServiceAccountDocs: "https://docs.rilldata.com/connectors/gcs",
 	Properties: []connectors.PropertySchema{
 		{
 			Key:         "path",

--- a/runtime/connectors/s3/s3.go
+++ b/runtime/connectors/s3/s3.go
@@ -24,8 +24,9 @@ func init() {
 }
 
 var spec = connectors.Spec{
-	DisplayName: "Amazon S3",
-	Description: "Connect to AWS S3 Storage.",
+	DisplayName:        "Amazon S3",
+	Description:        "Connect to AWS S3 Storage.",
+	ServiceAccountDocs: "https://docs.rilldata.com/connectors/s3",
 	Properties: []connectors.PropertySchema{
 		{
 			Key:         "path",


### PR DESCRIPTION
Initially putting the connector service account docs on `docs.rilldata.com/connectors/NAME` until we've decided how we'll structure the docs for local vs. cloud use cases.