### PR TITLE
fix: e2e test hanging

### DIFF
--- a/web-local/test/ui/utils/useTestServer.ts
+++ b/web-local/test/ui/utils/useTestServer.ts
@@ -27,6 +27,9 @@ export function useTestServer(port: number, dir: string) {
         port.toString(),
         `--port-grpc`,
         (port + 1000).toString(),
+        // Temporary workaround for test hangs until runtime fix. With pool size 1, sometimes network requests hang
+        "--db",
+        "stage.db?rill_pool_size=4",
         dir,
       ],
       {


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [x] E2E test coverage
- [ ] Needs manual QA?

## Summary
#### Issue addressed: 
e2e tests randomly hang and fail https://github.com/rilldata/rill-developer/issues/2068

#### Details:
The e2e tests are occasionally hanging on network requests for profiling. After talking to @begelundmuller, he suggested increasing the pool size during testing. That seems to have fixed the problem. He will take a look at the underlying cause so that we can avoid this issue even with a pool size of 1.


## Steps to Verify
```
$ cd ./web-local && npm run test
```