### PR TITLE
adds TIMESTAMP WITH TIME ZONE support; runtime fix required

### DIFF
--- a/web-common/src/lib/duckdb-data-types.ts
+++ b/web-common/src/lib/duckdb-data-types.ts
@@ -56,6 +56,7 @@ export const TIMESTAMPS = new Set([
   "TIMESTAMP",
   "TIME",
   "DATETIME",
+  "TIMESTAMP WITH TIME ZONE",
 
   ...DATES,
 ]);


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [ ] Needs manual QA?

## Summary
#### Issue addressed: 
- We were not supporting `TIMESTAMP WITH TIME ZONE` types in the interface
- This fix is partial; the profiles appear, but the runtime throws errors.

#### Details:
- add the `TIMESTAMP WITH TIME ZONE` type to the list of duckdb types

## Steps to Verify
1. run `npm run dev`
2. connect to the public dataset at https://storage.googleapis.com/pkg.rilldata.com/example-data/spending.parquet
3. there should be three columns wit h`TIMESTAMP WITH TIME ZONE`, e.g. `period_of_performance_start_date`.
4. the column should appear with this branch. It will NOT profile; that requires another fix #2499 