### PR TITLE
remove useless var `leaderboards` and useless dispatch that sets it

### DIFF
--- a/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
+++ b/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
@@ -22,7 +22,6 @@
     MetricsViewMeasure,
   } from "@rilldata/web-common/runtime-client";
   import { useQueryClient } from "@tanstack/svelte-query";
-  import { createEventDispatcher } from "svelte";
   import { isRangeInsideOther } from "../../../lib/time/ranges";
   import { runtime } from "../../../runtime-client/runtime-store";
   import { metricsExplorerStore, useDashboardStore } from "../dashboard-stores";
@@ -47,7 +46,6 @@
   let slice = 7;
 
   const queryClient = useQueryClient();
-  const dispatch = createEventDispatcher();
 
   $: metaQuery = useMetaQuery($runtime.instanceId, metricViewName);
 
@@ -108,13 +106,6 @@
   );
   $: hasTimeSeries = $metricTimeSeries.data;
 
-  function setLeaderboardValues(values) {
-    dispatch("leaderboard-value", {
-      dimensionName,
-      values,
-    });
-  }
-
   function toggleFilterMode() {
     cancelDashboardQueries(queryClient, metricViewName);
     metricsExplorerStore.toggleFilterMode(metricViewName, dimensionName);
@@ -173,7 +164,6 @@
         value: val[measure?.name],
         label: val[dimension?.name],
       })) ?? [];
-    setLeaderboardValues(values);
   }
 
   // get all values that are selected but not visible.

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
@@ -5,7 +5,6 @@
     useMetaQuery,
     useModelHasTimeSeries,
   } from "@rilldata/web-common/features/dashboards/selectors";
-  import { getMapFromArray } from "@rilldata/web-common/lib/arrayUtils";
   import {
     MetricsViewDimension,
     V1MetricsViewTotalsResponse,
@@ -15,7 +14,6 @@
   import { onDestroy, onMount } from "svelte";
   import { runtime } from "../../../runtime-client/runtime-store";
   import {
-    LeaderboardValue,
     MetricsExplorerEntity,
     metricsExplorerStore,
   } from "../dashboard-stores";
@@ -83,17 +81,6 @@
     referenceValue = $totalsQuery.data.data?.[activeMeasure.name];
   }
 
-  const leaderboards = new Map<string, Array<LeaderboardValue>>();
-  $: if (dimensions) {
-    const dimensionNameMap = getMapFromArray(
-      dimensions,
-      (dimension) => dimension.name
-    );
-    [...leaderboards.keys()]
-      .filter((dimensionName) => !dimensionNameMap.has(dimensionName))
-      .forEach((dimensionName) => leaderboards.delete(dimensionName));
-  }
-
   let leaderboardExpanded;
 
   function onSelectItem(event, item: MetricsViewDimension) {
@@ -103,10 +90,6 @@
       item.name,
       event.detail.label
     );
-  }
-
-  function onLeaderboardValues(event) {
-    leaderboards.set(event.detail.dimensionName, event.detail.values);
   }
 
   /** Functionality for resizing the virtual leaderboard */
@@ -177,7 +160,6 @@
           }
         }}
         on:select-item={(event) => onSelectItem(event, item)}
-        on:leaderboard-value={onLeaderboardValues}
         referenceValue={referenceValue || 0}
       />
     </VirtualizedGrid>


### PR DESCRIPTION
While working on other stuff, I noticed that in the file `LeaderboardDisplay.svelte`, the variable `leaderboards` is set, but never passed to anything else nor used to derive anything else. Search ctrl+f in that file to convince yourself the variable only show up in 4 places, and that these 4 places just update the variable without any other effects.

Moreover, in  `Leaderboard.svelte`, we dispatch an event that does nothing other than set the value of `leaderboards` in  `LeaderboardDisplay.svelte`, so that is useless too. Search all files for "leaderboard-value" to convince yourself that this event is only captured by `LeaderboardDisplay.svelte` and only sets the useless variable.

Assigning @djbarnwal -- This should be quick.