### PR TITLE
fixes non-reactive time range initialization

### DIFF
--- a/web-common/src/features/dashboards/time-controls/TimeControls.svelte
+++ b/web-common/src/features/dashboards/time-controls/TimeControls.svelte
@@ -18,8 +18,8 @@
     getTimeGrainOptions,
   } from "@rilldata/web-common/lib/time/grains";
   import {
-    convertTimeRangePreset,
     ISODurationToTimePreset,
+    convertTimeRangePreset,
     isRangeInsideOther,
   } from "@rilldata/web-common/lib/time/ranges";
   import {
@@ -31,12 +31,11 @@
     TimeRangeType,
   } from "@rilldata/web-common/lib/time/types";
   import {
-    createRuntimeServiceGetCatalogEntry,
     V1TimeGrain,
+    createRuntimeServiceGetCatalogEntry,
   } from "@rilldata/web-common/runtime-client";
   import type { CreateQueryResult } from "@tanstack/svelte-query";
   import { useQueryClient } from "@tanstack/svelte-query";
-  import { get } from "svelte/store";
   import { runtime } from "../../../runtime-client/runtime-store";
   import { metricsExplorerStore, useDashboardStore } from "../dashboard-stores";
   import NoTimeDimensionCTA from "./NoTimeDimensionCTA.svelte";
@@ -96,7 +95,8 @@
   // Once we have the allTimeRange, set the default time range and time grain.
   // This is a temporary workaround with high potential to break. We should refactor this defaulting logic to live with the store, not as part of a component.
   $: if (allTimeRange && allTimeRange?.start && isDashboardDefined) {
-    const selectedTimeRange = get(dashboardStore)?.selectedTimeRange;
+    const selectedTimeRange = $dashboardStore?.selectedTimeRange;
+
     if (!selectedTimeRange) {
       setDefaultTimeControls(allTimeRange);
     } else {


### PR DESCRIPTION
This is a temporary fix that resolves a few bugs relating to the dashboard. Previously, we were not correctly initializing the start / end date, causing issues when using the time controls. This was a recent issue introduced in the last week or so.

We will be refactoring this component to remove rough edges around state initialization. Until then, we need a patch release.