### PR TITLE
Set default grain on time range change

### DIFF
--- a/web-common/src/features/dashboards/time-controls/TimeControls.svelte
+++ b/web-common/src/features/dashboards/time-controls/TimeControls.svelte
@@ -170,9 +170,11 @@
       start: new Date(start),
       end: new Date(end),
     };
+
+    const defaultTimeGrain = getDefaultTimeGrain(start, end).grain;
     makeTimeSeriesTimeRangeAndUpdateAppState(
       baseTimeRange,
-      $dashboardStore.selectedTimeRange?.interval,
+      defaultTimeGrain,
       // reset the comparison range
       {}
     );
@@ -211,7 +213,7 @@
     const { name, start, end } = timeRange;
 
     // validate time range name + time grain combination
-    // (necessary because when the time range name is changed, the current time grain may not be valid for the new time range name)
+    // (necessary because when the time range name is changed, the default time grain may not be valid for the new time range name)
     timeGrainOptions = getTimeGrainOptions(start, end);
     const isValidTimeGrain = checkValidTimeGrain(
       timeGrain,


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [x] Needs manual QA?

## Summary
#### Issue addressed: 
The relationship between time grain and time range was stateful which gave inconsistent combinations which moving through different time ranges

https://www.notion.so/Refine-default-time-grain-choices-for-each-time-range-0edfb80f4be1495885be16465afb3dec?d=3270dacd38e54bbfbc1a6720cd94e981

#### Details:
The default time grain is applied on every time range change 

## Steps to Verify
1. On a dashboard select last 24 hours, the time grain should be hour
2. Change time grain to 7 days, the time grain should be day now.