### PR TITLE
Add an `/{organization}` page

### DIFF
--- a/web-admin/src/components/home/DeploymentStatusChip.svelte
+++ b/web-admin/src/components/home/DeploymentStatusChip.svelte
@@ -120,10 +120,12 @@
 
 {#if deploymentStatus && deploymentStatus !== V1DeploymentStatus.DEPLOYMENT_STATUS_UNSPECIFIED}
   {#if iconOnly}
-    <svelte:component
-      this={currentStatusDisplay.icon}
-      {...currentStatusDisplay.iconProps}
-    />
+    <div class="pb-0.5">
+      <svelte:component
+        this={currentStatusDisplay.icon}
+        {...currentStatusDisplay.iconProps}
+      />
+    </div>
   {:else}
     <div
       class="flex space-x-1 items-center px-2 border rounded rounded-[20px] w-fit {currentStatusDisplay.wrapperClass} {iconOnly &&

--- a/web-admin/src/components/home/OrganizationList.svelte
+++ b/web-admin/src/components/home/OrganizationList.svelte
@@ -9,7 +9,11 @@
   <ol>
     {#each $orgs.data.organizations as org}
       <li class="mb-3">
-        <h2 class="text-base leading-6 font-light mb-1">{org.name}</h2>
+        <a
+          href="/{org.name}"
+          class="text-base leading-6 font-light mb-1 text-gray-700 hover:underline"
+          >{org.name}</a
+        >
         <div class="py-2 px-1.5">
           <ProjectList organization={org.name} />
         </div>

--- a/web-admin/src/components/home/WelcomeMessage.svelte
+++ b/web-admin/src/components/home/WelcomeMessage.svelte
@@ -1,7 +1,7 @@
 <p class="text-gray-500 text-base mt-2 max-w-[600px]">
   It looks like you're just starting out! Check out our
   <a
-    href="https://docs.rilldata.com/quickstart/cloud"
+    href="https://docs.rilldata.com/quickstart/end-to-end"
     target="_blank"
     rel="noreferrer">Quickstart to create your first project</a
   >.

--- a/web-admin/src/components/navigation/BreadcrumbItem.svelte
+++ b/web-admin/src/components/navigation/BreadcrumbItem.svelte
@@ -9,7 +9,7 @@
   export let onSelectMenuOption: (option: string) => void = undefined;
   export let isCurrentPage = false;
 
-  const activeClass = "text-gray-800 font-semibold";
+  const activeClass = "text-gray-800 font-medium";
   const inactiveClass = "text-gray-500";
 
   let hovered = false;

--- a/web-admin/src/components/navigation/BreadcrumbItem.svelte
+++ b/web-admin/src/components/navigation/BreadcrumbItem.svelte
@@ -10,7 +10,7 @@
   export let isCurrentPage = false;
 
   const activeClass = "text-gray-800 font-medium";
-  const inactiveClass = "text-gray-500";
+  const inactiveClass = "text-gray-500 hover:text-gray-600";
 
   let hovered = false;
   function setHovered(value: boolean) {

--- a/web-admin/src/components/navigation/BreadcrumbItem.svelte
+++ b/web-admin/src/components/navigation/BreadcrumbItem.svelte
@@ -3,10 +3,11 @@
   import WithSelectMenu from "@rilldata/web-common/components/menu/wrappers/WithSelectMenu.svelte";
 
   export let label: string;
-  export let isCurrentPage = false;
+  export let href: string;
   export let menuOptions: { key: string; main: string }[] = [];
   export let menuKey: string;
   export let onSelectMenuOption: (option: string) => void = undefined;
+  export let isCurrentPage = false;
 
   const activeClass = "text-gray-800 font-semibold";
   const inactiveClass = "text-gray-500";
@@ -20,7 +21,7 @@
 <li class="flex flex items-center gap-x-2 p-2">
   <slot name="icon" />
   {#if !menuOptions}
-    <span class={isCurrentPage ? activeClass : inactiveClass}>{label}</span>
+    <a {href} class={isCurrentPage ? activeClass : inactiveClass}>{label}</a>
   {:else}
     <WithSelectMenu
       minWidth="0px"

--- a/web-admin/src/components/navigation/BreadcrumbItem.svelte
+++ b/web-admin/src/components/navigation/BreadcrumbItem.svelte
@@ -8,45 +8,38 @@
   export let menuKey: string;
   export let onSelectMenuOption: (option: string) => void = undefined;
   export let isCurrentPage = false;
-
-  const activeClass = "text-gray-800 font-medium";
-  const inactiveClass = "text-gray-500 hover:text-gray-600";
-
-  let hovered = false;
-  function setHovered(value: boolean) {
-    hovered = value;
-  }
 </script>
 
 <li class="flex flex items-center gap-x-2 p-2">
   <slot name="icon" />
-  {#if !menuOptions}
-    <a {href} class={isCurrentPage ? activeClass : inactiveClass}>{label}</a>
-  {:else}
-    <WithSelectMenu
-      minWidth="0px"
-      distance={4}
-      options={menuOptions}
-      selection={{
-        key: menuKey,
-        main: label,
-      }}
-      on:select={({ detail: { key } }) => onSelectMenuOption(key)}
-      let:toggleMenu
+  <div class="flex flex-row gap-x-1 items-center">
+    <a
+      {href}
+      class={isCurrentPage
+        ? "text-gray-800 font-medium"
+        : "text-gray-500 hover:text-gray-600"}>{label}</a
     >
-      <button
-        class="flex flex-row gap-x-1 items-center {isCurrentPage
-          ? activeClass
-          : inactiveClass}"
-        on:click={toggleMenu}
-        on:mouseenter={() => setHovered(true)}
-        on:mouseleave={() => setHovered(false)}
+    {#if menuOptions}
+      <WithSelectMenu
+        minWidth="0px"
+        distance={4}
+        options={menuOptions}
+        selection={{
+          key: menuKey,
+          main: label,
+        }}
+        on:select={({ detail: { key } }) => onSelectMenuOption(key)}
+        let:toggleMenu
       >
-        <span>{label}</span>
-        <div class="transition-transform {hovered ? 'translate-y-[2px]' : ''}">
+        <button
+          class="flex flex-col justify-center items-center transition-transform hover:translate-y-[2px] {isCurrentPage
+            ? 'text-gray-800'
+            : 'text-gray-500'}"
+          on:click={toggleMenu}
+        >
           <CaretDownIcon size="14px" />
-        </div>
-      </button>
-    </WithSelectMenu>
-  {/if}
+        </button>
+      </WithSelectMenu>
+    {/if}
+  </div>
 </li>

--- a/web-admin/src/components/navigation/Breadcrumbs.svelte
+++ b/web-admin/src/components/navigation/Breadcrumbs.svelte
@@ -82,7 +82,12 @@
             main: proj.name,
           }))}
         menuKey={projectName}
-        onSelectMenuOption={(project) => goto(`/${orgName}/${project}`)}
+        onSelectMenuOption={(project) =>
+          goto(
+            isDashboardPage
+              ? `/${orgName}/${project}/-/redirect`
+              : `/${orgName}/${project}`
+          )}
         isCurrentPage={isProjectPage}
       />
     {/if}

--- a/web-admin/src/components/navigation/Breadcrumbs.svelte
+++ b/web-admin/src/components/navigation/Breadcrumbs.svelte
@@ -82,8 +82,7 @@
             main: proj.name,
           }))}
         menuKey={projectName}
