### PR TITLE
fix: broken hide comparisons

### DIFF
--- a/web-common/src/features/dashboards/time-controls/TimeControls.svelte
+++ b/web-common/src/features/dashboards/time-controls/TimeControls.svelte
@@ -36,6 +36,7 @@
   } from "@rilldata/web-common/runtime-client";
   import type { CreateQueryResult } from "@tanstack/svelte-query";
   import { useQueryClient } from "@tanstack/svelte-query";
+  import { get } from "svelte/store";
   import { runtime } from "../../../runtime-client/runtime-store";
   import { metricsExplorerStore, useDashboardStore } from "../dashboard-stores";
   import NoTimeDimensionCTA from "./NoTimeDimensionCTA.svelte";
@@ -91,10 +92,12 @@
       V1TimeGrain.TIME_GRAIN_UNSPECIFIED;
   }
   $: allTimeRange = $allTimeRangeQuery?.data as TimeRange;
+  $: isDashboardDefined = $dashboardStore !== undefined;
   // Once we have the allTimeRange, set the default time range and time grain.
-  // This reactive statement feels a bit precarious!
-  $: if (allTimeRange && allTimeRange?.start && $dashboardStore !== undefined) {
-    if (!$dashboardStore?.selectedTimeRange) {
+  // This is a temporary workaround with high potential to break. We should refactor this defaulting logic to live with the store, not as part of a component.
+  $: if (allTimeRange && allTimeRange?.start && isDashboardDefined) {
+    const selectedTimeRange = get(dashboardStore)?.selectedTimeRange;
+    if (!selectedTimeRange) {
       setDefaultTimeControls(allTimeRange);
     } else {
       setTimeControlsFromUrl(allTimeRange);


### PR DESCRIPTION
Temporary patch for bug where no comparison option was not hiding comparison visuals.

Long term, we need to fix the architecture here such that the defaulting logic for store initialization lives with the store, not as part of reactive code in UI control components.