### PR TITLE
Fix `Browserslist` warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16733,7 +16733,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001435",
+      "version": "1.0.30001492",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001492.tgz",
+      "integrity": "sha512-2efF8SAZwgAX1FJr87KWhvuJxnGJKOnctQa8xLOskAXNXq8oiuqgl6u1kk3fFpsp3GgvzlRjiK1sl63hNtFADw==",
       "dev": true,
       "funding": [
         {
@@ -16743,9 +16745,12 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
-      ],
-      "license": "CC-BY-4.0"
+      ]
     },
     "node_modules/ccount": {
       "version": "1.1.0",


### PR DESCRIPTION
When running `npm run dev`, I was seeing this warning message:
![image](https://github.com/rilldata/rill-developer/assets/14206386/30bf14cc-b0a4-4d30-89ab-9b4329b5cae1)

This PR is the result of following the instructions to run `npx update-browserslist-db@latest` to update the `caniuse-lite` database.