-        onSelectMenuOption={(project) =>
-          goto(`/${orgName}/${project}/-/redirect`)}
+        onSelectMenuOption={(project) => goto(`/${orgName}/${project}`)}
         isCurrentPage={isProjectPage}
       />
     {/if}

--- a/web-admin/src/components/navigation/Breadcrumbs.svelte
+++ b/web-admin/src/components/navigation/Breadcrumbs.svelte
@@ -58,7 +58,7 @@
     {#if $organization.data.organization}
       <BreadcrumbItem
         label={orgName}
-        isCurrentPage={isOrganizationPage}
+        href={`/${orgName}`}
         menuOptions={$organizations.data?.organizations?.length > 1 &&
           $organizations.data.organizations.map((org) => ({
             key: org.name,
@@ -66,6 +66,7 @@
           }))}
         menuKey={orgName}
         onSelectMenuOption={(organization) => goto(`/${organization}`)}
+        isCurrentPage={isOrganizationPage}
       >
         <OrganizationAvatar organization={orgName} slot="icon" />
       </BreadcrumbItem>
@@ -74,7 +75,7 @@
       <span class="text-gray-600">/</span>
       <BreadcrumbItem
         label={projectName}
-        isCurrentPage={isProjectPage}
+        href={`/${orgName}/${projectName}`}
         menuOptions={$projects.data?.projects?.length > 1 &&
           $projects.data.projects.map((proj) => ({
             key: proj.name,
@@ -83,13 +84,14 @@
         menuKey={projectName}
         onSelectMenuOption={(project) =>
           goto(`/${orgName}/${project}/-/redirect`)}
+        isCurrentPage={isProjectPage}
       />
     {/if}
     {#if currentDashboard}
       <span class="text-gray-600">/</span>
       <BreadcrumbItem
         label={currentDashboard?.title || currentDashboard.name}
-        isCurrentPage={isDashboardPage}
+        href={`/${orgName}/${projectName}/${currentDashboard.name}`}
         menuOptions={$dashboardListItems?.items?.length > 1 &&
           $dashboardListItems.items.map((listing) => {
             return {
@@ -100,6 +102,7 @@
         menuKey={currentDashboard.name}
         onSelectMenuOption={(dashboard) =>
           goto(`/${orgName}/${projectName}/${dashboard}`)}
+        isCurrentPage={isDashboardPage}
       />
     {/if}
   </ol>

--- a/web-admin/src/components/projects/ProjectStatus.svelte
+++ b/web-admin/src/components/projects/ProjectStatus.svelte
@@ -1,3 +1,0 @@
-<div class="border bg-gray-50 p-2 text-gray-400">
-  Placeholder for project status
-</div>

--- a/web-admin/src/routes/[organization]/+page.svelte
+++ b/web-admin/src/routes/[organization]/+page.svelte
@@ -12,7 +12,7 @@
 
   $: org = createAdminServiceGetOrganization(orgName);
   $: projs = createAdminServiceListProjectsForOrganization(orgName, undefined, {
-    query: { enabled: !!$org.data.organization },
+    query: { enabled: !!$org.data?.organization },
   });
 </script>
 

--- a/web-admin/src/routes/[organization]/+page.svelte
+++ b/web-admin/src/routes/[organization]/+page.svelte
@@ -31,7 +31,7 @@
         {#if $projs.data.projects?.length === 0}
           <span
             >This organization has no projects yet. <a
-              href="https://docs.rilldata.com/quickstart/local"
+              href="https://docs.rilldata.com/quickstart/end-to-end"
               target="_blank"
               rel="noreferrer">See docs</a
             ></span

--- a/web-admin/src/routes/[organization]/+page.svelte
+++ b/web-admin/src/routes/[organization]/+page.svelte
@@ -1,46 +1,48 @@
 <script lang="ts">
-  import { goto } from "$app/navigation";
   import { page } from "$app/stores";
-  import { Button } from "@rilldata/web-common/components/button";
   import {
     createAdminServiceGetOrganization,
     createAdminServiceListProjectsForOrganization,
   } from "../../client";
+  import HomeShareCta from "../../components/home/HomeShareCTA.svelte";
+  import ProjectList from "../../components/home/ProjectList.svelte";
 
-  $: org = createAdminServiceGetOrganization($page.params.organization);
-  $: projs = createAdminServiceListProjectsForOrganization(
-    $page.params.organization,
-    undefined,
-    { query: { enabled: !!$org.data.organization } }
-  );
+  $: orgName = $page.params.organization;
 
-  $: if ($projs.data && $projs.data.projects?.length > 0) {
-    goto(
-      `/${$page.params.organization}/${$projs.data.projects[0].name}/-/redirect`
-    );
-  }
-
-  function openDocs() {
-    window.open("https://docs.rilldata.com/quickstart/local", "_blank");
-  }
+  $: org = createAdminServiceGetOrganization(orgName);
+  $: projs = createAdminServiceListProjectsForOrganization(orgName, undefined, {
+    query: { enabled: !!$org.data.organization },
+  });
 </script>
 
 <svelte:head>
-  <title>{$page.params.organization} overview - Rill</title>
+  <title>{orgName} overview - Rill</title>
 </svelte:head>
 
-<section class="flex flex-col justify-center items-center h-3/5">
-  {#if $org.isLoading || $projs.isLoading}
-    <span>Loading...</span>
-  {:else if $org.isError || $projs.isError}
-    <span>Error: {$org.error || $projs.error}</span>
-  {:else if $org.data && $org.data.organization && $projs.data && $projs.data.projects?.length === 0}
-    <h1 class="text-3xl font-medium text-gray-800 mb-4">
-      Organization: {$org.data.organization.name}
-    </h1>
-    <p class="text-lg text-gray-700 mb-6">
-      Your organization does not have any projects... yet!
-    </p>
-    <Button type="primary" on:click={openDocs}>Read the docs</Button>
-  {/if}
-</section>
+{#if $org.data && $org.data.organization && $projs.data}
+  <section
+    class="flex flex-col mx-8 my-8 sm:my-16 sm:mx-16 lg:mx-32 lg:my-24 2xl:mx-64 mx-auto"
+  >
+    <div class="flex flex-row gap-x-7 flex-wrap">
+      <div class="md:w-1/2 flex flex-col">
+        <span class="text-base leading-6 font-light mb-1 text-gray-700"
+          >{orgName}</span
+        >
+        {#if $projs.data.projects?.length === 0}
+          <span
+            >This organization has no projects yet. <a
+              href="https://docs.rilldata.com/quickstart/local"
+              target="_blank"
+              rel="noreferrer">See docs</a
+            ></span
+          >
+        {:else}
+          <div class="py-2 px-1.5">
+            <ProjectList organization={$page.params.organization} />
+          </div>
+        {/if}
+      </div>
+      <HomeShareCta />
+    </div>
+  </section>
+{/if}


### PR DESCRIPTION
This PR:
- Adds an organization page and links to it on the home page
- Makes the breadcrumbs conventionally clickable – each breadcrumb label corresponds to a page that you can visit
- Retains the redirect so that, from a dashboard page, switching projects redirects you to the new project's first dashboard
- Does some minor cleanup: fixes a doc link & centers project status icons with the project name

Contributes to #2109.