### PR TITLE
observability.SetRequestAttributes

### DIFF
--- a/runtime/server/catalog.go
+++ b/runtime/server/catalog.go
@@ -7,7 +7,9 @@ import (
 
 	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
 	"github.com/rilldata/rill/runtime/drivers"
+	"github.com/rilldata/rill/runtime/pkg/observability"
 	"github.com/rilldata/rill/runtime/server/auth"
+	"go.opentelemetry.io/otel/attribute"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -15,6 +17,11 @@ import (
 
 // ListCatalogEntries implements RuntimeService.
 func (s *Server) ListCatalogEntries(ctx context.Context, req *runtimev1.ListCatalogEntriesRequest) (*runtimev1.ListCatalogEntriesResponse, error) {
+	observability.SetRequestAttributes(ctx,
+		attribute.String("instance_id", req.InstanceId),
+		attribute.String("type", req.Type.String()),
+	)
+
 	if !auth.GetClaims(ctx).CanInstance(req.InstanceId, auth.ReadObjects) {
 		return nil, ErrForbidden
 	}


### PR DESCRIPTION
Example output:

```
{"level":"info","ts":1685611241.669065,"msg":"grpc finished call","protocol":"grpc","peer.address":"::1","grpc.component":"server","grpc.method_type":"unary","grpc.method":"/rill.runtime.v1.RuntimeService/ListCatalogEntries","instance_id":"default","type":"OBJECT_TYPE_UNSPECIFIED","grpc.code":"OK","duration":0.002065833}
```
