### PR TITLE
Fix Vite `/img` warnings

### DIFF
--- a/web-common/src/features/welcome/BackgroundImage.svelte
+++ b/web-common/src/features/welcome/BackgroundImage.svelte
@@ -1,5 +1,5 @@
 <div
-  class="min-h-screen h-full bg-[url('/img/welcome-bg-art.png')] bg-no-repeat bg-cover"
+  class="min-h-screen h-full bg-[url('$img/welcome-bg-art.png')] bg-no-repeat bg-cover"
 >
   <slot />
 </div>

--- a/web-common/src/features/welcome/ProjectCards.svelte
+++ b/web-common/src/features/welcome/ProjectCards.svelte
@@ -22,21 +22,21 @@
       title: "Cost Monitoring",
       description: "Monitoring cloud infrastructure",
       image:
-        "bg-[url('/img/welcome-bg-cost-monitoring.png')] bg-no-repeat bg-cover",
+        "bg-[url('$img/welcome-bg-cost-monitoring.png')] bg-no-repeat bg-cover",
       firstPage: "/dashboard/customer_margin_dash",
     },
     {
       name: "rill-openrtb-prog-ads",
       title: "OpenRTB Programmatic Ads",
       description: "Real-time Bidding (RTB) advertising",
-      image: "bg-[url('/img/welcome-bg-openrtb.png')] bg-no-repeat bg-cover",
+      image: "bg-[url('$img/welcome-bg-openrtb.png')] bg-no-repeat bg-cover",
       firstPage: "dashboard/auction",
     },
     {
       name: "rill-311-ops",
       title: "311 Call Center Operations",
       description: "Citizen reports across US cities",
-      image: "bg-[url('/img/welcome-bg-311.png')] bg-no-repeat bg-cover",
+      image: "bg-[url('$img/welcome-bg-311.png')] bg-no-repeat bg-cover",
       firstPage: "dashboard/call_center_metrics",
     },
   ];

--- a/web-local/vite.config.ts
+++ b/web-local/vite.config.ts
@@ -12,12 +12,15 @@ try {
   console.error(e);
 }
 
-const config = defineConfig({
+const config = defineConfig(({ mode }) => ({
   resolve: {
     alias: {
       src: "/src", // trick to get absolute imports to work
       "@rilldata/web-local": "/src",
       "@rilldata/web-common": "/../web-common/src",
+      // Adding $img alias to fix Vite build warnings due to static assets referenced in CSS
+      // See: https://stackoverflow.com/questions/75843825/sveltekit-dev-build-and-path-problems-with-static-assets-referenced-in-css
+      $img: mode === "production" ? "/../web-common/static/img" : "../img",
     },
   },
   server: {
@@ -31,6 +34,6 @@ const config = defineConfig({
     RILL_RUNTIME_URL: `"${runtimeUrl}"`,
   },
   plugins: [sveltekit()],
-});
+}));
 
 export default config;


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [ ] Needs manual QA?

## Summary
#### Issue addressed: 
Recent PRs (#2450, #2501) added images to the `/welcome` page by referencing static assets in CSS. Background images were added via Tailwind classes like `bg-[url('/img/welcome-bg-art.png')]`

This caused `vite build` to emit warnings because it can't resolve `/img` in the `/static` directory. See warnings:

<img width="1191" alt="image" src="https://github.com/rilldata/rill-developer/assets/14206386/7af782be-3610-41a1-b997-e81d44eadb0b">


#### Details:

I followed [this Stack Overflow post](https://stackoverflow.com/questions/75843825/sveltekit-dev-build-and-path-problems-with-static-assets-referenced-in-css) to work around the issue. It suggests using a Vite alias to explicitly state the images' directory, then using the alias in CSS like `bg-[url('$img/welcome-bg-art.png')]`