### PR TITLE
UI: Fix error handling of non-existent orgs and projects

### DIFF
--- a/web-admin/src/components/errors/error-utils.ts
+++ b/web-admin/src/components/errors/error-utils.ts
@@ -2,7 +2,7 @@ import { goto } from "$app/navigation";
 import type { AxiosError } from "axios";
 import type { RpcStatus } from "../../client";
 import { ADMIN_URL } from "../../client/http-client";
-import { ErrorStoreState, errorStore, isErrorStoreEmpty } from "./error-store";
+import { ErrorStoreState, errorStore } from "./error-store";
 
 export function globalErrorCallback(error: AxiosError): void {
   // If Unauthorized, redirect to login page
@@ -14,11 +14,7 @@ export function globalErrorCallback(error: AxiosError): void {
   // Create a pretty message for the error page
   const errorStoreState = createErrorStoreStateFromAxiosError(error);
 
-  // Sometimes there are multiple errors in one page load. When one of them is a 404, we
-  // prioritize it by overwriting whatever error was already in the store.
-  if (isErrorStoreEmpty || errorStoreState.statusCode === 404) {
-    errorStore.set(errorStoreState);
-  }
+  errorStore.set(errorStoreState);
 }
 
 function createErrorStoreStateFromAxiosError(

--- a/web-admin/src/components/errors/error-utils.ts
+++ b/web-admin/src/components/errors/error-utils.ts
@@ -36,7 +36,7 @@ function createErrorStoreStateFromAxiosError(
       header: "Organization not found",
       body: "The organization you requested could not be found. Please check that you have provided a valid organization name.",
     };
-  } else if (msg === "proj not found") {
+  } else if (msg === "project not found") {
     return {
       statusCode: error.response.status,
       header: "Project not found",

--- a/web-admin/src/components/navigation/Breadcrumbs.svelte
+++ b/web-admin/src/components/navigation/Breadcrumbs.svelte
@@ -8,6 +8,7 @@
   import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
   import {
     createAdminServiceGetCurrentUser,
+    createAdminServiceGetOrganization,
     createAdminServiceListOrganizations,
     createAdminServiceListProjectsForOrganization,
   } from "../../client";
@@ -17,7 +18,8 @@
 
   const user = createAdminServiceGetCurrentUser();
 
-  $: organization = $page.params.organization;
+  $: orgName = $page.params.organization;
+  $: organization = createAdminServiceGetOrganization(orgName);
   $: organizations = createAdminServiceListOrganizations(undefined, {
     query: {
       enabled: !!$user.data.user,
@@ -25,8 +27,16 @@
   });
   $: isOrganizationPage = $page.route.id === "/[organization]";
 
-  $: project = $page.params.project;
-  $: projects = createAdminServiceListProjectsForOrganization(organization);
+  $: projectName = $page.params.project;
+  $: projects = createAdminServiceListProjectsForOrganization(
+    orgName,
+    undefined,
+    {
+      query: {
+        enabled: !!$organization.data.organization,
+      },
+    }
+  );
   $: isProjectPage = $page.route.id === "/[organization]/[project]";
 
   // Here, we compose the dashboard list via two separate runtime queries.
@@ -38,7 +48,7 @@
     },
     {
       query: {
-        enabled: !!project && !!$runtime?.instanceId,
+        enabled: !!projectName && !!$runtime?.instanceId,
       },
     }
   );
@@ -50,7 +60,7 @@
     {
       query: {
         placeholderData: undefined,
-        enabled: !!project && !!$runtime?.instanceId,
+        enabled: !!projectName && !!$runtime?.instanceId,
       },
     }
   );
@@ -67,9 +77,9 @@
 
 <nav>
   <ol class="flex flex-row items-center">
-    {#if organization}
+    {#if $organization.data.organization}
       <BreadcrumbItem
-        label={organization}
+        label={orgName}
         isCurrentPage={isOrganizationPage}
         menuOptions={$organizations.data?.organizations?.length > 1 &&
           $organizations.data.organizations.map((org) => ({
@@ -77,25 +87,25 @@
             main: org.name,
             callback: () => goto(`/${org.name}`),
           }))}
-        menuKey={organization}
+        menuKey={orgName}
         onSelectMenuOption={(organization) => goto(`/${organization}`)}
       >
-        <OrganizationAvatar {organization} slot="icon" />
+        <OrganizationAvatar organization={orgName} slot="icon" />
       </BreadcrumbItem>
     {/if}
-    {#if project}
+    {#if projectName}
       <span class="text-gray-600">/</span>
       <BreadcrumbItem
-        label={project}
+        label={projectName}
         isCurrentPage={isProjectPage}
         menuOptions={$projects.data?.projects?.length > 1 &&
           $projects.data.projects.map((proj) => ({
             key: proj.name,
             main: proj.name,
-            callback: () => goto(`/${organization}/${proj.name}`),
+            callback: () => goto(`/${orgName}/${proj.name}`),
           }))}
-        menuKey={project}
-        onSelectMenuOption={(project) => goto(`/${organization}/${project}`)}
+        menuKey={projectName}
+        onSelectMenuOption={(project) => goto(`/${orgName}/${project}`)}
       />
     {/if}
     {#if currentDashboard}
@@ -109,12 +119,12 @@
               key: listing.name,
               main: listing?.title || listing.name,
               callback: () =>
-                goto(`/${organization}/${project}/${listing.name}`),
+                goto(`/${orgName}/${projectName}/${listing.name}`),
             };
           })}
         menuKey={currentDashboard.name}
         onSelectMenuOption={(dashboard) =>
-          goto(`/${organization}/${project}/${dashboard}`)}
+          goto(`/${orgName}/${projectName}/${dashboard}`)}
       />
     {/if}
   </ol>

--- a/web-admin/src/components/navigation/Breadcrumbs.svelte
+++ b/web-admin/src/components/navigation/Breadcrumbs.svelte
@@ -9,6 +9,7 @@
   import {
     createAdminServiceGetCurrentUser,
     createAdminServiceGetOrganization,
+    createAdminServiceGetProject,
     createAdminServiceListOrganizations,
     createAdminServiceListProjectsForOrganization,
   } from "../../client";
@@ -28,6 +29,7 @@
   $: isOrganizationPage = $page.route.id === "/[organization]";
 
   $: projectName = $page.params.project;
+  $: project = createAdminServiceGetProject(orgName, projectName);
   $: projects = createAdminServiceListProjectsForOrganization(
     orgName,
     undefined,
@@ -93,7 +95,7 @@
         <OrganizationAvatar organization={orgName} slot="icon" />
       </BreadcrumbItem>
     {/if}
-    {#if projectName}
+    {#if $project.data.project}
       <span class="text-gray-600">/</span>
       <BreadcrumbItem
         label={projectName}

--- a/web-admin/src/routes/[organization]/+page.svelte
+++ b/web-admin/src/routes/[organization]/+page.svelte
@@ -9,7 +9,9 @@
 
   $: org = createAdminServiceGetOrganization($page.params.organization);
   $: projs = createAdminServiceListProjectsForOrganization(
-    $page.params.organization
+    $page.params.organization,
+    undefined,
+    { query: { enabled: !!$org.data.organization } }
   );
 
   $: if ($projs.data && $projs.data.projects?.length > 0) {


### PR DESCRIPTION
This PR:
- Prevents breadcrumbs from flashing on org and project 404 error pages. Previously, we were not checking for a valid org or project before showing the breadcrumb. Now, we do check.
- Ensures we don't trigger a 400 error on the org page by querying for an org's projects when the org doesn't exist.
- Removes an old workaround in the `errors-utils.ts` file to show the user a 404 message when a 400 error also occurred.

Contributes to #2109.