### PR TITLE
Check slots job

### DIFF
--- a/admin/admin.go
+++ b/admin/admin.go
@@ -18,14 +18,14 @@ type Options struct {
 
 type Service struct {
 	DB             database.DB
+	Provisioner    *provisioner.StaticProvisioner
+	Email          *email.Client
 	opts           *Options
 	logger         *zap.Logger
 	github         Github
-	provisioner    provisioner.Provisioner
 	issuer         *auth.Issuer
 	closeCtx       context.Context
 	closeCtxCancel context.CancelFunc
-	Email          *email.Client
 }
 
 func New(ctx context.Context, opts *Options, logger *zap.Logger, issuer *auth.Issuer, emailClient *email.Client, github Github) (*Service, error) {
@@ -65,14 +65,14 @@ func New(ctx context.Context, opts *Options, logger *zap.Logger, issuer *auth.Is
 
 	return &Service{
 		DB:             db,
+		Provisioner:    prov,
+		Email:          emailClient,
 		opts:           opts,
 		logger:         logger,
 		github:         github,
-		provisioner:    prov,
 		issuer:         issuer,
 		closeCtx:       ctx,
 		closeCtxCancel: cancel,
-		Email:          emailClient,
 	}, nil
 }
 

--- a/admin/deployments.go
+++ b/admin/deployments.go
@@ -31,7 +31,7 @@ func (s *Service) createDeployment(ctx context.Context, proj *database.Project) 
 	}
 
 	// Get a runtime with capacity for the deployment
-	alloc, err := s.provisioner.Provision(ctx, &provisioner.ProvisionOptions{
+	alloc, err := s.Provisioner.Provision(ctx, &provisioner.ProvisionOptions{
 		OLAPDriver: proj.ProdOLAPDriver,
 		Slots:      proj.ProdSlots,
 		Region:     proj.Region,

--- a/admin/server/server.go
+++ b/admin/server/server.go
@@ -65,7 +65,7 @@ type Server struct {
 
 var _ adminv1.AdminServiceServer = (*Server)(nil)
 
-func New(opts *Options, logger *zap.Logger, adm *admin.Service, issuer *runtimeauth.Issuer) (*Server, error) {
+func New(logger *zap.Logger, adm *admin.Service, issuer *runtimeauth.Issuer, opts *Options) (*Server, error) {
 	externalURL, err := url.Parse(opts.ExternalURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse external URL: %w", err)

--- a/admin/worker/check_slots.go
+++ b/admin/worker/check_slots.go
@@ -1,0 +1,45 @@
+package worker
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+)
+
+func (w *Worker) checkSlots(ctx context.Context) error {
+	slotsUsedByRuntime, err := w.admin.DB.ResolveRuntimeSlotsUsed(ctx)
+	if err != nil {
+		return err
+	}
+
+	var slotsTotal, slotsUsed int
+	var minPctUsed float64
+
+	for _, spec := range w.admin.Provisioner.Spec.Runtimes {
+		slotsTotal += spec.Slots
+		for _, status := range slotsUsedByRuntime {
+			if spec.Host == status.RuntimeHost {
+				slotsUsed += status.SlotsUsed
+				pctUsed := float64(status.SlotsUsed) / float64(spec.Slots)
+				if pctUsed > minPctUsed {
+					minPctUsed = pctUsed
+				}
+			}
+		}
+	}
+
+	// Log info status
+	w.logger.Info(`slots check: status`, zap.Int("runtimes", len(w.admin.Provisioner.Spec.Runtimes)), zap.Int("slots_total", slotsTotal), zap.Int("slots_used", slotsUsed), zap.Float64("min_pct_used", minPctUsed))
+
+	// Check there's at least 20% free slots
+	if float64(slotsUsed)/float64(slotsTotal) >= 0.8 {
+		w.logger.Warn(`slots check: +80% of all slots used`, zap.Int("slots_total", slotsTotal), zap.Int("slots_used", slotsUsed), zap.Float64("min_pct_used", minPctUsed))
+	}
+
+	// Check there's at least one runtime with at least 30% free slots
+	if minPctUsed >= 0.7 {
+		w.logger.Warn(`slots check: +70% of slots used on every runtime`, zap.Int("slots_total", slotsTotal), zap.Int("slots_used", slotsUsed), zap.Float64("min_pct_used", minPctUsed))
+	}
+
+	return nil
+}

--- a/admin/worker/worker.go
+++ b/admin/worker/worker.go
@@ -32,7 +32,7 @@ func New(logger *zap.Logger, adm *admin.Service) *Worker {
 
 func (w *Worker) Run(ctx context.Context) error {
 	group, ctx := errgroup.WithContext(ctx)
-	group.Go(func() error { return w.schedule(ctx, "check_slots", w.checkSlots, 15*time.Second) })
+	group.Go(func() error { return w.schedule(ctx, "check_slots", w.checkSlots, 15*time.Minute) })
 	// NOTE: Add new jobs here
 
 	w.logger.Info("worker started")

--- a/admin/worker/worker.go
+++ b/admin/worker/worker.go
@@ -1,0 +1,60 @@
+package worker
+
+import (
+	"context"
+	"time"
+
+	"github.com/rilldata/rill/admin"
+	"github.com/rilldata/rill/runtime/pkg/observability"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/global"
+	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
+)
+
+var (
+	meter               = global.Meter("admin/worker")
+	jobLatencyHistogram = observability.Must(meter.Int64Histogram("job_latency", metric.WithUnit("ms")))
+)
+
+type Worker struct {
+	logger *zap.Logger
+	admin  *admin.Service
+}
+
+func New(logger *zap.Logger, adm *admin.Service) *Worker {
+	return &Worker{
+		logger: logger,
+		admin:  adm,
+	}
+}
+
+func (w *Worker) Run(ctx context.Context) error {
+	group, ctx := errgroup.WithContext(ctx)
+	group.Go(func() error { return w.schedule(ctx, "check_slots", w.checkSlots, 15*time.Second) })
+	// NOTE: Add new jobs here
+
+	w.logger.Info("worker started")
+	defer w.logger.Info("worker stopped")
+	return group.Wait()
+}
+
+func (w *Worker) schedule(ctx context.Context, name string, fn func(context.Context) error, every time.Duration) error {
+	for {
+		start := time.Now()
+		w.logger.Info("job started", zap.String("name", name))
+		err := fn(ctx)
+		jobLatencyHistogram.Record(ctx, time.Since(start).Milliseconds(), metric.WithAttributes(attribute.String("name", name), attribute.Bool("failed", err != nil)))
+		if err != nil {
+			w.logger.Error("job failed", zap.String("name", name), zap.Error(err), zap.Duration("duration", time.Since(start)))
+			return err
+		}
+		w.logger.Info("job completed", zap.String("name", name), zap.Duration("duration", time.Since(start)))
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(every):
+		}
+	}
+}


### PR DESCRIPTION
- Implements support for a background worker process in `admin`
- The worker runs by default when running `rill admin start`. You can override it as follows:
  - Run `rill admin start server` to only run the admin server
  - Run `rill admin start worker` to only run the worker
  - (Running multiple workers is harmless, but redundant)
- Adds the first background job: `check_slots`, which prints info/warning logs for slots capacity (runs every 15 minutes by default)