### PR TITLE
Add backwards-compatibility for measures without `name` key

### DIFF
--- a/web-common/src/features/metrics-views/metrics-internal-store.spec.ts
+++ b/web-common/src/features/metrics-views/metrics-internal-store.spec.ts
@@ -190,7 +190,7 @@ measures:
 `;
     [
       [
-        "From an old project",
+        "From an old project without measure name keys",
         `
   - label: Total Impressions
     expression: count(*)
@@ -218,7 +218,7 @@ measures:
     format_preset: humanize`,
       ],
       [
-        "From an old project with some names",
+        "From an old project with some measure name keys",
         `
   - label: Total Impressions
     name: measure_1

--- a/web-common/src/features/metrics-views/metrics-internal-store.spec.ts
+++ b/web-common/src/features/metrics-views/metrics-internal-store.spec.ts
@@ -4,13 +4,10 @@ import {
   MetricsInternalRepresentation,
 } from "@rilldata/web-common/features/metrics-views/metrics-internal-store";
 
-function createEmptyRepresentation() {
-  const internalRepresentation = new MetricsInternalRepresentation(
-    initBlankDashboardYAML("AdBids"),
-    () => {
-      // no-op
-    }
-  );
+function createInternalRepresentation(yaml = initBlankDashboardYAML("AdBids")) {
+  const internalRepresentation = new MetricsInternalRepresentation(yaml, () => {
+    // no-op
+  });
   internalRepresentation.bindStore(() => {
     // no-op
   });
@@ -20,7 +17,7 @@ function createEmptyRepresentation() {
 // TODO: add more exhaustive tests
 describe("Metrics Internal Store", () => {
   it("Add remove dimensions", () => {
-    const internalRepresentation = createEmptyRepresentation();
+    const internalRepresentation = createInternalRepresentation();
 
     internalRepresentation.addNewDimension();
     expect(internalRepresentation.internalYAML)
@@ -56,7 +53,7 @@ dimensions:
   });
 
   it("Add remove measures", () => {
-    const internalRepresentation = createEmptyRepresentation();
+    const internalRepresentation = createInternalRepresentation();
 
     internalRepresentation.addNewMeasure();
     expect(internalRepresentation.internalYAML)
@@ -180,5 +177,85 @@ measures:
     format_preset: humanize
 dimensions: []
 `);
+  });
+
+  describe("Measure Name backwards compatibility", () => {
+    const MetricsYAML = `title: "AdBids"
+model: ""
+default_time_range: ""
+smallest_time_grain: ""
+timeseries: ""
+dimensions: []
+measures:
+`;
+    [
+      [
+        "From an old project",
+        `
+  - label: Total Impressions
+    expression: count(*)
+    description: ""
+    format_preset: humanize
+  - label: Bids
+    expression: avg(bid_price)
+    description: ""
+    format_preset: humanize`,
+        `
+  - label: Total Impressions
+    expression: count(*)
+    description: ""
+    format_preset: humanize
+    name: measure
+  - label: Bids
+    expression: avg(bid_price)
+    description: ""
+    format_preset: humanize
+    name: measure_1
+  - label: ""
+    expression: ""
+    name: measure_2
+    description: ""
+    format_preset: humanize`,
+      ],
+      [
+        "From an old project with some names",
+        `
+  - label: Total Impressions
+    name: measure_1
+    expression: count(*)
+    description: ""
+    format_preset: humanize
+  - label: Bids
+    expression: avg(bid_price)
+    description: ""
+    format_preset: humanize`,
+        `
+  - label: Total Impressions
+    name: measure_1
+    expression: count(*)
+    description: ""
+    format_preset: humanize
+  - label: Bids
+    expression: avg(bid_price)
+    description: ""
+    format_preset: humanize
+    name: measure
+  - label: ""
+    expression: ""
+    name: measure_2
+    description: ""
+    format_preset: humanize`,
+      ],
+    ].forEach(([title, original, expected]) => {
+      it(title, () => {
+        const internalRepresentation = createInternalRepresentation(
+          MetricsYAML + original
+        );
+        internalRepresentation.addNewMeasure();
+        expect(internalRepresentation.internalYAML).toEqual(
+          MetricsYAML + expected + "\n"
+        );
+      });
+    });
   });
 });

--- a/web-common/src/features/metrics-views/metrics-internal-store.ts
+++ b/web-common/src/features/metrics-views/metrics-internal-store.ts
@@ -5,8 +5,8 @@ import type {
   V1Model,
   V1ReconcileError,
 } from "@rilldata/web-common/runtime-client";
-import { readable, Subscriber } from "svelte/store";
-import { Document, ParsedNode, parseDocument, YAMLMap } from "yaml";
+import { Subscriber, readable } from "svelte/store";
+import { Document, ParsedNode, YAMLMap, parseDocument } from "yaml";
 import type { Collection } from "yaml/dist/nodes/Collection";
 import { selectTimestampColumnFromSchema } from "./column-selectors";
 
@@ -182,7 +182,7 @@ export class MetricsInternalRepresentation {
   addNewMeasure() {
     const newName = getName(
       "measure",
-      this.internalRepresentation.measures.map((measure) => measure.name)
+      this.internalRepresentation.measures.map((measure) => measure?.name || "")
     );
 
     const measureNode = this.internalRepresentationDocument.createNode({

--- a/web-common/src/features/metrics-views/metrics-internal-store.ts
+++ b/web-common/src/features/metrics-views/metrics-internal-store.ts
@@ -38,8 +38,10 @@ export interface DimensionEntity {
   __ERROR__?: string;
 }
 
+// This is used to extract the base name from an auto incremented name.
+// EG: "measure_2".replace(NameNumberRegex, "") => "measure"
 const NameNumberRegex = new RegExp(/(\d+)$/);
-const MeasurePrefix = "measure";
+const MeasureNamePrefix = "measure";
 
 export class MetricsInternalRepresentation {
   // All operations are done on the document to preserve comments
@@ -77,7 +79,7 @@ export class MetricsInternalRepresentation {
     this.fillNames(
       (internalRepresentationDoc.get("measures") as Collection)
         ?.items as YAMLMap[],
-      MeasurePrefix
+      MeasureNamePrefix
     );
     // TODO: fill names for dimensions
 
@@ -177,7 +179,7 @@ export class MetricsInternalRepresentation {
 
   addNewMeasure() {
     const newName = getName(
-      MeasurePrefix,
+      MeasureNamePrefix,
       this.internalRepresentation.measures.map((measure) => measure?.name || "")
     );
 


### PR DESCRIPTION
This PR fixes the following bug:
- You have a dashboard file that includes measures without a `name` key
- You click the "Add measure" button in the Metrics UI
- The application freezes