### PR TITLE
Fixing valid dashboard refresh

### DIFF
--- a/web-common/src/runtime-client/RuntimeProvider.svelte
+++ b/web-common/src/runtime-client/RuntimeProvider.svelte
@@ -16,7 +16,7 @@
   // Re-run all runtime queries when `host` changes
   // By default, a new `instanceId` triggers a re-run because it's in the queryKeys
   const queryClient = useQueryClient();
-  $: $runtime.host && invalidateRuntimeQueries(queryClient);
+  $: host && invalidateRuntimeQueries(queryClient);
 </script>
 
 {#if $runtime.host !== undefined && $runtime.instanceId}

--- a/web-common/src/runtime-client/RuntimeProvider.svelte
+++ b/web-common/src/runtime-client/RuntimeProvider.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-  import { invalidateRuntimeQueries } from "@rilldata/web-local/lib/svelte-query/invalidation";
-  import { useQueryClient } from "@tanstack/svelte-query";
   import { runtime } from "./runtime-store";
 
   export let host: string;
@@ -12,11 +10,6 @@
     instanceId: instanceId,
     jwt: jwt,
   });
-
-  // Re-run all runtime queries when `host` changes
-  // By default, a new `instanceId` triggers a re-run because it's in the queryKeys
-  const queryClient = useQueryClient();
-  $: host && invalidateRuntimeQueries(queryClient);
 </script>
 
 {#if $runtime.host !== undefined && $runtime.instanceId}


### PR DESCRIPTION
We had a reactive statement dependant on `$runtime`. Since it changes every time jwt changes this lead to constant refresh of the dashboard.