### PR TITLE
removes rough edge around fetching spinner in the null percentage spark

### DIFF
--- a/web-common/src/components/column-profile/column-types/NestedProfile.svelte
+++ b/web-common/src/components/column-profile/column-types/NestedProfile.svelte
@@ -76,7 +76,6 @@
     {type}
   />
   <NullPercentageSpark
-    isFetching={fetchingSummaries}
     nullCount={$nulls?.nullCount}
     slot="nullity"
     totalRows={$nulls?.totalRows}

--- a/web-common/src/components/column-profile/column-types/NumericProfile.svelte
+++ b/web-common/src/components/column-profile/column-types/NumericProfile.svelte
@@ -6,9 +6,9 @@
     isFloat,
   } from "@rilldata/web-common/lib/duckdb-data-types";
   import {
+    QueryServiceColumnNumericHistogramHistogramMethod,
     createQueryServiceColumnDescriptiveStatistics,
     createQueryServiceColumnRugHistogram,
-    QueryServiceColumnNumericHistogramHistogramMethod,
   } from "@rilldata/web-common/runtime-client";
   import { getPriorityForColumn } from "@rilldata/web-common/runtime-client/http-request-queue/priorities";
   import { derived } from "svelte/store";
@@ -164,7 +164,6 @@
   <svelte:fragment slot="left">{columnName}</svelte:fragment>
   <NumericSpark {type} {compact} data={histogramData} slot="summary" />
   <NullPercentageSpark
-    isFetching={fetchingSummaries}
     nullCount={$nulls?.nullCount}
     slot="nullity"
     totalRows={$nulls?.totalRows}

--- a/web-common/src/components/column-profile/column-types/TimestampProfile.svelte
+++ b/web-common/src/components/column-profile/column-types/TimestampProfile.svelte
@@ -84,7 +84,6 @@
     </WithParentClientRect>
   </div>
   <NullPercentageSpark
-    isFetching={fetchingSummaries}
     nullCount={$nullPercentage?.nullCount}
     slot="nullity"
     totalRows={$nullPercentage?.totalRows}

--- a/web-common/src/components/column-profile/column-types/VarcharProfile.svelte
+++ b/web-common/src/components/column-profile/column-types/VarcharProfile.svelte
@@ -69,7 +69,6 @@
     totalRows={$columnCardinality?.totalRows}
   />
   <NullPercentageSpark
-    isFetching={fetchingSummaries}
     nullCount={$nulls?.nullCount}
     slot="nullity"
     totalRows={$nulls?.totalRows}

--- a/web-common/src/components/column-profile/column-types/sparks/NullPercentageSpark.svelte
+++ b/web-common/src/components/column-profile/column-types/sparks/NullPercentageSpark.svelte
@@ -12,10 +12,10 @@
   export let type: string;
   export let nullCount: number;
   export let totalRows: number;
-  export let isFetching: boolean;
 
   let percentage: number;
-  $: if (!isFetching) percentage = nullCount / totalRows;
+  $: if (nullCount !== undefined && totalRows !== undefined)
+    percentage = nullCount / totalRows;
   $: innerType = isNested(type) ? "STRUCT" : type;
 </script>
 


### PR DESCRIPTION
This bug was causing an issue in modeling. The profiling feature components were locking on an `isFetching` parameter, when really we just needed the numerator and denominator to not both be undefined before displaying.