### PR TITLE
fix: occasional e2e test failure when adding dashboard dimension

### DIFF
--- a/web-local/test/ui/dashboards.spec.ts
+++ b/web-local/test/ui/dashboards.spec.ts
@@ -344,27 +344,27 @@ describe("dashboards", () => {
 
     // Add Published, Domain back to dashboard
     await page.getByRole("button", { name: "Add dimension" }).click();
-    await dimensionsTable
-      .getByRole("row")
-      .nth(1)
+    const firstDimensionsRow = dimensionsTable.getByRole("row").nth(1);
+    await firstDimensionsRow
       .getByRole("textbox", { name: "Dimension label" })
       .fill("Publisher");
-    await dimensionsTable
-      .getByRole("row")
-      .nth(1)
+    await firstDimensionsRow
       .getByLabel("Dimension column")
       .selectOption("publisher");
+
     await page.getByRole("button", { name: "Add dimension" }).click();
-    await dimensionsTable
-      .getByRole("row")
-      .nth(2)
+
+    const secondDimensionsRow = dimensionsTable.getByRole("row").nth(2);
+    await secondDimensionsRow
       .getByRole("textbox", { name: "Dimension label" })
       .fill("Domain Name");
-    await dimensionsTable
-      .getByRole("row")
-      .nth(2)
+    await secondDimensionsRow
       .getByLabel("Dimension column")
       .selectOption("domain");
+    await secondDimensionsRow
+      .getByLabel("Dimension column")
+      .getByText("domain")
+      .isVisible();
 
     // Go to dashboard
     await page.getByRole("button", { name: "Go to dashboard" }).click();


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [x] E2E test coverage
- [ ] Needs manual QA?

## Summary
#### Issue addressed: 
<!-- INSERT ISSUE # / LINK HERE IF APPLICABLE -->

#### Details:
@begelundmuller and @ericpgreen2 have both reported seeing occasional e2e dashboard test failures in Github Actions on the last line of this testing sequence:
```typescript
  await page.getByRole("button", { name: "Add dimension" }).click();
  await dimensionsTable
    .getByRole("row")
    .nth(2)
    .getByRole("textbox", { name: "Dimension label" })
    .fill("Domain Name");
  await dimensionsTable
    .getByRole("row")
    .nth(2)
    .getByLabel("Dimension column")
    .selectOption("domain");

  // Go to dashboard
  await page.getByRole("button", { name: "Go to dashboard" }).click();

  // Check Avg Bid Price
  await playwrightExpect(page.getByText("Avg Bid Price $3.01")).toBeVisible();
```
This script is adding a dimension in the metrics config, configuring the column, and clicking "Go to dashboard".
Occasionally the test is throwing an error that it can't find the Avg Bid Price KPI on the dashboard.

I suspect the following is happening:
- If you try to "Go to dashboard" while a dimension is misconfigured, you get re-routed back to the metrics config
- In the scenario above, we select the "domain" column for a new dimension and then immediately click "Go to dashboard"
- Occasionally a race condition is hit where the "Go to dashboard" routing executes before the model state has finished updating with the new "domain" column setting. When that happens, the "Go to dashboard" button sends you back to the metrics config, so the test cannot find any KPIs because it didn't go to the dashboard

**The fix**
I've added a step to wait until the column selection is visibly confirmed in the UI before hitting the "Go to dashboard" button

## Steps to Verify
You can run the tests to confirm that the tests still work using `npm test`.
Unfortunately reproducing this bug is extremely hard to do since its a rare race condition, so absolutely confirming that this will fix it is difficult.