### PR TITLE
Improve "Deploy" button dialog

### DIFF
--- a/web-common/src/features/dashboards/workspace/DashboardHeader.svelte
+++ b/web-common/src/features/dashboards/workspace/DashboardHeader.svelte
@@ -82,8 +82,7 @@
           <Tooltip distance={8}>
             <Button on:click={deployModal} type="primary">Deploy</Button>
             <TooltipContent slot="tooltip-content">
-              Schedule time to chat with Rill about early access to hosted
-              dashboards.
+              Deploy this dashboard to Rill Cloud
             </TooltipContent>
           </Tooltip>
         </PanelCTA>

--- a/web-common/src/features/dashboards/workspace/DeployDashboardOverlay.svelte
+++ b/web-common/src/features/dashboards/workspace/DeployDashboardOverlay.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
   import Dialog from "@rilldata/web-common/components/modal/dialog/Dialog.svelte";
   import { projectShareStore } from "@rilldata/web-common/features/dashboards/dashboard-stores";
+  import Button from "../../../components/button/Button.svelte";
+  import CliCommandDisplay from "../../../components/commands/CLICommandDisplay.svelte";
+  import DialogFooter from "../../../components/modal/dialog/DialogFooter.svelte";
 
   function close() {
     projectShareStore.set(false);
@@ -8,9 +11,19 @@
 </script>
 
 <Dialog on:cancel={close} size="md">
-  <div class="" slot="body">
-    <div class="text-center text-2xl p-6">
-      Please use the CLI to deploy your project by running `rill deploy`
+  <svelte:fragment slot="title">Deploy your project</svelte:fragment>
+  <div class="flex flex-col items-center gap-y-4" slot="body">
+    <div class="text-left text-sm text-gray-500 w-full">
+      Run this command in the Rill CLI to deploy this project. <a
+        href="https://docs.rilldata.com"
+        target="_blank"
+        rel="noreferrer">See docs</a
+      >
     </div>
+    <CliCommandDisplay command="rill deploy" />
   </div>
+  <svelte:fragment slot="secondary-action-body">Close</svelte:fragment>
+  <DialogFooter slot="footer">
+    <Button type="secondary" on:click={close}>Close</Button>
+  </DialogFooter>
 </Dialog>

--- a/web-common/src/features/dashboards/workspace/DeployDashboardOverlay.svelte
+++ b/web-common/src/features/dashboards/workspace/DeployDashboardOverlay.svelte
@@ -14,7 +14,7 @@
   <svelte:fragment slot="title">Deploy your project</svelte:fragment>
   <div class="flex flex-col items-center gap-y-4" slot="body">
     <div class="text-left text-sm text-gray-500 w-full">
-      Run this command in the Rill CLI to deploy this project. <a
+      Run this command in the Rill CLI to deploy this project to Rill Cloud. <a
         href="https://docs.rilldata.com"
         target="_blank"
         rel="noreferrer">See docs</a


### PR DESCRIPTION
This PR gets the deploy button in Rill Developer closer to the Figma mocks.

It doesn't match the mocks exactly because it's using our current `Dialog` component out-of-the-box. Redesigning our `Dialog` component can be a project for a different day.

Contributes to #2109.