### PR TITLE
common error handling fix

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/rilldata/rill/cli/cmd/admin"
 	"github.com/rilldata/rill/cli/cmd/auth"
@@ -46,26 +46,23 @@ var rootCmd = &cobra.Command{
 func Execute(ctx context.Context, ver config.Version) {
 	err := runCmd(ctx, ver)
 	if err != nil {
-		if s, ok := rpcStatus(err); ok {
-			// try to see if it is a known message
-			switch s.Message() {
-			case "org not found":
-				// handle various cases like passed via flag, taken from default etc to print better error messages ??
-				fmt.Println("Org not found. Run `rill org list` to see the orgs. Run `rill org switch` to default org.")
-			case "proj not found":
-				fmt.Println("Project not found. Run `rill project list` to check the list of projects.")
-			case "auth token not found":
-				fmt.Println("Auth token is invalid/expired. Run `rill logout` and login again with `rill login`.")
-			case "not authenticated as a user":
-				fmt.Println("Please log in or sign up for Rill with `rill login`.")
-			default:
-				// no known message
-				// printing the full error message so that wrapped context is not lost
-				// todo :: add trace id as well
-				fmt.Printf("Error: %s (%v)\n", err, s.Code())
-			}
+		errMsg := err.Error()
+		// check for known messages
+		if strings.Contains(errMsg, "org not found") {
+			fmt.Println("Org not found. Run `rill org list` to see the orgs. Run `rill org switch` to default org.")
+		} else if strings.Contains(errMsg, "project not found") {
+			fmt.Println("Project not found. Run `rill project list` to check the list of projects.")
+		} else if strings.Contains(errMsg, "auth token not found") {
+			fmt.Println("Auth token is invalid/expired. Run `rill logout` and login again with `rill login`.")
+		} else if strings.Contains(errMsg, "not authenticated as a user") {
+			fmt.Println("Please log in or sign up for Rill with `rill login`.")
 		} else {
-			fmt.Printf("Error: %s\n", err.Error())
+			if s, ok := status.FromError(err); ok {
+				// rpc error
+				fmt.Printf("Error: %s (%v)\n", s.Message(), s.Code())
+			} else {
+				fmt.Printf("Error: %s\n", err.Error())
+			}
 		}
 		os.Exit(1)
 	}
@@ -151,18 +148,4 @@ func runCmd(ctx context.Context, ver config.Version) error {
 		rootCmd.AddCommand(cmd)
 	}
 	return rootCmd.ExecuteContext(ctx)
-}
-
-func rpcStatus(err error) (*status.Status, bool) {
-	for {
-		st, ok := status.FromError(err)
-		if st == nil {
-			// returns nil when err is nil
-			return nil, false
-		}
-		if ok {
-			return st, true
-		}
-		err = errors.Unwrap(err)
-	}
 }

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -60,8 +60,9 @@ func Execute(ctx context.Context, ver config.Version) {
 				fmt.Println("Please log in or sign up for Rill with `rill login`.")
 			default:
 				// no known message
+				// printing the full error message so that wrapped context is not lost
 				// todo :: add trace id as well
-				fmt.Printf("Error: %s (%v)\n", s.Message(), s.Code())
+				fmt.Printf("Error: %s (%v)\n", err, s.Code())
 			}
 		} else {
 			fmt.Printf("Error: %s\n", err.Error())


### PR DESCRIPTION
`status.FromError(err)` doesn't work for wrapped errors. We are wrapping rpc errors in lot of places.