### PR TITLE
Fix 400 error in dashboards without a time series

### DIFF
--- a/web-common/src/features/dashboards/dimension-table/DimensionDisplay.svelte
+++ b/web-common/src/features/dashboards/dimension-table/DimensionDisplay.svelte
@@ -151,7 +151,12 @@
     allTimeRangeQuery = useModelAllTimeRange(
       $runtime.instanceId,
       $metaQuery.data.model,
-      $metaQuery.data.timeDimension
+      $metaQuery.data.timeDimension,
+      {
+        query: {
+          enabled: !!$metaQuery.data.timeDimension,
+        },
+      }
     );
   }
 

--- a/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
+++ b/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
@@ -59,7 +59,12 @@
   $: allTimeRangeQuery = useModelAllTimeRange(
     $runtime.instanceId,
     $metaQuery.data.model,
-    $metaQuery.data.timeDimension
+    $metaQuery.data.timeDimension,
+    {
+      query: {
+        enabled: !!$metaQuery.data.timeDimension,
+      },
+    }
   );
   $: allTimeRange = $allTimeRangeQuery?.data;
 

--- a/web-common/src/features/dashboards/selectors.ts
+++ b/web-common/src/features/dashboards/selectors.ts
@@ -1,14 +1,17 @@
 import { TimeRangePreset } from "@rilldata/web-common/lib/time/types";
 import {
   RpcStatus,
+  V1MetricsView,
+  V1MetricsViewFilter,
   createQueryServiceColumnTimeRange,
   createRuntimeServiceGetCatalogEntry,
   createRuntimeServiceListCatalogEntries,
   createRuntimeServiceListFiles,
-  V1MetricsView,
-  V1MetricsViewFilter,
 } from "@rilldata/web-common/runtime-client";
-import type { QueryObserverResult } from "@tanstack/svelte-query";
+import type {
+  CreateQueryOptions,
+  QueryObserverResult,
+} from "@tanstack/svelte-query";
 
 export function useDashboardNames(instanceId: string) {
   return createRuntimeServiceListFiles(
@@ -139,8 +142,13 @@ export const useModelHasTimeSeries = (
 export function useModelAllTimeRange(
   instanceId: string,
   modelName: string,
-  timeDimension: string
+  timeDimension: string,
+  options?: {
+    query?: CreateQueryOptions;
+  }
 ) {
+  const { query: queryOptions } = options ?? {};
+
   return createQueryServiceColumnTimeRange(
     instanceId,
     modelName,
@@ -158,6 +166,7 @@ export function useModelAllTimeRange(
             end: new Date(data.timeRangeSummary.max),
           };
         },
+        ...queryOptions,
       },
     }
   );

--- a/web-common/src/features/dashboards/time-controls/TimeControls.svelte
+++ b/web-common/src/features/dashboards/time-controls/TimeControls.svelte
@@ -76,7 +76,12 @@
     allTimeRangeQuery = useModelAllTimeRange(
       $runtime.instanceId,
       $metricsViewQuery.data.entry.metricsView.model,
-      $metricsViewQuery.data.entry.metricsView.timeDimension
+      $metricsViewQuery.data.entry.metricsView.timeDimension,
+      {
+        query: {
+          enabled: !!hasTimeSeries,
+        },
+      }
     );
     defaultTimeRange = ISODurationToTimePreset(
       $metricsViewQuery.data.entry.metricsView?.defaultTimeRange

--- a/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
+++ b/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
@@ -13,10 +13,10 @@
     nicelyFormattedTypesToNumberKind,
   } from "@rilldata/web-common/features/dashboards/humanize-numbers";
   import {
-    useMetaQuery,
-    useModelAllTimeRange,
     selectBestMeasureStrings,
     selectMeasureKeys,
+    useMetaQuery,
+    useModelAllTimeRange,
   } from "@rilldata/web-common/features/dashboards/selectors";
   import { EntityStatus } from "@rilldata/web-common/features/entity-management/types";
   import { removeTimezoneOffset } from "@rilldata/web-common/lib/formatters";
@@ -55,7 +55,12 @@
   $: allTimeRangeQuery = useModelAllTimeRange(
     $runtime.instanceId,
     $metaQuery.data.model,
-    $metaQuery.data.timeDimension
+    $metaQuery.data.timeDimension,
+    {
+      query: {
+        enabled: !!$metaQuery.data.timeDimension,
+      },
+    }
   );
 
   // get the time range name, which is the preset.


### PR DESCRIPTION
This PR fixes the 400 error that's triggered when a dashboard calls the Query Service's `time-range-summary` endpoint when a time series is *not* present.

Because fetching and constructing a model's "all time range" is a common operation, we've created a custom selector hook `useModelAllTimeRange` to contain the transformation logic. To this custom selector hook, I've added the ability to pass TanStack query options (such as the `enabled` flag for dependent queries). I've mirrored the pattern that Orval uses in its generated hooks.

Contributes to #2109.