### PR TITLE
Use better logout to login redirect logic

### DIFF
--- a/web-admin/src/components/authentication/UserButton.svelte
+++ b/web-admin/src/components/authentication/UserButton.svelte
@@ -6,7 +6,8 @@
   const user = createAdminServiceGetCurrentUser();
 
   function handleLogOut() {
-    window.location.href = `${ADMIN_URL}/auth/logout?redirect=${window.location.origin}${window.location.pathname}`;
+    const loginWithRedirect = `${ADMIN_URL}/auth/login?redirect=${window.location.origin}${window.location.pathname}`;
+    window.location.href = `${ADMIN_URL}/auth/logout?redirect=${loginWithRedirect}`;
   }
 
   function handleDocumentation() {


### PR DESCRIPTION
This PR changes the logout redirect logic so that:
- When a user logs out, they're redirected to the login page
- After logging in again, the user is redirected to the page they started on (not the home page)

This design solves for this scenario:
- You get a link to a dashboard that you don’t have access to with your current account. You want to logout & login with the correct account, and land on the link that was shared with you.

This design does not solve for this scenario:
- You’re on a dashboard on one account. You want to switch accounts to work on another project. You want to logout & login with your other account, and be redirected to your home page.