### PR TITLE
Retry initial JWKS fetch

### DIFF
--- a/cli/pkg/local/app.go
+++ b/cli/pkg/local/app.go
@@ -252,7 +252,7 @@ func (a *App) Serve(httpPort, grpcPort int, enableUI, openBrowser, readonly bool
 		AllowedOrigins:  []string{"*"},
 		ServePrometheus: true,
 	}
-	runtimeServer, err := runtimeserver.NewServer(opts, a.Runtime, serverLogger)
+	runtimeServer, err := runtimeserver.NewServer(ctx, opts, a.Runtime, serverLogger)
 	if err != nil {
 		return err
 	}

--- a/runtime/server/auth/jwt.go
+++ b/runtime/server/auth/jwt.go
@@ -162,7 +162,7 @@ type Audience struct {
 // The issuerURL should be the external URL of the issuing admin server.
 // The issuerURL is expected to serve a JWKS on /.well-known/jwks.json.
 // The audienceURL should be the external URL of the receiving runtime server.
-func OpenAudience(logger *zap.Logger, issuerURL, audienceURL string) (*Audience, error) {
+func OpenAudience(ctx context.Context, logger *zap.Logger, issuerURL, audienceURL string) (*Audience, error) {
 	// To be safe, require issuer and audience is provided
 	if issuerURL == "" {
 		return nil, fmt.Errorf("issuerURL is not set")
@@ -177,17 +177,29 @@ func OpenAudience(logger *zap.Logger, issuerURL, audienceURL string) (*Audience,
 		return nil, err
 	}
 
-	// Setup keyfunc that refreshes the JWKS in the background
-	jwks, err := keyfunc.Get(jwksURL, keyfunc.Options{
-		Ctx: context.Background(),
-		RefreshErrorHandler: func(err error) {
-			logger.Error("JWK refresh failed", zap.Error(err))
-		},
-		RefreshInterval:   time.Hour,
-		RefreshRateLimit:  time.Minute * 5,
-		RefreshTimeout:    time.Second * 10,
-		RefreshUnknownKID: true,
-	})
+	// Setup keyfunc that refreshes the JWKS in the background.
+	// It returns an error if the initial fetch fails. So we wrap it with a retry in case the admin server is not ready.
+	var jwks *keyfunc.JWKS
+	for i := 0; i < 5; i++ {
+		jwks, err = keyfunc.Get(jwksURL, keyfunc.Options{
+			Ctx: ctx,
+			RefreshErrorHandler: func(err error) {
+				logger.Error("JWK refresh failed", zap.Error(err))
+			},
+			RefreshInterval:   time.Hour,
+			RefreshRateLimit:  time.Minute * 5,
+			RefreshTimeout:    time.Second * 10,
+			RefreshUnknownKID: true,
+		})
+		if err != nil {
+			logger.Info("JWKS fetch failed, retrying in 5s", zap.Error(err))
+			select {
+			case <-time.After(time.Second * 5):
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		}
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/runtime/server/auth/jwt_test.go
+++ b/runtime/server/auth/jwt_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -73,7 +74,7 @@ func newTestIssuerAndAudience(t *testing.T) (*Issuer, *Audience, func()) {
 
 	// Create Audience
 	audienceURL := "http://example.org"
-	aud, err := OpenAudience(zap.NewNop(), srv.URL, audienceURL)
+	aud, err := OpenAudience(context.Background(), zap.NewNop(), srv.URL, audienceURL)
 	require.NoError(t, err)
 
 	return iss, aud, func() { srv.Close(); aud.Close() }

--- a/runtime/server/catalog_test.go
+++ b/runtime/server/catalog_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
 
@@ -13,7 +14,7 @@ import (
 func TestServer_PutFileAndReconcile(t *testing.T) {
 	ctx := testCtx()
 	rt, instanceID := testruntime.NewInstance(t)
-	srv, err := NewServer(&Options{}, rt, nil)
+	srv, err := NewServer(context.Background(), &Options{}, rt, nil)
 	require.NoError(t, err)
 
 	cat, err := rt.NewCatalogService(ctx, instanceID)

--- a/runtime/server/queries_columns_test.go
+++ b/runtime/server/queries_columns_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -542,7 +543,7 @@ func getColumnTestServerWithEmptyModel(t *testing.T) (*Server, string) {
 func getColumnTestServerWithModel(t *testing.T, sql string, expectation int) (*Server, string) {
 	rt, instanceID := testruntime.NewInstanceWithModel(t, "test", sql)
 
-	server, err := NewServer(&Options{}, rt, nil)
+	server, err := NewServer(context.Background(), &Options{}, rt, nil)
 	require.NoError(t, err)
 
 	olap, err := rt.OLAP(testCtx(), instanceID)

--- a/runtime/server/queries_metrics_comparison_toplist_test.go
+++ b/runtime/server/queries_metrics_comparison_toplist_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"testing"
 
 	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
@@ -12,7 +13,7 @@ import (
 func getMetricsTestServer(t *testing.T, projectName string) (*Server, string) {
 	rt, instanceID := testruntime.NewInstanceForProject(t, projectName)
 
-	server, err := NewServer(&Options{}, rt, nil)
+	server, err := NewServer(context.Background(), &Options{}, rt, nil)
 	require.NoError(t, err)
 
 	return server, instanceID

--- a/runtime/server/queries_tables_test.go
+++ b/runtime/server/queries_tables_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"testing"
 
 	"github.com/jmoiron/sqlx"
@@ -112,7 +113,7 @@ func getTableTestServer(t *testing.T) (*Server, string) {
 		SELECT 1::int AS a, 10::int AS "b""b"
 	`)
 
-	server, err := NewServer(&Options{}, rt, nil)
+	server, err := NewServer(context.Background(), &Options{}, rt, nil)
 	require.NoError(t, err)
 
 	return server, instanceID
@@ -121,7 +122,7 @@ func getTableTestServer(t *testing.T) (*Server, string) {
 func getTableTestServerWithSql(t *testing.T, sql string) (*Server, string) {
 	rt, instanceID := testruntime.NewInstanceWithModel(t, "test", sql)
 
-	server, err := NewServer(&Options{}, rt, nil)
+	server, err := NewServer(context.Background(), &Options{}, rt, nil)
 	require.NoError(t, err)
 
 	return server, instanceID
@@ -142,7 +143,7 @@ func getTableTestServerWithEmptyModel(t *testing.T) (*Server, string) {
 		SELECT 1::int AS a, 10::int AS "b""b" where 1<>1
 	`)
 
-	server, err := NewServer(&Options{}, rt, nil)
+	server, err := NewServer(context.Background(), &Options{}, rt, nil)
 	require.NoError(t, err)
 
 	return server, instanceID

--- a/runtime/server/queries_timeseries_test.go
+++ b/runtime/server/queries_timeseries_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -992,7 +993,7 @@ func getTimeseriesTestServer(t *testing.T) (*Server, string) {
 		SELECT 1.0 AS clicks, 5 as imps, TIMESTAMP '2019-01-02 00:00:00' AS time, DATE '2019-01-02' as day, 'iphone' AS device, null AS publisher, 'msn.com' AS domain, NULL as latitude, NULL as country
 	`)
 
-	server, err := NewServer(&Options{}, rt, nil)
+	server, err := NewServer(context.Background(), &Options{}, rt, nil)
 	require.NoError(t, err)
 
 	return server, instanceID
@@ -1003,7 +1004,7 @@ func getTimeseriesTestServerWithEmptyModel(t *testing.T) (*Server, string) {
 		SELECT 1.0 AS clicks, TIMESTAMP '2019-01-01 00:00:00' AS time, 'android' AS device, 'Google' AS publisher, 'google.com' AS domain where 1<>1
 	`)
 
-	server, err := NewServer(&Options{}, rt, nil)
+	server, err := NewServer(context.Background(), &Options{}, rt, nil)
 	require.NoError(t, err)
 
 	return server, instanceID
@@ -1030,7 +1031,7 @@ func getSparkTimeseriesTestServer(t *testing.T) (*Server, string) {
 		SELECT 1.0 AS clicks, TIMESTAMP '2019-01-09T00:00:00Z' AS time, 'iphone' AS device
 	`)
 
-	server, err := NewServer(&Options{}, rt, nil)
+	server, err := NewServer(context.Background(), &Options{}, rt, nil)
 	require.NoError(t, err)
 
 	return server, instanceID

--- a/runtime/server/server.go
+++ b/runtime/server/server.go
@@ -54,7 +54,9 @@ var (
 	_ runtimev1.ConnectorServiceServer = (*Server)(nil)
 )
 
-func NewServer(opts *Options, rt *runtime.Runtime, logger *zap.Logger) (*Server, error) {
+// NewServer creates a new runtime server.
+// The provided ctx is used for the lifetime of the server for background refresh of the JWKS that is used to validate auth tokens.
+func NewServer(ctx context.Context, opts *Options, rt *runtime.Runtime, logger *zap.Logger) (*Server, error) {
 	srv := &Server{
 		opts:    opts,
 		runtime: rt,
@@ -62,7 +64,7 @@ func NewServer(opts *Options, rt *runtime.Runtime, logger *zap.Logger) (*Server,
 	}
 
 	if opts.AuthEnable {
-		aud, err := auth.OpenAudience(logger, opts.AuthIssuerURL, opts.AuthAudienceURL)
+		aud, err := auth.OpenAudience(ctx, logger, opts.AuthIssuerURL, opts.AuthAudienceURL)
 		if err != nil {
 			return nil, err
 		}

--- a/runtime/server/server_test.go
+++ b/runtime/server/server_test.go
@@ -12,7 +12,7 @@ import (
 func getTestServer(t *testing.T) (*Server, string) {
 	rt, instanceID := testruntime.NewInstance(t)
 
-	server, err := NewServer(&Options{}, rt, nil)
+	server, err := NewServer(context.Background(), &Options{}, rt, nil)
 	require.NoError(t, err)
 
 	return server, instanceID


### PR DESCRIPTION
Should fix runtime startup failing if the admin server is restarting at the same time. We have seen this error message previously:

```
{"level":"fatal","ts":1686039113.0174265,"caller":"runtime/start.go:130","msg":"error: could not create server","error":"failed to extract response via extractor function: invalid HTTP status code: 503","stacktrace":"github.com/rilldata/rill/cli/cmd/runtime.StartCmd.func1\n\t/home/runner/work/rill-developer/rill-developer/cli/cmd/runtime/start.go:130\ngithub.com/spf13/cobra.(*Command).execute\n\t/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:944\ngithub.com/spf13/cobra.(*Command).ExecuteC\n\t/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:1068\ngithub.com/spf13/cobra.(*Command).Execute\n\t/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:992\ngithub.com/spf13/cobra.(*Command).ExecuteContext\n\t/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:985\ngithub.com/rilldata/rill/cli/cmd.runCmd\n\t/home/runner/work/rill-developer/rill-developer/cli/cmd/root.go:156\ngithub.com/rilldata/rill/cli/cmd.Execute\n\t/home/runner/work/rill-developer/rill-developer/cli/cmd/root.go:46\nmain.main\n\t/home/runner/work/rill-developer/rill-developer/cli/main.go:29\nruntime.main\n\t/opt/hostedtoolcache/go/1.20.3/x64/src/runtime/proc.go:250"}
```