### PR TITLE
Fix error code styling issue

### DIFF
--- a/web-admin/src/app.html
+++ b/web-admin/src/app.html
@@ -38,6 +38,13 @@
       type="font/woff2"
       crossorigin
     />
+    <link
+      rel="preload"
+      href="%sveltekit.assets%/fonts/inter/Inter-ExtraBold.woff2?v=3.19"
+      as="font"
+      type="font/woff2"
+      crossorigin
+    />
     <meta charset="utf-8" />
     <link rel="icon" href="%sveltekit.assets%/favicon.png" />
     <meta name="viewport" content="width=device-width" />


### PR DESCRIPTION
The extra bold fontface was not added to the pre-load list. As a result, the error code text (which was using extra bold styling) had a delay in it's styling.

That being said, preloading it on all the pages also has it issues. It can slow down the load time of all the pages in the application

The other option is to use `font-display:block` ([more here](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display)), but this hides the error code until the font is fetched while showing other text on the page which is an odd experience.

I am more inclined to keep this as is. Not sure if slight delay in styling is worth loading 100kb on every page.