### PR TITLE
WIP: remove last-point truncation in dashboard time series & bignums

### DIFF
--- a/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
+++ b/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
@@ -16,10 +16,13 @@
     useModelAllTimeRange,
     useModelHasTimeSeries,
   } from "@rilldata/web-common/features/dashboards/selectors";
+  import { TIME_GRAIN } from "@rilldata/web-common/lib/time/config";
+  import { getOffset } from "@rilldata/web-common/lib/time/transforms";
+  import { TimeOffsetType } from "@rilldata/web-common/lib/time/types";
   import {
-    createQueryServiceMetricsViewToplist,
     MetricsViewDimension,
     MetricsViewMeasure,
+    createQueryServiceMetricsViewToplist,
   } from "@rilldata/web-common/runtime-client";
   import { useQueryClient } from "@tanstack/svelte-query";
   import { createEventDispatcher } from "svelte";
@@ -151,7 +154,11 @@
         ...topListParams,
         ...{
           timeStart: $dashboardStore.selectedTimeRange?.start,
-          timeEnd: $dashboardStore.selectedTimeRange?.end,
+          timeEnd: getOffset(
+            $dashboardStore.selectedTimeRange?.end,
+            TIME_GRAIN[$dashboardStore.selectedTimeRange?.interval]?.duration,
+            TimeOffsetType.ADD
+          ),
         },
       };
     }

--- a/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
+++ b/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
@@ -161,7 +161,6 @@
         measureNames: selectedMeasureNames,
         filter: $dashboardStore?.filters,
         timeStart: $dashboardStore.selectedTimeRange?.start.toISOString(),
-        // note: we add an additional time grain here so the API will return the last otherwise-excluded point.
         timeEnd: endRangeTimestampForAPI.toISOString(),
         timeGranularity: $dashboardStore.selectedTimeRange?.interval,
       }

--- a/web-common/src/lib/time/config.ts
+++ b/web-common/src/lib/time/config.ts
@@ -48,10 +48,10 @@ export const LATEST_WINDOW_TIME_RANGES: Record<string, TimeRangeMeta> = {
     end: {
       reference: ReferencePoint.LATEST_DATA,
       transformation: [
-        {
-          period: Period.HOUR,
-          truncationType: TimeTruncationType.START_OF_PERIOD,
-        },
+        // {
+        //   period: Period.HOUR,
+        //   truncationType: TimeTruncationType.START_OF_PERIOD,
+        // },
       ],
     },
   },
@@ -98,10 +98,10 @@ export const LATEST_WINDOW_TIME_RANGES: Record<string, TimeRangeMeta> = {
     end: {
       reference: ReferencePoint.LATEST_DATA,
       transformation: [
-        {
-          period: Period.HOUR,
-          truncationType: TimeTruncationType.START_OF_PERIOD,
-        },
+        // {
+        //   period: Period.HOUR,
+        //   truncationType: TimeTruncationType.START_OF_PERIOD,
+        // },
       ],
     },
   },
@@ -122,10 +122,10 @@ export const LATEST_WINDOW_TIME_RANGES: Record<string, TimeRangeMeta> = {
     end: {
       reference: ReferencePoint.LATEST_DATA,
       transformation: [
-        {
-          period: Period.HOUR,
-          truncationType: TimeTruncationType.START_OF_PERIOD,
-        },
+        // {
+        //   period: Period.HOUR,
+        //   truncationType: TimeTruncationType.START_OF_PERIOD,
+        // },
       ],
     },
   },
@@ -146,10 +146,10 @@ export const LATEST_WINDOW_TIME_RANGES: Record<string, TimeRangeMeta> = {
     end: {
       reference: ReferencePoint.LATEST_DATA,
       transformation: [
-        {
-          period: Period.HOUR,
-          truncationType: TimeTruncationType.START_OF_PERIOD,
-        },
+        // {
+        //   period: Period.HOUR,
+        //   truncationType: TimeTruncationType.START_OF_PERIOD,
+        // },
       ],
     },
   },
