### PR TITLE
Improve "Add {source, model, dashboard}" buttons

### DIFF
--- a/web-common/src/features/dashboards/DashboardAssets.svelte
+++ b/web-common/src/features/dashboards/DashboardAssets.svelte
@@ -40,6 +40,7 @@
   import NavigationHeader from "../../layout/navigation/NavigationHeader.svelte";
   import { behaviourEvent } from "../../metrics/initMetrics";
   import { runtime } from "../../runtime-client/runtime-store";
+  import AddAssetButton from "../entity-management/AddAssetButton.svelte";
   import RenameAssetModal from "../entity-management/RenameAssetModal.svelte";
 
   $: instanceId = $runtime.instanceId;
@@ -183,15 +184,9 @@
   $: canAddDashboard = $featureFlags.readOnly === false;
 </script>
 
-<NavigationHeader
-  bind:show={showMetricsDefs}
-  on:add={dispatchAddEmptyMetricsDef}
-  tooltipText="Create a new dashboard"
-  toggleText="dashboards"
-  canAddAsset={canAddDashboard}
+<NavigationHeader bind:show={showMetricsDefs} toggleText="dashboards"
+  >Dashboards</NavigationHeader
 >
-  Dashboards
-</NavigationHeader>
 
 {#if showMetricsDefs && $dashboardNames.data}
   <div
@@ -255,6 +250,13 @@
         </svelte:fragment>
       </NavigationEntry>
     {/each}
+    {#if canAddDashboard}
+      <AddAssetButton
+        id="add-dashboard"
+        label="Add dashboard"
+        on:click={() => dispatchAddEmptyMetricsDef()}
+      />
+    {/if}
   </div>
   {#if showRenameMetricsDefinitionModal}
     <RenameAssetModal

--- a/web-common/src/features/entity-management/AddAssetButton.svelte
+++ b/web-common/src/features/entity-management/AddAssetButton.svelte
@@ -8,7 +8,7 @@
 <button
   on:click
   {id}
-  class="py-1 pl-2.5 pr-2 hover:bg-gray-100 w-full text-left flex gap-x-2 items-center text-xs"
+  class="pl-2.5 pr-2 py-1 hover:bg-gray-100 w-full text-left flex gap-x-1.5 items-center text-xs"
 >
   <Add className="text-gray-900 bg-gray-300 rounded" size={"16px"} />
   {label}

--- a/web-common/src/features/entity-management/AddAssetButton.svelte
+++ b/web-common/src/features/entity-management/AddAssetButton.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import Add from "../../components/icons/Add.svelte";
+
+  export let id: string;
+  export let label: string;
+</script>
+
+<button
+  on:click
+  {id}
+  class="py-1 pl-2.5 pr-2 hover:bg-gray-100 w-full text-left flex gap-x-2 items-center text-xs"
+>
+  <Add className="text-gray-900 bg-gray-300 rounded" size={"16px"} />
+  {label}
+</button>

--- a/web-common/src/features/models/navigation/ModelAssets.svelte
+++ b/web-common/src/features/models/navigation/ModelAssets.svelte
@@ -10,6 +10,7 @@
   import NavigationEntry from "../../../layout/navigation/NavigationEntry.svelte";
   import NavigationHeader from "../../../layout/navigation/NavigationHeader.svelte";
   import { runtime } from "../../../runtime-client/runtime-store";
+  import AddAssetButton from "../../entity-management/AddAssetButton.svelte";
   import { getName } from "../../entity-management/name-utils";
   import { createModel } from "../createModel";
   import { useModelNames } from "../selectors";
@@ -46,14 +47,9 @@
   };
 </script>
 
-<NavigationHeader
-  bind:show={showModels}
-  contextButtonID={"create-model-button"}
-  on:add={handleAddModel}
-  tooltipText="Create a new model"
+<NavigationHeader bind:show={showModels} toggleText="models"
+  >Models</NavigationHeader
 >
-  Models
-</NavigationHeader>
 
 {#if showModels}
   <div
@@ -90,6 +86,11 @@
         </NavigationEntry>
       {/each}
     {/if}
+    <AddAssetButton
+      id="create-model-button"
+      label="Add model"
+      on:click={handleAddModel}
+    />
   </div>
 {/if}
 

--- a/web-common/src/features/sources/navigation/TableAssets.svelte
+++ b/web-common/src/features/sources/navigation/TableAssets.svelte
@@ -18,6 +18,7 @@
   import NavigationEntry from "../../../layout/navigation/NavigationEntry.svelte";
   import NavigationHeader from "../../../layout/navigation/NavigationHeader.svelte";
   import { runtime } from "../../../runtime-client/runtime-store";
+  import AddAssetButton from "../../entity-management/AddAssetButton.svelte";
   import { useModelNames } from "../../models/selectors";
   import AddSourceModal from "../add-source/AddSourceModal.svelte";
   import { createModelFromSource } from "../createModel";
@@ -64,15 +65,9 @@
   };
 </script>
 
-<NavigationHeader
-  bind:show={showTables}
-  contextButtonID={"add-table"}
-  on:add={openShowAddSourceModal}
-  toggleText="sources"
-  tooltipText="Add a new data source"
+<NavigationHeader bind:show={showTables} toggleText="sources"
+  >Sources</NavigationHeader
 >
-  Sources
-</NavigationHeader>
 
 {#if showTables}
   <div class="pb-3" transition:slide|local={{ duration: LIST_SLIDE_DURATION }}>
@@ -112,6 +107,11 @@
       {/each}
     {/if}
     <EmbeddedSourceNav />
+    <AddAssetButton
+      id="add-table"
+      label="Add source"
+      on:click={openShowAddSourceModal}
+    />
   </div>
 {/if}
 

--- a/web-common/src/layout/navigation/NavigationEntry.svelte
+++ b/web-common/src/layout/navigation/NavigationEntry.svelte
@@ -5,7 +5,6 @@
   import { WithTogglableFloatingElement } from "@rilldata/web-common/components/floating-element";
   import CaretDownIcon from "@rilldata/web-common/components/icons/CaretDownIcon.svelte";
   import MoreHorizontal from "@rilldata/web-common/components/icons/MoreHorizontal.svelte";
-  import Spacer from "@rilldata/web-common/components/icons/Spacer.svelte";
   import { Menu } from "@rilldata/web-common/components/menu";
   import { notifications } from "@rilldata/web-common/components/notifications";
   import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
@@ -92,11 +91,9 @@
     class="
     focus:bg-gray-200
     focus:outline-none
-    navigation-entry-title grid gap-x-1 items-center pl-2 pr-2 {!isActive &&
-    !mousedown
-      ? 'hover:bg-gray-100'
-      : ''}"
-    style:grid-template-columns="max-content auto max-content"
+    flex gap-x-[7px] items-center {expandable
+      ? 'pl-[11px]'
+      : 'pl-8'} pr-2 py-1 {!isActive && !mousedown ? 'hover:bg-gray-100' : ''}"
     use:commandClickAction
     use:shiftClickAction
     on:command-click
@@ -104,19 +101,15 @@
   >
     <!-- slot for navigation click -->
 
-    <div>
-      {#if expandable}
-        <ExpanderButton
-          bind:isHovered={seeMoreHovered}
-          rotated={showDetails}
-          on:click={onShowDetails}
-        >
-          <CaretDownIcon size="14px" />
-        </ExpanderButton>
-      {:else}
-        <Spacer size="14px" />
-      {/if}
-    </div>
+    {#if expandable}
+      <ExpanderButton
+        bind:isHovered={seeMoreHovered}
+        rotated={showDetails}
+        on:click={onShowDetails}
+      >
+        <CaretDownIcon size="14px" />
+      </ExpanderButton>
+    {/if}
 
     <div
       class="ui-copy flex items-center gap-x-1 w-full text-ellipsis overflow-hidden whitespace-nowrap"

--- a/web-common/src/layout/navigation/NavigationHeader.svelte
+++ b/web-common/src/layout/navigation/NavigationHeader.svelte
@@ -1,19 +1,10 @@
 <script lang="ts">
-  import ContextButton from "@rilldata/web-common/components/column-profile/ContextButton.svelte";
-  import AddIcon from "@rilldata/web-common/components/icons/Add.svelte";
-  import { createEventDispatcher } from "svelte";
   import { slide } from "svelte/transition";
   import CollapsibleSectionTitle from "../CollapsibleSectionTitle.svelte";
   import { LIST_SLIDE_DURATION } from "../config";
 
   export let show = true;
-  export let tooltipText: string;
-  export let toggleText = "models";
-  /** The CSS ID used for tests for the context button */
-  export let contextButtonID: string = undefined;
-  export let canAddAsset = true;
-
-  const dispatch = createEventDispatcher();
+  export let toggleText: string;
 </script>
 
 <div
@@ -26,18 +17,4 @@
       <slot />
     </div>
   </CollapsibleSectionTitle>
-  {#if canAddAsset}
-    <ContextButton
-      id={contextButtonID}
-      {tooltipText}
-      on:click={() => {
-        dispatch("add");
-      }}
-      width={24}
-      height={24}
-      rounded
-    >
-      <AddIcon />
-    </ContextButton>
-  {/if}
 </div>


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [x] E2E test coverage
- [x] Needs manual QA?

## Summary
#### Issue addressed: 
[PRD in Notion](https://www.notion.so/rilldata/Improving-Target-size-for-Add-Source-Models-Dashboard-Nav-c04af12473a642e8b87143b826a12038)

#### Details:
This PR improves the "Add {source, model, dashboard}" buttons. It removes the icon buttons in favor of large horizontal buttons that explicitly say "Add source", "Add model", and "Add dashboard", respectively. 

This PR does not implement the "Suggested Actions" component of the PRD. That will follow in a separate PR.

## Steps to Verify
Verify that the new buttons match the Figma mocks.