### PR TITLE
Use `font-medium` in calls to action

### DIFF
--- a/web-admin/src/components/errors/ErrorPage.svelte
+++ b/web-admin/src/components/errors/ErrorPage.svelte
@@ -1,30 +1,30 @@
 <script lang="ts">
   import { goto } from "$app/navigation";
+  import CtaButton from "@rilldata/web-common/components/calls-to-action/CTAButton.svelte";
+  import CtaContentContainer from "@rilldata/web-common/components/calls-to-action/CTAContentContainer.svelte";
+  import CtaLayoutContainer from "@rilldata/web-common/components/calls-to-action/CTALayoutContainer.svelte";
+  import CtaMessage from "@rilldata/web-common/components/calls-to-action/CTAMessage.svelte";
+  import CtaNeedHelp from "@rilldata/web-common/components/calls-to-action/CTANeedHelp.svelte";
 
   export let statusCode: number;
   export let header: string;
   export let body: string;
 </script>
 
-<div class="flex flex-col justify-center items-center h-3/5 space-y-6 m-auto">
-  <h1
-    class="text-8xl font-extrabold bg-gradient-to-b from-[#CBD5E1] to-[#E2E8F0] text-transparent bg-clip-text"
-  >
-    {statusCode}
-  </h1>
-  <div class="flex flex-col items-center space-y-2">
+<CtaLayoutContainer>
+  <CtaContentContainer>
+    <h1
+      class="text-8xl font-extrabold bg-gradient-to-b from-[#CBD5E1] to-[#E2E8F0] text-transparent bg-clip-text"
+    >
+      {statusCode}
+    </h1>
     <h2 class="text-lg font-semibold">{header}</h2>
-    <p class="text-base text-gray-500 text-center" style="max-width: 530px">
+    <CtaMessage>
       {body}
-    </p>
-  </div>
-  <button
-    class="border border-blue-300 text-blue-600 w-full h-10 hover:bg-slate-100 hover:border-gray-100"
-    style="max-width: 400px"
-    on:click={() => goto("/")}
-    >Back to home
-  </button>
-  <p class="text-gray-500">
-    Need help? Reach out to us on <a href="http://bit.ly/3jg4IsF">Discord</a>
-  </p>
-</div>
+    </CtaMessage>
+    <CtaButton variant="primary-outline" on:click={() => goto("/")}>
+      Back to home
+    </CtaButton>
+    <CtaNeedHelp />
+  </CtaContentContainer>
+</CtaLayoutContainer>

--- a/web-common/src/components/calls-to-action/CTAButton.svelte
+++ b/web-common/src/components/calls-to-action/CTAButton.svelte
@@ -5,7 +5,6 @@
   export let disabled = false;
 
   function getVariantClass(variant: string) {
-    console.log;
     switch (variant) {
       case "primary":
         return "border-blue-600 bg-blue-600 text-white hover:bg-blue-500 hover:border-blue-500";

--- a/web-common/src/components/calls-to-action/CTAButton.svelte
+++ b/web-common/src/components/calls-to-action/CTAButton.svelte
@@ -27,7 +27,7 @@
 </script>
 
 <button
-  class="text-sm w-full max-w-[400px] h-10 border rounded-sm {getVariantClass(
+  class="text-sm font-medium w-full max-w-[400px] h-10 border rounded-sm {getVariantClass(
     variant
   )} {disabled && disabledClasses}"
   on:click={handleClick}


### PR DESCRIPTION
This PR:
- Applies `font-medium` to the `CTAButton`
- Refactors the `ErrorPage` component to use the Call To Action components

Contributes to #2109.