@@ -170,10 +170,10 @@ export const LATEST_WINDOW_TIME_RANGES: Record<string, TimeRangeMeta> = {
     end: {
       reference: ReferencePoint.LATEST_DATA,
       transformation: [
-        {
-          period: Period.HOUR,
-          truncationType: TimeTruncationType.START_OF_PERIOD,
-        },
+        // {
+        //   period: Period.HOUR,
+        //   truncationType: TimeTruncationType.START_OF_PERIOD,
+        // },
       ],
     },
   },
@@ -205,12 +205,7 @@ export const PERIOD_TO_DATE_RANGES: Record<string, TimeRangeMeta> = {
     },
     end: {
       reference: ReferencePoint.LATEST_DATA,
-      transformation: [
-        {
-          period: Period.HOUR,
-          truncationType: TimeTruncationType.START_OF_PERIOD,
-        },
-      ],
+      transformation: [],
     },
   },
   WEEK_TO_DATE: {
@@ -228,12 +223,7 @@ export const PERIOD_TO_DATE_RANGES: Record<string, TimeRangeMeta> = {
     },
     end: {
       reference: ReferencePoint.LATEST_DATA,
-      transformation: [
-        {
-          period: Period.HOUR,
-          truncationType: TimeTruncationType.START_OF_PERIOD,
-        },
-      ],
+      transformation: [],
     },
   },
   MONTH_TO_DATE: {
@@ -251,12 +241,7 @@ export const PERIOD_TO_DATE_RANGES: Record<string, TimeRangeMeta> = {
     },
     end: {
       reference: ReferencePoint.LATEST_DATA,
-      transformation: [
-        {
-          period: Period.DAY,
-          truncationType: TimeTruncationType.START_OF_PERIOD,
-        },
-      ],
+      transformation: [],
     },
   },
   YEAR_TO_DATE: {
@@ -274,12 +259,7 @@ export const PERIOD_TO_DATE_RANGES: Record<string, TimeRangeMeta> = {
     },
     end: {
       reference: ReferencePoint.LATEST_DATA,
-      transformation: [
-        {
-          period: Period.DAY,
-          truncationType: TimeTruncationType.START_OF_PERIOD,
-        },
-      ],
+      transformation: [],
     },
   },
 };

--- a/web-common/src/lib/time/config.ts
+++ b/web-common/src/lib/time/config.ts
@@ -22,11 +22,7 @@ import {
  * anchored to the latest data point in the dataset with a conceptually-fixed
  * lookback window. For example, the "Last 6 Hours" time range is anchored to
  * the latest data point in the dataset, and then looks back 6 hours from that
- * point.
- *
- * This description is not 100% accurate, of course, since the latest data point
- * may be during an incomplete period. For now, we are truncating to a reasonable
- * periodicity (e.g. to the start of the hour) and then applying the offset.
+ * point, while truncating that start time to the beginning of the hour.
  */
 export const LATEST_WINDOW_TIME_RANGES: Record<string, TimeRangeMeta> = {
   LAST_SIX_HOURS: {
@@ -41,7 +37,7 @@ export const LATEST_WINDOW_TIME_RANGES: Record<string, TimeRangeMeta> = {
           period: Period.HOUR, //TODO: How to handle user selected timegrains?
           truncationType: TimeTruncationType.START_OF_PERIOD,
         }, // truncation
-        // then offset that by 6 hours
+        // then offset that by 5 hours.
         { duration: "PT6H", operationType: TimeOffsetType.SUBTRACT }, // operation
       ],
     },


### PR DESCRIPTION
This PR address the issue where the latest point needs one additional time grain added to it before it goes to the API. It also relaxes the truncation in the config for the time range presets, which ends up leading to _two_ truncations.

Putting this PR up as a prototype of a solution. Not sure if it is the right path