### PR TITLE
bug bash changes

### DIFF
--- a/cli/cmd/auth/login.go
+++ b/cli/cmd/auth/login.go
@@ -24,9 +24,14 @@ func LoginCmd(cfg *config.Config) *cobra.Command {
 			warn := color.New(color.Bold).Add(color.FgYellow)
 			ctx := cmd.Context()
 
+			// updating this as its not required to logout first and login again
 			if cfg.AdminTokenDefault != "" {
-				warn.Println("You are already logged in. To log in again, run `rill logout` first.")
-				return nil
+				err := Logout(ctx, cfg)
+				if err != nil {
+					return err
+				}
+
+				cfg.AdminTokenDefault = ""
 			}
 
 			// Login user

--- a/cli/cmd/org/list.go
+++ b/cli/cmd/org/list.go
@@ -25,7 +25,11 @@ func ListCmd(cfg *config.Config) *cobra.Command {
 				return err
 			}
 
-			cmdutil.SuccessPrinter("Organizations list")
+			if len(res.Organizations) == 0 {
+				cmdutil.WarnPrinter("No organizations found")
+				return nil
+			}
+
 			cmdutil.TablePrinter(toTable(res.Organizations, cfg.Org))
 			return nil
 		},

--- a/cli/cmd/project/list.go
+++ b/cli/cmd/project/list.go
@@ -27,7 +27,11 @@ func ListCmd(cfg *config.Config) *cobra.Command {
 				return err
 			}
 
-			cmdutil.SuccessPrinter("Projects list")
+			if len(proj.Projects) == 0 {
+				cmdutil.WarnPrinter("No projects found")
+				return nil
+			}
+
 			cmdutil.TablePrinter(toTable(proj.Projects))
 			return nil
 		},

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -53,7 +53,7 @@ func Execute(ctx context.Context, ver config.Version) {
 		} else if strings.Contains(errMsg, "project not found") {
 			fmt.Println("Project not found. Run `rill project list` to check the list of projects.")
 		} else if strings.Contains(errMsg, "auth token not found") {
-			fmt.Println("Auth token is invalid/expired. Run `rill logout` and login again with `rill login`.")
+			fmt.Println("Auth token is invalid/expired. Login again with `rill login`.")
 		} else if strings.Contains(errMsg, "not authenticated as a user") {
 			fmt.Println("Please log in or sign up for Rill with `rill login`.")
 		} else {

--- a/cli/pkg/cmdutil/cmdutil.go
+++ b/cli/pkg/cmdutil/cmdutil.go
@@ -76,7 +76,7 @@ func Spinner(prefix string) *spinner.Spinner {
 func TablePrinter(v interface{}) {
 	var b strings.Builder
 	tableprinter.Print(&b, v)
-	fmt.Fprintln(os.Stdout, b.String())
+	fmt.Fprint(os.Stdout, b.String())
 }
 
 func SuccessPrinter(str string) {
@@ -208,7 +208,6 @@ func PrintMembers(members []*adminv1.Member) {
 		return
 	}
 
-	SuccessPrinter("Members list")
 	TablePrinter(toMemberTable(members))
 }
 
@@ -244,7 +243,7 @@ func toMemberRow(m *adminv1.Member) *member {
 type member struct {
 	Name      string `header:"name" json:"display_name"`
 	Email     string `header:"email" json:"email"`
-	RoleName  string `header:"role_name" json:"role_name"`
+	RoleName  string `header:"role" json:"role_name"`
 	CreatedOn string `header:"created_on,timestamp(ms|utc|human)" json:"created_on"`
 	UpdatedOn string `header:"updated_on,timestamp(ms|utc|human)" json:"updated_on"`
 }
@@ -268,7 +267,7 @@ func toInviteRow(i *adminv1.UserInvite) *userInvite {
 
 type userInvite struct {
 	Email     string `header:"email" json:"email"`
-	RoleName  string `header:"role_name" json:"role_name"`
+	RoleName  string `header:"role" json:"role_name"`
 	InvitedBy string `header:"invited_by" json:"invited_by"`
 }
 


### PR DESCRIPTION
- [ ] Aditya - `org` commands feel inconsistent.  (@Rakesh Sharma)
    - `create` takes `--name`
    - `delete` needs it inline (`rill project delete <project name>` )
    - `edit` takes `--org`
- [x] Benjamin – The table printing feels a little messy, compared to e.g. Kubernetes. (@Rakesh Sharma) 
We should:
    - Change “ROLE NAME” to just “ROLE”
    - Remove the header (”Members list” in the screenshot)
    - Remove the empty newline
- [x] Parag - (User journey) Extremely alpha message after rill init
- [x] Kasper - Maybe just ask the user to do rill login and assume implicit logout? (@Rakesh Sharma )
Auth token is invalid/expired. Run rill logout and login again with rill login. and maybe even here also?
You are already logged in. To log in again, run `rill logout` first.
- [ ] Himadri - Project list should show the UI link too, probably something like (@Rakesh Sharma: remove https://github.com/ prefix from Github URL listings)
- [ ] Parag - (User journey) Git creation steps -
    
    Step 3 - says create a new github repo - does the repo name need to be same as project/folder name ? - I tried with different btw
    
    Step 4 - git instructions says `**git remote add origin [https://github.com/your-account/your-repo.git**`]([https://github.com/your-account/your-repo.git`](https://github.com/your-account/your-repo.git%60)) add [git@github.com](mailto:git@github.com):your-account/your-repo.git in case using ssh
    
    Step 5 - (Critical) We are missing one step in instructions for rill deploy when folder is not a git folder - After adding remote, we should run `git branch -M main` as step 5 before **`git push -u origin main` otherwise it will fail with following error -**
    
    error: src refspec main does not match any
    error: failed to push some refs to
    
    I think its because git init creates `master` branch but [[github.com](http://github.com/)](http://github.com) creates `main`  (@Rakesh Sharma)