### PR TITLE
Add Go test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ last-query-output.json
 staging-databases
 /rilldata
 docs/dist/
+coverage
 
 # Maven
 target/

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,3 @@
-.PHONY: docs.generate
-docs.generate:
-	# Temporarily replaces ~/.rill/config.yaml to avoid including user-defined defaults in generated docs.
-	# Sets version to the latest tag to simulate a production build, where certain commands are hidden.
-	rm -rf docs/docs/reference/cli
-	if [ -f ~/.rill/config.yaml ]; then mv ~/.rill/config.yaml ~/.rill/config.yaml.tmp; fi;
-	go run -ldflags="-X main.Version=$(shell git describe --tags `git rev-list --tags --max-count=1`)" ./cli docs generate docs/docs/reference/cli/
-	if [ -f ~/.rill/config.yaml.tmp ]; then mv ~/.rill/config.yaml.tmp ~/.rill/config.yaml; fi;
-
 .PHONY: cli
 cli: cli.prepare
 	go build -o rill cli/main.go 
@@ -21,6 +12,25 @@ cli.prepare:
 	rm -rf cli/pkg/examples/embed/dist || true
 	mkdir -p cli/pkg/examples/embed/dist
 	cp -r examples/* cli/pkg/examples/embed/dist/
+
+.PHONY: coverage.go
+coverage.go:
+	rm -rf coverage/go.out
+	mkdir -p coverage
+	# Run tests with coverage output. First builds the list of packages to include in coverage, excluding generated code in 'proto/gen'.
+	set -e ; \
+		PACKAGES=$$(go list ./... | grep -v 'proto/gen/' | tr '\n' ',' | sed -e 's/,$$//' | sed -e 's/github.com\/rilldata\/rill/./g') ;\
+		go test ./... -short -v -coverprofile ./coverage/go.out -coverpkg $$PACKAGES
+	go tool cover -func coverage/go.out
+
+.PHONY: docs.generate
+docs.generate:
+	# Temporarily replaces ~/.rill/config.yaml to avoid including user-defined defaults in generated docs.
+	# Sets version to the latest tag to simulate a production build, where certain commands are hidden.
+	rm -rf docs/docs/reference/cli
+	if [ -f ~/.rill/config.yaml ]; then mv ~/.rill/config.yaml ~/.rill/config.yaml.tmp; fi;
+	go run -ldflags="-X main.Version=$(shell git describe --tags `git rev-list --tags --max-count=1`)" ./cli docs generate docs/docs/reference/cli/
+	if [ -f ~/.rill/config.yaml.tmp ]; then mv ~/.rill/config.yaml.tmp ~/.rill/config.yaml; fi;
 
 .PHONY: proto.generate
 proto.generate:

--- a/runtime/drivers/duckdb/olap_test.go
+++ b/runtime/drivers/duckdb/olap_test.go
@@ -31,6 +31,10 @@ func TestQuery(t *testing.T) {
 }
 
 func TestPriorityQueue(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
 	conn := prepareConn(t)
 	olap, _ := conn.OLAPStore()
 	defer conn.Close()
@@ -76,6 +80,10 @@ func TestPriorityQueue(t *testing.T) {
 }
 
 func TestCancel(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
 	conn := prepareConn(t)
 	olap, _ := conn.OLAPStore()
 	defer conn.Close()
@@ -149,6 +157,10 @@ func TestCancel(t *testing.T) {
 }
 
 func TestClose(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
 	conn := prepareConn(t)
 	olap, _ := conn.OLAPStore()
 


### PR DESCRIPTION
It's currently just an ad-hoc output you can get by running `make coverage.go`. We can investigate connecting to a coverage monitoring service in a later PR.

It reports the current coverage at 50.5% of statements.