### PR TITLE
Add all dev-projects* to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ export/
 /cli/pkg/web/embed/dist
 /rill
 /cli/pkg/examples/embed/dist
-/dev-project
+/dev-project*
 
 # data files
 *.duckdb


### PR DESCRIPTION
This would enable us to add multiple projects starting with `dev-project` to the repo. This will help with testing out multiple projects easily.