### PR TITLE
Fix links to quickstart

### DIFF
--- a/web-admin/src/components/home/WelcomeMessage.svelte
+++ b/web-admin/src/components/home/WelcomeMessage.svelte
@@ -1,7 +1,7 @@
 <p class="text-gray-500 text-base mt-2 max-w-[600px]">
   It looks like you're just starting out! Check out our
   <a
-    href="https://docs.rilldata.com/quickstart/end-to-end"
+    href="https://docs.rilldata.com/get-started"
     target="_blank"
     rel="noreferrer">Quickstart to create your first project</a
   >.

--- a/web-admin/src/routes/[organization]/+page.svelte
+++ b/web-admin/src/routes/[organization]/+page.svelte
@@ -33,7 +33,7 @@
           {#if $projs.data.projects?.length === 0}
             <span
               >This organization has no projects yet. <a
-                href="https://docs.rilldata.com/quickstart/end-to-end"
+                href="https://docs.rilldata.com/get-started"
                 target="_blank"
                 rel="noreferrer">See docs</a
               ></span


### PR DESCRIPTION
Recent docs updates broke a couple links in Rill Cloud.