### PR TITLE
Fix "organization is undefined" bug

### DIFF
--- a/web-admin/src/components/navigation/Breadcrumbs.svelte
+++ b/web-admin/src/components/navigation/Breadcrumbs.svelte
@@ -36,7 +36,7 @@
     undefined,
     {
       query: {
-        enabled: !!$organization.data.organization,
+        enabled: !!$organization.data?.organization,
       },
     }
   );
@@ -55,7 +55,7 @@
 
 <nav>
   <ol class="flex flex-row items-center">
-    {#if $organization.data.organization}
+    {#if $organization.data?.organization}
       <BreadcrumbItem
         label={orgName}
         isCurrentPage={isOrganizationPage}
@@ -70,7 +70,7 @@
         <OrganizationAvatar organization={orgName} slot="icon" />
       </BreadcrumbItem>
     {/if}
-    {#if $project.data.project}
+    {#if $project.data?.project}
       <span class="text-gray-600">/</span>
       <BreadcrumbItem
         label={projectName}


### PR DESCRIPTION
PR #2297 affected all our usage of TanStack Query. Now, by design, the `data` object is `undefined` until data is returned from the server. In many places previously, our code assumed the `data` object would be `{}` until data is returned from the server.

This PR fixes one file where we didn't switch the code to account for `data = undefined`.