### PR TITLE
Support `headers` in source YAML for HTTP connector

### DIFF
--- a/runtime/connectors/https/https.go
+++ b/runtime/connectors/https/https.go
@@ -34,7 +34,8 @@ var spec = connectors.Spec{
 }
 
 type Config struct {
-	Path string `mapstructure:"path"`
+	Path    string            `mapstructure:"path"`
+	Headers map[string]string `mapstructure:"headers"`
 }
 
 func ParseConfig(props map[string]any) (*Config, error) {
@@ -66,6 +67,10 @@ func (c connector) ConsumeAsIterator(ctx context.Context, env *connectors.Env, s
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, conf.Path, http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch url %s:  %w", conf.Path, err)
+	}
+
+	for k, v := range conf.Headers {
+		req.Header.Set(k, v)
 	}
 
 	start := time.Now()

--- a/runtime/services/catalog/artifacts/yaml/objects.go
+++ b/runtime/services/catalog/artifacts/yaml/objects.go
@@ -34,6 +34,7 @@ type Source struct {
 	ExtractPolicy         *ExtractPolicy `yaml:"extract,omitempty"`
 	Format                string         `yaml:"format,omitempty" mapstructure:"format,omitempty"`
 	DuckDBProps           map[string]any `yaml:"duckdb,omitempty" mapstructure:"duckdb,omitempty"`
+	Headers               map[string]any `yaml:"headers,omitempty" mapstructure:"headers,omitempty"`
 }
 
 type ExtractPolicy struct {
@@ -189,6 +190,10 @@ func fromSourceArtifact(source *Source, path string) (*drivers.CatalogEntry, err
 
 	if source.Format != "" {
 		props["format"] = source.Format
+	}
+
+	if source.Headers != nil {
+		props["headers"] = source.Headers
 	}
 
 	propsPB, err := structpb.NewStruct(props)


### PR DESCRIPTION
E.g. for authorization:

```
headers:
  authorization: Bearer abcdef...
```