### PR TITLE
property => column in dashboard.yaml

### DIFF
--- a/runtime/services/catalog/artifacts/yaml/objects.go
+++ b/runtime/services/catalog/artifacts/yaml/objects.go
@@ -71,7 +71,8 @@ type Measure struct {
 type Dimension struct {
 	Name        string
 	Label       string
-	Column      string `yaml:"property"`
+	Property    string `yaml:"property,omitempty"`
+	Column      string
 	Description string
 	Ignore      bool `yaml:"ignore,omitempty"`
 }
@@ -316,6 +317,10 @@ func fromMetricsViewArtifact(metrics *MetricsView, path string) (*drivers.Catalo
 	for _, dimension := range metrics.Dimensions {
 		if dimension.Ignore {
 			continue
+		}
+		if dimension.Property != "" && dimension.Column == "" {
+			// backwards compatibility when we were using `property` instead of `column`
+			dimension.Column = dimension.Property
 		}
 		dimensions = append(dimensions, dimension)
 	}

--- a/web-common/src/features/metrics-views/DimensionColumns.ts
+++ b/web-common/src/features/metrics-views/DimensionColumns.ts
@@ -16,7 +16,7 @@ export const initDimensionColumns = (inputChangeHandler, dimensionOptions) =>
     },
 
     {
-      name: "property",
+      name: "column",
       label: "Dimension column",
       ariaLabel: "Dimension column",
       headerTooltip:

--- a/web-common/src/features/metrics-views/metrics-internal-store.spec.ts
+++ b/web-common/src/features/metrics-views/metrics-internal-store.spec.ts
@@ -32,11 +32,11 @@ measures: []
 dimensions:
   - name: dimension
     label: ""
-    property: ""
+    column: ""
     description: ""
 `);
     internalRepresentation.updateDimension(0, "label", "Publisher");
-    internalRepresentation.updateDimension(0, "property", "publisher");
+    internalRepresentation.updateDimension(0, "column", "publisher");
     expect(internalRepresentation.internalYAML)
       .toEqual(`# Visit https://docs.rilldata.com/reference/project-files to learn more about Rill project files.
 
@@ -49,7 +49,7 @@ measures: []
 dimensions:
   - name: dimension
     label: Publisher
-    property: publisher
+    column: publisher
     description: ""
 `);
   });
@@ -272,7 +272,7 @@ dimensions:
 `;
     [
       [
-        "From an old project without dimension name keys",
+        "From an old project without dimension name and column keys",
         `
   - label: Publisher
     property: publisher
@@ -282,40 +282,40 @@ dimensions:
     description: ""`,
         `
   - label: Publisher
-    property: publisher
     description: ""
     name: dimension
+    column: publisher
   - label: Domain
-    property: domain
     description: ""
     name: dimension_1
+    column: domain
   - name: dimension_2
     label: ""
-    property: ""
+    column: ""
     description: ""`,
       ],
       [
-        "From an old project with some dimension name keys",
+        "From an old project with some dimension name and column keys",
         `
   - name: dimension_1
     label: Publisher
     property: publisher
     description: ""
   - label: Domain
-    property: domain
+    column: domain
     description: ""`,
         `
   - name: dimension_1
     label: Publisher
-    property: publisher
     description: ""
+    column: publisher
   - label: Domain
-    property: domain
+    column: domain
     description: ""
     name: dimension
   - name: dimension_2
     label: ""
-    property: ""
+    column: ""
     description: ""`,
       ],
     ].forEach(([title, original, expected]) => {

--- a/web-common/src/features/metrics-views/metrics-internal-store.ts
+++ b/web-common/src/features/metrics-views/metrics-internal-store.ts
@@ -5,7 +5,6 @@ import type {
   V1Model,
   V1ReconcileError,
 } from "@rilldata/web-common/runtime-client";
-import { dim } from "ansi-colors";
 import { Subscriber, readable } from "svelte/store";
 import { Document, ParsedNode, YAMLMap, parseDocument } from "yaml";
 import type { Collection } from "yaml/dist/nodes/Collection";

--- a/web-common/src/features/metrics-views/workspace/MetricsExploreMetricsButton.svelte
+++ b/web-common/src/features/metrics-views/workspace/MetricsExploreMetricsButton.svelte
@@ -45,7 +45,7 @@
     // check if all the measures have a valid expression
     measures?.filter((measure) => measure?.expression?.length)?.length === 0 ||
     // and if the dimensions all have a valid property
-    dimensions?.filter((dimension) => dimension?.property?.length)?.length === 0
+    dimensions?.filter((dimension) => dimension?.column?.length)?.length === 0
   ) {
     buttonDisabled = true;
     buttonStatus = ["Add measures and dimensions before exploring metrics"];
@@ -63,8 +63,8 @@
 <Tooltip alignment="middle" distance={5} location="right">
   <!-- TODO: we need to standardize these buttons. -->
   <Button
-    label="Go to dashboard"
     disabled={buttonDisabled}
+    label="Go to dashboard"
     on:click={() => viewDashboard()}
     type="primary"
   >


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [x] Unit test coverage
- [x] E2E test coverage
- [ ] Needs manual QA?

## Summary
#### Issue addressed: 
<!-- INSERT ISSUE # / LINK HERE IF APPLICABLE -->

#### Details:
This PR uses column instead of property to define the source of a dimension in dashboard config yaml. Only edits to the dashboard from the UI will update the yaml to use this new field. Backwards compatibility is also part of this PR for older projects.

## Steps to Verify
N/A Will be in the dev branch