### PR TITLE
Handle different error message fields for Auth

### DIFF
--- a/web-auth/src/components/Auth.svelte
+++ b/web-auth/src/components/Auth.svelte
@@ -114,11 +114,11 @@
             // Auth0 is not consistent in the naming of the error description field
             const errorText =
               typeof err?.description === "string"
-                ? err?.description
+                ? err.description
                 : typeof err?.policy === "string"
-                ? err?.policy
+                ? err.policy
                 : typeof err?.error_description === "string"
-                ? err?.error_description
+                ? err.error_description
                 : err?.message;
 
             if (err) displayError({ message: errorText });

--- a/web-auth/src/components/Auth.svelte
+++ b/web-auth/src/components/Auth.svelte
@@ -109,8 +109,9 @@
             email: email,
             password: password,
           },
-          (err) => {
-            // Auth0 is not consistent with its error message fields
+          // explicitly typing as any to avoid missing property TS/svelte-check error
+          (err: any) => {
+            // Auth0 is not consistent in the naming of the error description field
             const errorText =
               typeof err?.description === "string"
                 ? err?.description

--- a/web-auth/src/components/Auth.svelte
+++ b/web-auth/src/components/Auth.svelte
@@ -110,7 +110,17 @@
             password: password,
           },
           (err) => {
-            if (err) displayError({ message: err?.description });
+            // Auth0 is not consistent with its error message fields
+            const errorText =
+              typeof err?.description === "string"
+                ? err?.description
+                : typeof err?.policy === "string"
+                ? err?.policy
+                : typeof err?.error_description === "string"
+                ? err?.error_description
+                : err?.message;
+
+            if (err) displayError({ message: errorText });
             isEmailDisabled = false;
           }
         );


### PR DESCRIPTION
Auth0 is not consistent with it's error fields. 

For example adding a weak password on SignUp gives the below error as `description` is an object
![Screenshot 2023-06-02 at 10 23 19 PM](https://github.com/rilldata/rill-developer/assets/4402679/bbeb4d44-d1af-4780-84f2-2755a1567748)

This PR tries for a best effort solution looking for a string error message.
