### PR TITLE
fix: model with errors nav bugs

### DIFF
--- a/web-common/src/features/models/workspace/ModelBody.svelte
+++ b/web-common/src/features/models/workspace/ModelBody.svelte
@@ -261,7 +261,7 @@
       </div>
       {#if errors.length > 0}
         <div
-          transition:slide={{ duration: 200 }}
+          transition:slide|local={{ duration: 200 }}
           class="error break-words overflow-auto p-6 border-2 border-gray-300 font-bold text-gray-700 w-full shrink-0 max-h-[60%] z-10 bg-gray-100 flex flex-col gap-2"
         >
           {#each errors as error}


### PR DESCRIPTION
The error window slide transition in the ModelBody is causing the ModelWorkspace to not update with new modelNames during routing when a model is opened initially with errors. Changing the transition to have the `local` modifier fixes the issue. This resolves bugs like https://github.com/rilldata/rill-developer/issues/2435

I am not sure why this would fix this bug; we probably need to do a deeper exercise of reproducing this bug in a REPL and reporting to Svelte team as I don't think this is specific to our application logic.